### PR TITLE
Update shebang to use /usr/bin/env for better compatibility

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # build the app
 CGO_ENABLED=0 go build -o ./bin/spf


### PR DESCRIPTION
This change updates the shebang line in the build script from #!/bin/bash to #!/usr/bin/env bash. Using #!/usr/bin/env bash ensures better compatibility across different environments. This is particularly useful in systems where bash might not be located in the /bin directory, like NixOS.