### PR TITLE
Make `install.sh` more robust to not being root

### DIFF
--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -81,11 +81,23 @@ tar -xzf "${file_name}.tar.gz"
 echo -e "${bright_yellow}Installing ${cyan}${package}...${nc}"
 cd ./dist/${file_name}
 chmod +x ./spf
-if sudo mv ./spf /usr/local/bin/; then
+echo -e "${yellow}Press ctrl+C to not install as sudo and try locally.${nc}"
+if ! sudo mv ./spf /usr/local/bin/; then
+  echo -e "${yellow}Unable to move binary to /usr/local/bin. Do you have sudo permissions?${nc}"
+  mkdir -p ~/.local/bin
+  if ! mv ./spf ~/.local/bin/; then
+    echo -e "${red}❌ Failed to install superfile: Unable to move to ~/.local/bin as well.${nc}"
+  else
+    if ! [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+      export PATH="${PATH}:${HOME}/.local/bin"
+      echo 'export PATH="${PATH}:${HOME}/.local/bin"' >> ~/.bashrc
+    fi
+    echo -e "🎉 ${bright_cyan}Local ${bright_green}Installation complete!${nc}"
+    echo -e "${bright_cyan}You can type ${white}\"${bright_yellow}spf${white}\" ${bright_cyan}to start!${nc}"
+  fi
+else
   echo -e "🎉 ${bright_green}Installation complete!${nc}"
   echo -e "${bright_cyan}You can type ${white}\"${bright_yellow}spf${white}\" ${bright_cyan}to start!${nc}"
-else
-  echo -e "${red}❌ Fail install superfile: ${yellow}Unable to move binary to /usr/local/bin. Do you have sudo permissions?${nc}"
 fi
 
 rm -rf "$temp_dir"


### PR DESCRIPTION
Instead of just failing if `sudo` is not granted, the install script now tries to: 
1. move `./spf` to `~/.local/bin` (which is the correct path for user executables according to the [XDG Base Directory Spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)) 
  1. Make that directory if it doesn't exist
  2. Checks if this dir is in the path, and if not export path to include it (and add to bashrc)
2. improves error messages accordingly.

Here is an example of how it looks with these changes: (ignore the actual colors, my terminal's color profile is different)
![image](https://github.com/yorukot/superfile/assets/29684689/476145dc-6810-4739-b2e2-9b53828a6cb1)

One question I had is should I also mention that `~/.local/bin` has been added to `~/.bashrc` (so that users of other shells i.e. fish/zsh/xonsh etc) would be able to add it to their configs themselves? I am in favour of adding it.
Alternatively, we can try detecting shell and run respective command but not even `fzf` takes that approach - it asks you to run the right file yourself (out of some provided scripts)