### PR TITLE
Continued #258: `install.sh` Add support for multiple shells

### DIFF
--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -89,8 +89,39 @@ if ! sudo mv ./spf /usr/local/bin/; then
     echo -e "${red}❌ Failed to install superfile: Unable to move to ~/.local/bin as well.${nc}"
   else
     if ! [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
-      export PATH="${PATH}:${HOME}/.local/bin"
-      echo 'export PATH="${PATH}:${HOME}/.local/bin"' >> ~/.bashrc
+      shell_found_and_not_bash=1
+      case $SHELL in
+        */bash)
+          echo 'export PATH="${HOME}/.local/bin":${PATH}' >> ~/.bashrc
+          shell_found_and_not_bash=0
+          ;;
+        */zsh)
+          echo 'export PATH="${HOME}/.local/bin":${PATH}' >> ~/.zshrc
+          ;;
+        */fish)
+          echo 'fish_add_path "${HOME}/.local/bin"' >> ~/.config/fish/config.fish 
+          ;;
+        */ksh)
+          echo 'export PATH="${HOME}/.local/bin":${PATH}' >> ~/.kshrc
+          ;;
+        */xonsh)
+          echo '$PATH.prepend("${HOME}/.local/bin")' >> ~/.xonshrc
+          ;;
+        */csh)
+          echo 'setenv PATH "${HOME}/.local/bin":${PATH}' >> ~/.cshrc
+          ;;
+        */tcsh)
+          echo 'setenv PATH "${HOME}/.local/bin":${PATH}' >> ~/.tshrc
+          ;;
+        *)
+          echo -e "${red}Unsupported shell: ${SHELL}. Please add ${white}\"${bright_cyan}\${HOME}/.local/bin${white}\" ${red}to PATH in your shell's config file.${red}"
+          shell_found_and_not_bash=0
+          ;;
+      esac
+      if [ $shell_found_and_not_bash == 1 ]; then
+        echo -e "${white}\"${bright_purple}${HOME}/.local/bin${white}\"${yellow} has been added to your PATH.${nc}"
+        echo -e "${yellow}Please source your config file/relogin.${nc}"
+      fi
     fi
     echo -e "🎉 ${bright_cyan}Local ${bright_green}Installation complete!${nc}"
     echo -e "${bright_cyan}You can type ${white}\"${bright_yellow}spf${white}\" ${bright_cyan}to start!${nc}"


### PR DESCRIPTION
This is continued from #258 (which was already merged, so I couldn't add commits there).

Most `~/.profile` files already add `~/.local/bin` to `PATH`; if not, we can add it to the respective shell configuration file.

Added support for
- `bash`
- `zsh`
- `fish`
- `ksh`
- `xonsh`
- `csh`
- `tcsh`

There is no way for a child process (this install script, always running in `bash`) to directly affect the environment variables of the parent process (the invoking shell), so the best we can do in this case is instruct the user to re-source or relogin.

Also, changed to prepend instead of append to `PATH` for consistency.