### PR TITLE
add fix-hotkeys flag, feedback for missing hotkeys

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -54,6 +54,14 @@ func Run(content embed.FS) {
 				},
 			},
 		},
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "fix-hotkeys",
+				Aliases: []string{"fh"},
+				Usage:   "Adds any missing hotkeys to the hotkey config file",
+				Value:   false,
+			},
+		},
 		Action: func(c *cli.Context) error {
 			path := ""
 			if c.Args().Present() {
@@ -62,6 +70,8 @@ func Run(content embed.FS) {
 
 			InitConfigFile()
 
+			varibale.FixHotkeys = c.Bool("fix-hotkeys")
+
 			firstUse := checkFirstUse()
 
 			p := tea.NewProgram(internal.InitialModel(path, firstUse), tea.WithAltScreen(), tea.WithMouseCellMotion())
@@ -69,6 +79,7 @@ func Run(content embed.FS) {
 				log.Fatalf("Alas, there's been an error: %v", err)
 				os.Exit(1)
 			}
+
 			CheckForUpdates()
 			return nil
 		},

--- a/src/config/fixed_variable.go
+++ b/src/config/fixed_variable.go
@@ -24,6 +24,7 @@ var (
 	HotkeysFilea      string = SuperFileMainDir + "/hotkeys.toml"
 	ToggleDotFilea    string = SuperFileDataDir + "/toggleDotFile"
 	LogFilea          string = SuperFileStateDir + "/superfile.log"
+	FixHotkeys        bool   = false
 )
 
 const (

--- a/src/internal/config_function.go
+++ b/src/internal/config_function.go
@@ -118,19 +118,18 @@ func loadHotkeysFile() {
 
 	hasMissingHotkeysInConfig := reflect.DeepEqual(hotkeys, hotkeysFromConfig) == false
 
-	hotKeysConfig := reflect.ValueOf(hotkeysFromConfig)
-	for i := 0; i < hotKeysConfig.NumField(); i++ {
-		field := hotKeysConfig.Type().Field(i)
-		value := hotKeysConfig.Field(i)
-		name := field.Name
-		isMissing := value.Len() == 0
+	if hasMissingHotkeysInConfig && varibale.FixHotkeys == false {
+		hotKeysConfig := reflect.ValueOf(hotkeysFromConfig)
+		for i := 0; i < hotKeysConfig.NumField(); i++ {
+			field := hotKeysConfig.Type().Field(i)
+			value := hotKeysConfig.Field(i)
+			name := field.Name
+			isMissing := value.Len() == 0
 
-		if isMissing {
-			fmt.Printf("Field \"%s\" is missing in hotkeys configuration\n", name)
+			if isMissing {
+				fmt.Printf("Field \"%s\" is missing in hotkeys configuration\n", name)
+			}
 		}
-	}
-
-	if hasMissingHotkeysInConfig {
 		fmt.Println("To add missing fields to hotkeys directory automaticially run Superfile with the --fix-hotkeys flag")
 	}
 

--- a/src/internal/config_function.go
+++ b/src/internal/config_function.go
@@ -52,7 +52,7 @@ func initialConfig(dir string) (toggleDotFileBool bool, firstFilePanelDir string
 	if dir != "" {
 		firstFilePanelDir, err = filepath.Abs(dir)
 	} else {
-		Config.DefaultDirectory = strings.Replace(Config.DefaultDirectory, "~", varibale.HomeDir, -1) 
+		Config.DefaultDirectory = strings.Replace(Config.DefaultDirectory, "~", varibale.HomeDir, -1)
 		firstFilePanelDir, err = filepath.Abs(Config.DefaultDirectory)
 	}
 
@@ -90,7 +90,7 @@ func loadConfigFile() {
 			log.Fatalf("Error writing config file: %v", err)
 		}
 	}
-	if (Config.FilePreviewWidth > 10 || Config.FilePreviewWidth < 2) &&  Config.FilePreviewWidth != 0{
+	if (Config.FilePreviewWidth > 10 || Config.FilePreviewWidth < 2) && Config.FilePreviewWidth != 0 {
 		fmt.Println(loadConfigError("file_preview_width"))
 		os.Exit(0)
 	}


### PR DESCRIPTION
- adds fix-hotkeys flag
- no longer writes to hotkeys config every time Superfile is ran
- adds feedback to users for missing hotkey entries for Superfile
- adds directions on how to fix hotkey file using --fix-hotkeys flag