### PR TITLE
fixed typo in hotkeys.toml

### DIFF
--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -44,7 +44,7 @@ cancel_typing = ['ctrl+c', 'esc']
 parent_directory = ['h', 'left', "backspace"] 
 search_bar = ['/', '']
 # =================================================================================================
-# Select mode hotkeys (can conflict with other modes, cananot conflict with global hotkeys)
+# Select mode hotkeys (can conflict with other modes, cannot conflict with global hotkeys)
 file_panel_select_mode_items_select_down = ['shift+down', 'J']
 file_panel_select_mode_items_select_up = ['shift+up', 'K']
 file_panel_select_all_items = ['A', '']


### PR DESCRIPTION
I just removed an a in the default hotkeys.toml.
The typo was in line 47. "Cannot" got spelled "cananot". Nothing big