### PR TITLE
Update image_preview.go

### DIFF
--- a/src/pkg/file_preview/image_preview.go
+++ b/src/pkg/file_preview/image_preview.go
@@ -19,19 +19,14 @@ func ConvertImageToANSI(img image.Image, defaultBGColor color.Color) string {
 	width := img.Bounds().Dx()
 	height := img.Bounds().Dy()
 	output := ""
-	BGColor :=colorToTermenv(defaultBGColor. "")
-
-	// r, g, b, _ := defaultBGColor.RGBA()
-
-	// BGColor := fmt.Sprintf("#%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8))
 
 	for y := 0; y < height; y += 2 {
 		for x := 0; x < width; x++ {
-			upperColor := colorToTermenv(img.At(x, y), "")
-			lowerColor := BGColor
+			upperColor := colorToTermenv(img.At(x, y), colorToHex(defaultBGColor))
+			lowerColor := colorToTermenv(defaultBGColor, "")
 
 			if y + 1 < height {
-				lowerColor = colorToTermenv(img.At(x, y + 1), "")
+				lowerColor = colorToTermenv(img.At(x, y + 1), colorToHex(defaultBGColor))
 			}
 
 			// Using the "▄" character which fills the lower half
@@ -48,7 +43,7 @@ func ConvertImageToANSI(img image.Image, defaultBGColor color.Color) string {
 func colorToTermenv(c color.Color, fallbackColor string) termenv.RGBColor {
 	r, g, b, a := c.RGBA()
 	if a == 0 {
-        	return termenv.RGBColor("")
+        	return termenv.RGBColor(fallbackColor)
     	}
 	return termenv.RGBColor(fmt.Sprintf("#%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8)))
 }
@@ -90,4 +85,12 @@ func hexToColor(hex string) (color.RGBA, error) {
 		return color.RGBA{}, err
 	}
 	return color.RGBA{R: uint8(values >> 16), G: uint8((values >> 8) & 0xFF), B: uint8(values & 0xFF), A: 255},nil
+}
+
+func colorToHex(color color.Color) (fullbackHex string) {
+	r, g, b, _ := color.RGBA()
+
+	fullbackHex = fmt.Sprintf("#%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8))
+	return fullbackHex
+
 }

--- a/src/pkg/file_preview/image_preview.go
+++ b/src/pkg/file_preview/image_preview.go
@@ -19,18 +19,19 @@ func ConvertImageToANSI(img image.Image, defaultBGColor color.Color) string {
 	width := img.Bounds().Dx()
 	height := img.Bounds().Dy()
 	output := ""
+	BGColor :=colorToTermenv(defaultBGColor. "")
 
-	r, g, b, _ := defaultBGColor.RGBA()
+	// r, g, b, _ := defaultBGColor.RGBA()
 
-	BGColor := fmt.Sprintf("#%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8))
+	// BGColor := fmt.Sprintf("#%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8))
 
 	for y := 0; y < height; y += 2 {
 		for x := 0; x < width; x++ {
-			upperColor := colorToTermenv(img.At(x, y), BGColor)
-			lowerColor := termenv.RGBColor(fmt.Sprintf("#%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8)))
+			upperColor := colorToTermenv(img.At(x, y), "")
+			lowerColor := BGColor
 
 			if y + 1 < height {
-				lowerColor = colorToTermenv(img.At(x, y + 1), BGColor)
+				lowerColor = colorToTermenv(img.At(x, y + 1), "")
 			}
 
 			// Using the "▄" character which fills the lower half
@@ -44,10 +45,10 @@ func ConvertImageToANSI(img image.Image, defaultBGColor color.Color) string {
 }
 
 // colorToTermenv converts a color.Color to a termenv.RGBColor
-func colorToTermenv(c color.Color, BGColor string) termenv.RGBColor {
+func colorToTermenv(c color.Color, fallbackColor string) termenv.RGBColor {
 	r, g, b, a := c.RGBA()
-	if a == 0 {
-		return termenv.RGBColor(BGColor)
+	if a == 0  && fallbackColor != "" {
+		return termenv.RGBColor(fallbackColor)
 	}
 
 	return termenv.RGBColor(fmt.Sprintf("#%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8)))
@@ -72,12 +73,22 @@ func ImagePreview(path string, maxWidth, maxHeight int, defaultBGColor string) (
 	resizedImg := resize.Thumbnail(uint(maxWidth), uint(maxHeight), img, resize.Lanczos3)
 
 	// Convert image to ANSI
-	ansiImage := ConvertImageToANSI(resizedImg, hexToColor(defaultBGColor))
+	bgColor, err := hexToColor(defaultBGColor)
+	if err != nil {
+		return "", fmt.Errorf("invalid background color: %v", err)
+	}
+	ansiImage := ConvertImageToANSI(resizedImg, bgColor)
 
 	return ansiImage, nil
 }
 
-func hexToColor(hex string) color.RGBA {
-	values, _ := strconv.ParseUint(string(hex[1:]), 16, 32)
-	return color.RGBA{R: uint8(values >> 16), G: uint8((values >> 8) & 0xFF), B: uint8(values & 0xFF), A: 255}
+func hexToColor(hex string) (color.RGBA, error) {
+	if len(hex) != 7 || hex[0] != '#' {
+		return color.RGBA{}, fmt.Errorf("invalid hex color format")
+	}
+	values, err := strconv.ParseUint(string(hex[1:]), 16, 32)
+	if err != nil {
+		return color.RGBA{}, err
+	}
+	return color.RGBA{R: uint8(values >> 16), G: uint8((values >> 8) & 0xFF), B: uint8(values & 0xFF), A: 255},nil
 }

--- a/src/pkg/file_preview/image_preview.go
+++ b/src/pkg/file_preview/image_preview.go
@@ -47,10 +47,9 @@ func ConvertImageToANSI(img image.Image, defaultBGColor color.Color) string {
 // colorToTermenv converts a color.Color to a termenv.RGBColor
 func colorToTermenv(c color.Color, fallbackColor string) termenv.RGBColor {
 	r, g, b, a := c.RGBA()
-	if a == 0  && fallbackColor != "" {
-		return termenv.RGBColor(fallbackColor)
-	}
-
+	if a == 0 {
+        	return termenv.RGBColor("")
+    	}
 	return termenv.RGBColor(fmt.Sprintf("#%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8)))
 }
 


### PR DESCRIPTION
- Added Error handling in hexToColor function.
- The ConvertImageToANSI function now uses colorToTermenv for all color conversions.
- Simplified the background color handling in ConvertImageToANSI.
- colorToTermenv function now takes a fallback color string, making it more flexible.
- Added error checking for the background color in ImagePreview.