### PR TITLE
Update installation.md: Add x-cmd method to install superfile

### DIFF
--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -104,6 +104,13 @@ in {
 }
 ```
 
+### X-CMD
+
+[x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.
+```sh
+x env use superfile
+```
+
 ## Start superfile
 
 After completing the installation, you can restart the terminal (if necessary)


### PR DESCRIPTION
- Hi, we have implemented a lightweight [package manager using shell and awk](https://www.x-cmd.com/pkg/). It helps you download superfile release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the superfile installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/)
  ```sh
  x env use superfile
  ```
- Furthermore, the [`x spf`](https://www.x-cmd.com/pkg/superfile) command is provided, which automatically downloads and calls `spf` without affecting the environment, such as not modifying the `PATH` variable.[demo](https://www.x-cmd.com/1min/superfile)
