### PR TITLE
fix/exiftool session left open

### DIFF
--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -338,6 +338,7 @@ func (m *model) returnMetaData() {
 	if Config.Metadata && checkIsSymlinked.Mode()&os.ModeSymlink == 0 {
 
 		fileInfos := et.ExtractMetadata(filePath)
+		et.Close()
 
 		for _, fileInfo := range fileInfos {
 			if fileInfo.Err != nil {


### PR DESCRIPTION
Issue :
Create too many instances of exiftool  
[link to the issue](https://github.com/yorukot/superfile/issues/324)

Updated the code so that the exifTool session is closed after use.
Please let me know if you find a better fix.