### PR TITLE
fixed exiftool session left open after use

### DIFF
--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -317,14 +317,18 @@ func (m *model) getFilePanelItems() {
 }
 
 func (m model) quitSuperfile() {
-	// cd on quit
-	if Config.CdOnQuit {
-		currentDir := m.fileModel.filePanels[m.filePanelFocusIndex].location
-		if currentDir == variable.HomeDir {
-			return
-		}
-		// escape single quote
-		currentDir = strings.ReplaceAll(currentDir, "'", "'\\''")
-		os.WriteFile(variable.SuperFileStateDir+"/lastdir", []byte("cd '"+currentDir+"'"), 0755)
-	}
+    // close exiftool session
+    if Config.Metadata {
+        et.Close();
+    }
+    // cd on quit
+    if Config.CdOnQuit {
+        currentDir := m.fileModel.filePanels[m.filePanelFocusIndex].location
+        if currentDir == variable.HomeDir {
+            return
+        }
+        // escape single quote
+        currentDir = strings.ReplaceAll(currentDir, "'", "'\\''")
+        os.WriteFile(variable.SuperFileStateDir+"/lastdir", []byte("cd '"+currentDir+"'"), 0755)
+    }
 }


### PR DESCRIPTION
Issue :
Create too many instances of exiftool
[link to the issue](https://github.com/yorukot/superfile/issues/324)

Updated the code so that the exifTool session is closed after use.
Please let me know if you find a better fix.