### PR TITLE
fix: change command execution to start instead of output

### DIFF
--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -95,7 +95,7 @@ func (m *model) enterPanel() {
 			openCommand = "open"
 		}
 		cmd := exec.Command(openCommand, panel.element[panel.cursor].location)
-		_, err = cmd.Output()
+		err = cmd.Start()
 		if err != nil {
 			outPutLog(fmt.Sprintf("err when open file with %s", openCommand), err)
 		}


### PR DESCRIPTION
Addresses the issue mentioned in: https://github.com/yorukot/superfile/issues/364

Issue
The program was freezing when attempting to launch an application using the exec.Command function. This was due to the use of cmd.Output(), which waits for the command to complete and captures its output. If the launched application does not terminate, the program would hang indefinitely.

Solution
To resolve this issue, the code was modified to use cmd.Start() instead of cmd.Output(). The cmd.Start() function starts the specified command but does not wait for it to complete, allowing the program to continue running without freezing.