### PR TITLE
Add sort case toggle (#469)

### DIFF
--- a/src/internal/config_type.go
+++ b/src/internal/config_type.go
@@ -125,6 +125,7 @@ type ConfigType struct {
 	FileSizeUseSI          bool   `toml:"file_size_use_si" comment:"\nDisplay file sizes using powers of 1000 (kB, MB, GB) instead of powers of 1024 (KiB, MiB, GiB)."`
 	DefaultSortType        int    `toml:"default_sort_type" comment:"\nDefault sort type (0: Name, 1: Size, 2: Date Modified)."`
 	SortOrderReversed      bool   `toml:"sort_order_reversed" comment:"\nDefault sort order (false: Ascending, true: Descending)."`
+	CaseSensitiveSort			 bool   `toml:"case_sensitive_sort" comment:"\nCase sensitive sort by name (captal "B" comes before "a" if true)."`
 
 	Nerdfont              bool `toml:"nerdfont" comment:"\n================   Style =================\n\n If you don't have or don't want Nerdfont installed you can turn this off"`
 	TransparentBackground bool `toml:"transparent_background" comment:"\nSet transparent background or not (this only work when your terminal background is transparent)"`

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -65,7 +65,11 @@ func returnFolderElement(location string, displayDotFile bool, sortOptions sortO
 			if !files[i].IsDir() && files[j].IsDir() {
 				return false
 			}
-			return files[i].Name() < files[j].Name() != reversed
+			if Config.CaseSensitiveSort {
+				return files[i].Name() < files[j].Name() != reversed
+			} else {
+				return strings.ToLower(files[i].Name()) < strings.ToLower(files[j].Name()) != reversed
+			}
 		}
 	case "Size":
 		order = func(i, j int) bool {

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -27,6 +27,9 @@ default_sort_type = 0
 # Default sort order (false: Ascending, true: Descending).
 sort_order_reversed = false
 #
+# Case sensitive sort by name (upper "B" comes before lower "a" if true).
+case_sensitive_sort = false
+#
 # ================   Style =================
 # 
 # If you don't have or don't want Nerdfont installed you can turn this off

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -76,6 +76,13 @@ Sorting order of the file panel.
 
 `true` => Descending (z-a)
 
+- ###### case_sensitive_sort
+Case sensitive sort by name (upper "B" comes before lower "a" if true).
+
+`true` => Case sensitive ("B" comes before "a")
+
+`false` => Case insensitive ("a" comes before "B")
+
 ### Style
 
 - ###### transparent_background


### PR DESCRIPTION
When true (old functionality), files are sorted "B", then "a", then "c".
When false (default), files are sorted "a", then "B", then "c".
