### PR TITLE
Adds the argument --print-last-dir

### DIFF
--- a/src/config/fixed_variable.go
+++ b/src/config/fixed_variable.go
@@ -26,6 +26,8 @@ var (
 	LogFile          string = SuperFileStateDir + "/superfile.log"
 	FixHotkeys       bool   = false
 	FixConfigFile    bool   = false
+	LastDir          string = ""
+	PrintLastDir     bool   = false
 )
 
 const (

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -1,4 +1,5 @@
 package internal
+
 import (
 	"log"
 	"os"
@@ -408,8 +409,10 @@ func (m model) quitSuperfile() {
         et.Close();
     }
     // cd on quit
+    currentDir := m.fileModel.filePanels[m.filePanelFocusIndex].location
+    variable.LastDir = currentDir
+
     if Config.CdOnQuit {
-        currentDir := m.fileModel.filePanels[m.filePanelFocusIndex].location
         if currentDir == variable.HomeDir {
             return
         }


### PR DESCRIPTION
Addresses #274 

It does so by adding two variables `PrintLastDir` and `LastDir` which are bool and string respectively, updates `LastDir` while quitting the application, and prints it after exiting the main loop if the flag was provided.