### PR TITLE
use `filepath.EvalSymlinks` instead of `isBrokenSymlink`

### DIFF
--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -59,12 +59,12 @@ func returnFolderElement(location string, displayDotFile bool, sortOptions sortO
 	switch sortOptions.options[sortOptions.selected] {
 	case "Name":
 		order = func(i, j int) bool {
-			_, errI := os.ReadDir(location+"/"+files[i].Name());
-			_, errJ := os.ReadDir(location+"/"+files[j].Name());
-			if (files[i].IsDir()||errI==nil) && (!files[j].IsDir()&&errJ!=nil) {
+			_, errI := os.ReadDir(location + "/" + files[i].Name())
+			_, errJ := os.ReadDir(location + "/" + files[j].Name())
+			if (files[i].IsDir() || errI == nil) && (!files[j].IsDir() && errJ != nil) {
 				return true
 			}
-			if (!files[i].IsDir()&&errI!=nil) && (files[j].IsDir()||errJ==nil) {
+			if (!files[i].IsDir() && errI != nil) && (files[j].IsDir() || errJ == nil) {
 				return false
 			}
 			if Config.CaseSensitiveSort {
@@ -79,13 +79,13 @@ func returnFolderElement(location string, displayDotFile bool, sortOptions sortO
 			// Files sorted by size
 			fileInfoI, _ := files[i].Info()
 			fileInfoJ, _ := files[j].Info()
-			_, errI := os.ReadDir(location+"/"+files[i].Name());
-			_, errJ := os.ReadDir(location+"/"+files[j].Name());
+			_, errI := os.ReadDir(location + "/" + files[i].Name())
+			_, errJ := os.ReadDir(location + "/" + files[j].Name())
 
-			if (files[i].IsDir()||errI==nil) && (!files[j].IsDir()&&errJ!=nil) {
+			if (files[i].IsDir() || errI == nil) && (!files[j].IsDir() && errJ != nil) {
 				return true
 			}
-			if (!files[i].IsDir()&&errI!=nil) && (files[j].IsDir()||errJ==nil) {
+			if (!files[i].IsDir() && errI != nil) && (files[j].IsDir() || errJ == nil) {
 				return false
 			}
 			if files[i].IsDir() && files[j].IsDir() {
@@ -351,7 +351,8 @@ func (m *model) returnMetaData() {
 	fileInfo, err := os.Stat(filePath)
 
 	if isSymlink(filePath) {
-		if isBrokenSymlink(filePath) {
+		_, err := filepath.EvalSymlinks(filePath)
+		if err != nil {
 			m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"Link file is broken!", ""})
 		} else {
 			m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"This is a link file.", ""})
@@ -471,22 +472,6 @@ func countFiles(dirPath string) (int, error) {
 	})
 
 	return count, err
-}
-
-// Check whether is broken recursive symlinks
-func isBrokenSymlink(filePath string) bool {
-	linkPath, err := os.Readlink(filePath)
-	if err != nil {
-		return true
-	}
-
-	absLinkPath, err := filepath.Abs(linkPath)
-	if err != nil {
-		return true
-	}
-
-	_, err = os.Stat(absLinkPath)
-	return err != nil
 }
 
 // Check whether is symlinks

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -75,13 +75,7 @@ func (m *model) enterPanel() {
 		}
 
 		if fileInfo.Mode()&os.ModeSymlink != 0 {
-			if isBrokenSymlink(panel.element[panel.cursor].location) {
-				return
-			}
-
-			linkPath, _ := os.Readlink(panel.element[panel.cursor].location)
-
-			absLinkPath, err := filepath.Abs(linkPath)
+			absLinkPath, err := filepath.EvalSymlinks(panel.element[panel.cursor].location)
 			if err != nil {
 				return
 			}

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -75,12 +75,21 @@ func (m *model) enterPanel() {
 		}
 
 		if fileInfo.Mode()&os.ModeSymlink != 0 {
-			absLinkPath, err := filepath.EvalSymlinks(panel.element[panel.cursor].location)
+			targetPath, err := filepath.EvalSymlinks(panel.element[panel.cursor].location)
 			if err != nil {
 				return
 			}
 
-			m.fileModel.filePanels[m.filePanelFocusIndex].location = absLinkPath
+			targetInfo, err := os.Lstat(targetPath)
+
+			if err != nil {
+				return
+			}
+
+			if targetInfo.IsDir() {
+				m.fileModel.filePanels[m.filePanelFocusIndex].location = absLinkPath
+			}
+
 			return
 		}
 

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -87,7 +87,7 @@ func (m *model) enterPanel() {
 			}
 
 			if targetInfo.IsDir() {
-				m.fileModel.filePanels[m.filePanelFocusIndex].location = absLinkPath
+				m.fileModel.filePanels[m.filePanelFocusIndex].location = targetPath
 			}
 
 			return


### PR DESCRIPTION
`isBrokenSymlink` function in `src/internal/function.go` calls `filepath.Abs` after `os.Readlink` but this could lead to problems if the symlink is relative for example on unix systems, especially linux `/bin` is often linked to `/usr/bin` but relatively... So `os.Readlink` will return `usr/bin` and not `/usr/bin` and `filepath.Abs` will join it with the current working directory which would not be `/` but the directory from which you run `spf` and `os.Stat` will ofcourse return an error as that file does not exist.

For example:
![20241125_21h13m12s_grim](https://github.com/user-attachments/assets/9a9aca8c-b509-4c03-9188-96d03fc4b5ef)

This shows up as a broken symlink although it is valid and I can't go into the directory

Alternate approach is to use [`filepath.EvalSymlinks`](https://pkg.go.dev/path/filepath#EvalSymlinks) which correctly returns the path or an `error` in case it is broken etc. And with this change the same example looks like this:

![20241126_11h16m22s_grim](https://github.com/user-attachments/assets/d623f7cd-758a-4948-8449-c76a0a848510)

And I can actually go into the directory and it takes me to the proper target 