### PR TITLE
fix: opening files on windows

### DIFF
--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -96,7 +96,20 @@ func (m *model) enterPanel() {
 		openCommand := "xdg-open"
 		if runtime.GOOS == "darwin" {
 			openCommand = "open"
+		} else if runtime.GOOS == "windows" {
+
+			dllpath := filepath.Join(os.Getenv("SYSTEMROOT"), "System32", "rundll32.exe")
+			dllfile := "url.dll,FileProtocolHandler"
+
+			cmd := exec.Command(dllpath, dllfile, panel.element[panel.cursor].location)
+			err = cmd.Start()
+			if err != nil {
+				outPutLog(fmt.Sprintf("err when open file with %s", openCommand), err)
+			}
+
+			return
 		}
+
 		cmd := exec.Command(openCommand, panel.element[panel.cursor].location)
 		err = cmd.Start()
 		if err != nil {


### PR DESCRIPTION
Addresses #249 and #382

Does so by checking `runtime.GOOS` and if it is "windows" calls `rundll32.exe` with the dll file `url.dll,FileProtocolHandler` and passes the file name to it, and logs the error in case any

Implementation exactly similar to windows implementation of [skratchdot/open-golang](https://github.com/skratchdot/open-golang)

See also : [lolbas-project.github.io/lolbas/Libraries/Url/](https://lolbas-project.github.io/lolbas/Libraries/Url/)

Tested and works well on Windows 11