### PR TITLE
feat: add keys PageUp and PageDown for better navigation

### DIFF
--- a/src/internal/config_type.go
+++ b/src/internal/config_type.go
@@ -153,6 +153,8 @@ type HotkeysType struct {
 	// movement
 	ListUp   []string `toml:"list_up" comment:"movement"`
 	ListDown []string `toml:"list_down"`
+	PageUp   []string `toml:"page_up"`
+	PageDown []string `toml:"page_down"`
 
 	CloseFilePanel         []string `toml:"close_file_panel" comment:"file panel control"`
 	CreateNewFilePanel     []string `toml:"create_new_file_panel"`

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -279,6 +279,60 @@ func (m *model) controlFilePanelListDown(wheel bool) {
 
 }
 
+func (m *model) controlFilePanelPgUp(){
+  panel := m.fileModel.filePanels[m.filePanelFocusIndex]
+  panlen := len(panel.element)
+  panHeight := panelElementHeight(m.mainPanelHeight)
+  panCenter := panHeight / 2     // For making sure the cursor is at the center of the panel
+
+  if panlen == 0 {
+    return
+  }
+
+  if panHeight >= panlen {
+    panel.cursor = 0
+  } else {
+    if panel.cursor - panHeight <= 0 {
+      panel.cursor = 0
+      panel.render = 0
+    } else {
+      panel.cursor -= panHeight
+      panel.render = panel.cursor - panCenter
+      
+      if panel.render < 0 {
+        panel.render = 0
+      }
+    }
+  }
+
+	m.fileModel.filePanels[m.filePanelFocusIndex] = panel
+}
+
+func (m *model) controlFilePanelPgDown(){
+  panel := m.fileModel.filePanels[m.filePanelFocusIndex]
+  panlen := len(panel.element)
+  panHeight := panelElementHeight(m.mainPanelHeight)
+  panCenter := panHeight / 2     // For making sure the cursor is at the center of the panel
+
+  if panlen == 0 {
+    return
+  }
+
+  if panHeight >= panlen {
+    panel.cursor = panlen - 1
+  } else {
+    if panel.cursor + panHeight >= panlen {
+      panel.cursor = panlen - 1
+      panel.render = panel.cursor - panCenter
+    } else {
+      panel.cursor += panHeight
+      panel.render = panel.cursor - panCenter
+    }
+  }
+
+	m.fileModel.filePanels[m.filePanelFocusIndex] = panel
+}
+
 // Handles the action of selecting an item in the file panel upwards. (only work on select mode)
 func (m *model) itemSelectUp(wheel bool) {
 	runTime := 1

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -49,6 +49,12 @@ func (m *model) mainKey(msg string, cmd tea.Cmd) ( tea.Cmd) {
 			}()
 		}
 
+  case tea.KeyPgUp.String():
+    m.controlFilePanelPgUp()
+
+  case tea.KeyPgDown.String():
+    m.controlFilePanelPgDown()
+
 	case containsKey(msg, hotkeys.ChangePanelMode):
 		m.changeFilePanelMode()
 

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -49,10 +49,10 @@ func (m *model) mainKey(msg string, cmd tea.Cmd) ( tea.Cmd) {
 			}()
 		}
 
-  case tea.KeyPgUp.String():
+  case containsKey(msg, hotkeys.PageUp):
     m.controlFilePanelPgUp()
 
-  case tea.KeyPgDown.String():
+  case containsKey(msg, hotkeys.PageDown):
     m.controlFilePanelPgDown()
 
 	case containsKey(msg, hotkeys.ChangePanelMode):

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -5,6 +5,8 @@ quit = ['q', 'esc']
 # movement
 list_up = ['up', 'k']
 list_down = ['down', 'j']
+page_up = ['pgup','']
+page_down = ['pgdown','']
 # file panel control
 create_new_file_panel = ['n', '']
 close_file_panel = ['w', '']

--- a/src/superfile_config/vimHotkeys.toml
+++ b/src/superfile_config/vimHotkeys.toml
@@ -7,6 +7,8 @@ quit = ['ctrl+c', ''] # also know as, theprimeagen troller
 # movement
 list_up = ['k', '']
 list_down = ['j', '']
+page_up = ['pgup','']
+page_down = ['pgdown','']
 # file panel control
 create_new_file_panel = ['n', '']
 close_file_panel = ['q', '']


### PR DESCRIPTION
Addresses #290 

The behaviour is as follows:

1. If number of files in the panel is less than the height meaning all files can be contained in a single panel without scroll
PageUp jumps to the first and PageDown jumps to the last element

2. Otherwise, It jumps by the `panelHeight` i.e number of files that can be fit in a panel while always keeping the item the cursor is at, at the center, except at the extreme ends of course

I have tried to keep the behaviour as seen in most applications like text editors etc
Let me know if anything different would be desired