### PR TITLE
fix: lag in dotfile toggle with multiple panels

### DIFF
--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -182,6 +182,7 @@ func (m *model) toggleDotFileController() {
 		newToggleDotFile = "true"
 		m.toggleDotFile = true
 	}
+  m.updatedToggleDotFile = true
 	err := os.WriteFile(variable.ToggleDotFile, []byte(newToggleDotFile), 0644)
 	if err != nil {
 		outPutLog("Pinned folder function updatedData superfile data error", err)

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -383,7 +383,9 @@ func (m *model) getFilePanelItems() {
 		nowTime := time.Now()
 		// Check last time each element was updated, if less then 3 seconds ignore
 		if filePanel.focusType == noneFocus && nowTime.Sub(filePanel.lastTimeGetElement) < 3*time.Second {
-			continue
+      if !m.updatedToggleDotFile {
+        continue
+      }
 		}
 
 		focusPanelReRender := false
@@ -413,6 +415,8 @@ func (m *model) getFilePanelItems() {
 		m.fileModel.filePanels[i].element = fileElement
 		m.fileModel.filePanels[i].lastTimeGetElement = nowTime
 	}
+
+  m.updatedToggleDotFile = false
 }
 
 // Close superfile application. Cd into the curent dir if CdOnQuit on and save

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -72,24 +72,25 @@ const (
 
 // Main model
 type model struct {
-	fileModel           fileModel
-	sidebarModel        sidebarModel
-	processBarModel     processBarModel
-	focusPanel          focusPanelType
-	copyItems           copyItems
-	typingModal         typingModal
-	warnModal           warnModal
-	helpMenu            helpMenuModal
-	fileMetaData        fileMetadata
-	commandLine         commandLineModal
-	confirmToQuit       bool
-	firstTextInput      bool
-	toggleDotFile       bool
-	toggleFooter        bool
-	filePanelFocusIndex int
-	mainPanelHeight     int
-	fullWidth           int
-	fullHeight          int
+	fileModel            fileModel
+	sidebarModel         sidebarModel
+	processBarModel      processBarModel
+	focusPanel           focusPanelType
+	copyItems            copyItems
+	typingModal          typingModal
+	warnModal            warnModal
+	helpMenu             helpMenuModal
+	fileMetaData         fileMetadata
+	commandLine          commandLineModal
+	confirmToQuit        bool
+	firstTextInput       bool
+	toggleDotFile        bool
+	updatedToggleDotFile bool
+	toggleFooter         bool
+	filePanelFocusIndex  int
+	mainPanelHeight      int
+	fullWidth            int
+	fullHeight           int
 }
 
 // Modal


### PR DESCRIPTION
A very small PR Addressing #376 

This "bug" was because if the `filePanel` was not in focus and the last time it was modified was before 3 seconds, it would not be updated.. Which would cause lag and irregularity with multiple panels

Maybe this was like so, to improve performance as redrawing everything, at every moment would be costly, But I didn't notice such performance issues so maybe it's fine, let me know what you think

PS: removed that last assignment because it's very next line was doing the same thing