### PR TITLE
feat: add desktop entry

### DIFF
--- a/asset/spf.desktop
+++ b/asset/spf.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=spf
+GenericName=superfile
+Comment=fancy and modern terminal file manager
+Type=Application
+MimeType=inode/directory
+Icon=utilities-terminal
+Terminal=true
+TryExec=spf
+Exec=spf %u
+Categories=Utility;System;FileTools;FileManager;Filesystem;ConsoleOnly
+Keywords=File;Manager;Explorer


### PR DESCRIPTION
adds a `.desktop` file, so that users can launch it from `rofi` or any start menu that looks for Desktop entries.

I have left the `Icon` key a general one for now, it can be updated later with the superfile's icon as and when package maintainers start shipping icons.