### PR TITLE
Enable cd_on_quit When Current Directory is Home Directory

### DIFF
--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -431,9 +431,6 @@ func (m model) quitSuperfile() {
     variable.LastDir = currentDir
 
     if Config.CdOnQuit {
-        if currentDir == variable.HomeDir {
-            return
-        }
         // escape single quote
         currentDir = strings.ReplaceAll(currentDir, "'", "'\\''")
         os.WriteFile(variable.SuperFileStateDir+"/lastdir", []byte("cd '"+currentDir+"'"), 0755)


### PR DESCRIPTION
# Description

I'm not sure if this is a bug but you can not "Cd On Quit" when the current directory is the home directory. This doesn't make intuitive sense to me. It seems it was very early code.

This pull request allows you to "Cd On Quit" when the home directory is the current directory.

# Fixes

Allows you "Cd On Quit" when the home directory is the current directory.

## Type of change

Please delete options that are not relevant.

- [✅] Bug fix