### PR TITLE
fix: reduce lag when navigating directories with large image files

### DIFF
--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -613,6 +613,9 @@ func (m model) filePreviewPanelRender() string {
 	}
 
 	if isImageFile(itemPath) {
+		if !m.fileModel.filePreview.open {
+            return box.Render("\n --- Preview panel is closed ---")
+        }
 		ansiRender, err := filepreview.ImagePreview(itemPath, m.fileModel.filePreview.width, previewLine, theme.FilePanelBG)
 		if err == image.ErrFormat {
 			return box.Render("\n --- " + icon.Error + " Unsupported image formats ---")


### PR DESCRIPTION
This will fix: #428 

Changes so far:
- Skip image processing when preview panel is closed
- Add colour caching to reduce redundant colour space conversions in image 
processing. Cache previously converted colours to avoid repeated RGBA->termenv 
conversions of identical pixels.

So far, this means that:
1. No lag occurs when navigating directories with large images while preview is hidden
2. No lag occurs when performing other operations (e.g renaming files) within directories with large images while preview is hidden
3. Eliminates repeated colour conversions for duplicate pixels
