### PR TITLE
Warn overwrite when renaming

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -39,6 +39,39 @@ func (m *model) panelCreateNewFile() {
 
 }
 
+func (m *model) IsRenamingConflicting() bool {
+	panel := m.fileModel.filePanels[m.filePanelFocusIndex]
+	oldPath := panel.element[panel.cursor].location
+	newPath := panel.location + "/" + panel.rename.Value()
+
+	if oldPath == newPath {
+		return false
+	}
+
+	_, err := os.Stat(newPath)
+	if err == nil {
+		return true
+	}
+
+	return false
+}
+
+func (m *model) warnModalForRenaming() {
+	id := shortuuid.New()
+	message := channelMessage{
+		messageId:   id,
+		messageType: sendWarnModal,
+	}
+
+	message.warnModal = warnModal{
+		open:     true,
+		title:    "There is already a file or directory with that name",
+		content:  "This operation will override the existing file",
+		warnType: confirmRenameItem,
+	}
+	channel <- message
+}
+
 // Rename file where the cusror is located
 func (m *model) panelItemRename() {
 	panel := m.fileModel.filePanels[m.filePanelFocusIndex]

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -33,6 +33,7 @@ const (
 
 const (
 	confirmDeleteItem warnType = iota
+	confirmRenameItem
 )
 
 // Constants for panel with no focus


### PR DESCRIPTION
Warn user and ask for confirmation when a file/directory renaming will cause overwrite.

![spf-screenshot-rename](https://github.com/user-attachments/assets/73b29520-0463-453e-b60a-b40feb5f45d4)

Addresses #348 