### PR TITLE
Fix panic when deleting last file in directory

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -141,11 +141,11 @@ func (m *model) deleteSingleItem() {
 		channel <- message
 	}
 	if len(panel.element) == 0 {
-        panel.cursor = 0
-    } else {
-			if panel.cursor >= len(panel.element) {
-                panel.cursor = len(panel.element) - 1
-			}
+		panel.cursor = 0
+	} else {
+		if panel.cursor >= len(panel.element) {
+			panel.cursor = len(panel.element) - 1
+		}
 	}
 	m.fileModel.filePanels[m.filePanelFocusIndex] = panel
 }
@@ -263,11 +263,11 @@ func (m *model) completelyDeleteSingleItem() {
 		channel <- message
 	}
 	if len(panel.element) == 0 {
-        panel.cursor = 0
-    } else {
-			if panel.cursor >= len(panel.element) {
-                panel.cursor = len(panel.element) - 1
-			}
+		panel.cursor = 0
+	} else {
+		if panel.cursor >= len(panel.element) {
+			panel.cursor = len(panel.element) - 1
+		}
 	}
 	m.fileModel.filePanels[m.filePanelFocusIndex] = panel
 }

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -140,8 +140,12 @@ func (m *model) deleteSingleItem() {
 		message.processNewState = p
 		channel <- message
 	}
-	if panel.cursor == len(panel.element)-1 {
-		panel.cursor--
+	if len(panel.element) == 0 {
+        panel.cursor = 0
+    } else {
+			if panel.cursor >= len(panel.element) {
+                panel.cursor = len(panel.element) - 1
+			}
 	}
 	m.fileModel.filePanels[m.filePanelFocusIndex] = panel
 }
@@ -258,8 +262,12 @@ func (m *model) completelyDeleteSingleItem() {
 		message.processNewState = p
 		channel <- message
 	}
-	if panel.cursor == len(panel.element)-1 {
-		panel.cursor--
+	if len(panel.element) == 0 {
+        panel.cursor = 0
+    } else {
+			if panel.cursor >= len(panel.element) {
+                panel.cursor = len(panel.element) - 1
+			}
 	}
 	m.fileModel.filePanels[m.filePanelFocusIndex] = panel
 }


### PR DESCRIPTION
Fixes #528.
## Problem
If you try to delete the last file in a directory, the application would panic with an "index out of range [-1]" error. This occurred because the cursor position didn't reset properly after the deletion, leading to an invalid array
access in the file preview panel.

## Solution
Added proper cursor position handling after file deletion:
- if the current directory is empty, the cursor becomes 0
- if the cursor is beyond last element, set it to last element position
