### PR TITLE
Fix panic when scrolling through an empty metadata list

### DIFF
--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -544,6 +544,10 @@ func (m *model) controlMetadataListUp(wheel bool) {
 		runTime = wheelRunTime
 	}
 
+	if len(m.fileMetaData.metaData) == 0 {
+		return
+	}
+
 	for i := 0; i < runTime; i++ {
 		if m.fileMetaData.renderIndex > 0 {
 			m.fileMetaData.renderIndex--


### PR DESCRIPTION
Don't scroll down the metadata list when empty.
Before the fix, the program was crashing due to a negative index on a list.

Fixes #485 