### PR TITLE
Fix panic when trying to get folder size without needed permissions

### DIFF
--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -415,12 +415,15 @@ func calculateMD5Checksum(filePath string) (string, error) {
 // Get directory total size
 func dirSize(path string) int64 {
 	var size int64
-	filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+	filepath.WalkDir(path, func(_ string, entry os.DirEntry, err error) error {
 		if err != nil {
 			outPutLog("Dir size function error", err)
 		}
-		if !info.IsDir() {
-			size += info.Size()
+		if !entry.IsDir() {
+			info, err := entry.Info()
+			if err == nil {
+				size += info.Size()
+			}
 		}
 		return err
 	})


### PR DESCRIPTION
Check error on file info before getting its size.

When traversing directories, some of them might have the execute bit unset, which means you cant access its files (thus their sizes). Apparently trying to directly access the file info would cause a panic (on the OS side i think) which crashed the application. Checking for any errors before that solves the issue.

For now I just did not add the unreachable file size to the sum, which would lead to an incorrect size displayed to the user. Maybe displaying `FileSize: undefined`, or insufficient permissions, or not showing them at all would be better. If that's the case, would be happy to change that too.

Fixes #486 