### PR TITLE
Fix wrong log line, Fatalln was used with formatting verbs

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -193,7 +193,7 @@ func checkFirstUse() bool {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		firstUse = true
 		if err := os.WriteFile(file, nil, 0644); err != nil {
-			log.Fatalln("failed to create file: %w", err)
+			log.Fatalf("Failed to create file: %v", err)
 		}
 	}
 	return firstUse


### PR DESCRIPTION
## What ?
Fixed a wrong log line .

## Why ?
If left as is, logging will produce incorrect string.

## How do you know it works ?
Used the correct Fatalf function that is consistent with the current usage of Fatalf across the codebase. 