### PR TITLE
Fix isTextFile check by not checking more than the number bytes we read

### DIFF
--- a/src/internal/string_function.go
+++ b/src/internal/string_function.go
@@ -152,12 +152,12 @@ func isTextFile(filename string) (bool, error) {
 
 	reader := bufio.NewReader(file)
 	buffer := make([]byte, 1024)
-	_, err = reader.Read(buffer)
+	cnt, err := reader.Read(buffer)
 	if err != nil {
 		return false, err
 	}
 
-	for _, b := range buffer {
+	for _, b := range buffer[:cnt] {
 		if b == 0 {
 			return false, nil
 		}


### PR DESCRIPTION
## What ?
Fix isTextFile in internal/string_functions.go  by not checking more than the number bytes we read.

## Why ?
It causes isTextFile function to misbehave

<details>
<summary> Why isTextFile misbehaves</summary>
I created a file with `echo text > file.txtfile` and added some logs in isTextFile

```go
cnt, err := reader.Read(buffer)
	log.Printf("[string_function.isTextFile] read %v bytes, %v", cnt, buffer[:cnt])
	if err != nil {
		return false, err
	}

	for i, b := range buffer {
		if b == 0 {
			log.Printf("[string_function.isTextFile] b[%v] is 0 in file, hence not text file", i)
			return false, nil
		}
		if !unicode.IsPrint(rune(b)) && !unicode.IsSpace(rune(b)) {
			log.Printf("[string_function.isTextFile] b[%v]=%v is not pritiable in file, hence not text file", i, b)
			return false, nil
		}
	}

```

isTextFile returned false for this file, while it shouldn't have with these logs

```
2025/01/23 11:34:34 [string_function.isTextFile] read 5 bytes, [116 101 120 116 10]
2025/01/23 11:34:34 [string_function.isTextFile] b[5] is 0 in file, hence not text file
2025/01/23 11:34:34 [model_render.filePreviewPanelRender] textFile is  false
2025/01/23 11:34:34 [string_function.isTextFile] read 5 bytes, [116 101 120 116 10]
2025/01/23 11:34:34 [string_function.isTextFile] b[5] is 0 in file, hence not text file
2025/01/23 11:34:34 [model_render.filePreviewPanelRender] textFile is  false
2025/01/23 11:34:35 [string_function.isTextFile] read 5 bytes, [116 101 120 116 10]
2025/01/23 11:34:35 [string_function.isTextFile] b[5] is 0 in file, hence not text file
2025/01/23 11:34:35 [model_render.filePreviewPanelRender] textFile is  false
2025/01/23 11:34:35 [string_function.isTextFile] read 5 bytes, [116 101 120 116 10]
2025/01/23 11:34:35 [string_function.isTextFile] b[5] is 0 in file, hence not text file
```

Hence it shows unsupported file
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/9bbfb1a1-d62e-49bf-b5c2-31a8eee52412" />

</details>


## How do you know it works ?

With new build, its able to read the `file.txtfile` file mentioned in "Why isTextFile misbehaves" 
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/b7ee82df-2a33-434f-9fe0-61b5409e6f68" />


