### PR TITLE
Fix previews for text file with control characters  - Avoid layout breaking, improved code, added tests for string functions

### DIFF
--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -551,6 +551,32 @@ func (m model) sortOptionsRender() string {
 	return sortOptionsModalBorderStyle(panel.sortOptions.height, panel.sortOptions.width, bottomBorder).Render(sortOptionsContent)
 }
 
+func readFileContent(filepath string, maxLineLength int, previewLine int) (string, error) {
+	fileContent := ""
+	file, err := os.Open(filepath)
+	if err != nil {
+		return fileContent, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	lineCount := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) > maxLineLength {
+			line = line[:maxLineLength]
+		}
+		fileContent += line + "\n"
+		lineCount++
+		if previewLine > 0 && lineCount >= previewLine {
+			break
+		}
+	}
+	// returns the first non-EOF error that was encountered by the [Scanner]
+	// Handled by the caller
+	return fileContent, scanner.Err()
+}
+
 func (m model) filePreviewPanelRender() string {
 	previewLine := m.mainPanelHeight + 2
 	m.fileModel.filePreview.width += m.fullWidth - Config.SidebarWidth - m.fileModel.filePreview.width - ((m.fileModel.width + 2) * len(m.fileModel.filePanels)) - 2
@@ -630,86 +656,42 @@ func (m model) filePreviewPanelRender() string {
 	}
 
 	format := lexers.Match(filepath.Base(itemPath))
-	if format != nil {
-		var codeHighlight string
-		var err error
-		var fileContent string
-		file, err := os.Open(itemPath)
+
+	if format == nil {
+		isText, err := isTextFile(itemPath)
 		if err != nil {
-			outPutLog(err)
-			return box.Render("\n --- " + icon.Error + " Error open file ---")
+			outPutLog("Error while checking text file", err)
+			return box.Render("\n --- " + icon.Error + " Error get file info ---")
+		} else if !isText {
+			return box.Render("\n --- " + icon.Error + " Unsupported formats ---")
 		}
-		defer file.Close()
+	}
 
-		scanner := bufio.NewScanner(file)
-		lineCount := 0
+	// At this point either format is not nil, or we can read the file
+	fileContent , err := readFileContent(itemPath, m.fileModel.width+20, previewLine)
+	if err != nil {
+		outPutLog(err)
+		return box.Render("\n --- " + icon.Error + " Error open file ---")
+	}
 
-		maxLineLength := m.fileModel.width + 20
-		for scanner.Scan() {
-			line := scanner.Text()
-			if len(line) > maxLineLength {
-				line = line[:maxLineLength]
-			}
-			fileContent += line + "\n"
-			lineCount++
-			if previewLine > 0 && lineCount >= previewLine {
-				break
-			}
+	// We know the format of file, and we can apply syntax highlighting
+	if format != nil {
+		background := ""
+		if ! Config.TransparentBackground {
+			background = theme.FilePanelBG
 		}
-
-		if Config.TransparentBackground {
-			codeHighlight, err = ansichroma.HightlightString(fileContent, format.Config().Name, theme.CodeSyntaxHighlightTheme, "")
-		} else {
-			codeHighlight, err = ansichroma.HightlightString(fileContent, format.Config().Name, theme.CodeSyntaxHighlightTheme, theme.FilePanelBG)
-		}
+		fileContent, err = ansichroma.HightlightString(fileContent, format.Config().Name, theme.CodeSyntaxHighlightTheme, background)
 		if err != nil {
 			outPutLog("Error render code highlight", err)
 			return box.Render("\n --- " + icon.Error + " Error render code highlight ---")
 		}
-		if codeHighlight == "" {
-			return box.Render("\n --- empty ---")
-		}
-
-		codeHighlight = checkAndTruncateLineLengths(codeHighlight, m.fileModel.filePreview.width)
-
-		return box.Render(codeHighlight)
-	} else {
-		textFile, err := isTextFile(itemPath)
-		if err != nil {
-			outPutLog("Error check text file", err)
-		}
-		if textFile {
-			var fileContent string
-			file, err := os.Open(itemPath)
-			if err != nil {
-				outPutLog(err)
-				return box.Render("\n --- " + icon.Error + " Error open file ---")
-			}
-			defer file.Close()
-
-			scanner := bufio.NewScanner(file)
-			lineCount := 0
-
-			for scanner.Scan() {
-				fileContent += scanner.Text() + "\n"
-				lineCount++
-				if previewLine > 0 && lineCount >= previewLine {
-					break
-				}
-			}
-
-			if err := scanner.Err(); err != nil {
-				outPutLog(err)
-				return box.Render("\n --- " + icon.Error + " Error open file ---")
-			}
-
-			textContent := checkAndTruncateLineLengths(fileContent, m.fileModel.filePreview.width)
-
-			return box.Render(textContent)
-		}
 	}
 
-	return box.Render("\n --- " + icon.Error + " Unsupported formats ---")
+	if fileContent == "" {
+		return box.Render("\n --- empty ---")
+	}
+	fileContent = checkAndTruncateLineLengths(fileContent, m.fileModel.filePreview.width)
+	return box.Render(fileContent)
 }
 
 func (m model) commandLineInputBoxRender() string {

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -552,10 +552,12 @@ func (m model) sortOptionsRender() string {
 }
 
 func readFileContent(filepath string, maxLineLength int, previewLine int) (string, error) {
-	fileContent := ""
+	// String builder is Much better for efficiency 
+	// See - https://stackoverflow.com/questions/1760757/how-to-efficiently-concatenate-strings-in-go/47798475#47798475
+	var resultBuilder strings.Builder 
 	file, err := os.Open(filepath)
 	if err != nil {
-		return fileContent, err
+		return resultBuilder.String(), err
 	}
 	defer file.Close()
 
@@ -566,15 +568,14 @@ func readFileContent(filepath string, maxLineLength int, previewLine int) (strin
 		if len(line) > maxLineLength {
 			line = line[:maxLineLength]
 		}
-		fileContent += line + "\n"
+		resultBuilder.WriteString(line+"\n")
 		lineCount++
 		if previewLine > 0 && lineCount >= previewLine {
 			break
 		}
 	}
 	// returns the first non-EOF error that was encountered by the [Scanner]
-	// Handled by the caller
-	return fileContent, scanner.Err()
+	return resultBuilder.String(), scanner.Err()
 }
 
 func (m model) filePreviewPanelRender() string {

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -552,7 +552,7 @@ func (m model) sortOptionsRender() string {
 }
 
 func readFileContent(filepath string, maxLineLength int, previewLine int) (string, error) {
-	// String builder is Much better for efficiency 
+	// String builder is much better for efficiency 
 	// See - https://stackoverflow.com/questions/1760757/how-to-efficiently-concatenate-strings-in-go/47798475#47798475
 	var resultBuilder strings.Builder 
 	file, err := os.Open(filepath)

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -568,6 +568,8 @@ func readFileContent(filepath string, maxLineLength int, previewLine int) (strin
 		if len(line) > maxLineLength {
 			line = line[:maxLineLength]
 		}
+		// This is critical to avoid layout break, removes non Printable ASCII control characters. 
+		line = makePrintable(line)
 		resultBuilder.WriteString(line+"\n")
 		lineCount++
 		if previewLine > 0 && lineCount >= previewLine {

--- a/src/internal/string_function.go
+++ b/src/internal/string_function.go
@@ -142,6 +142,17 @@ func checkAndTruncateLineLengths(text string, maxLength int) string {
 	return finalResult
 }
 
+// Separated this out out for easy testing
+func isBufferPrintable(buffer []byte) bool {
+	for _, b := range buffer {
+		// This will also handle b==0
+		if !unicode.IsPrint(rune(b)) && !unicode.IsSpace(rune(b)) {
+			return false
+		}
+	}
+	return true
+}
+
 // Check file is text file or not
 func isTextFile(filename string) (bool, error) {
 	file, err := os.Open(filename)
@@ -156,15 +167,5 @@ func isTextFile(filename string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	for _, b := range buffer[:cnt] {
-		if b == 0 {
-			return false, nil
-		}
-		if !unicode.IsPrint(rune(b)) && !unicode.IsSpace(rune(b)) {
-			return false, nil
-		}
-	}
-
-	return true, nil
+	return isBufferPrintable(buffer[:cnt]), nil
 }

--- a/src/internal/string_function.go
+++ b/src/internal/string_function.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"strings"
@@ -164,7 +165,7 @@ func isTextFile(filename string) (bool, error) {
 	reader := bufio.NewReader(file)
 	buffer := make([]byte, 1024)
 	cnt, err := reader.Read(buffer)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return false, err
 	}
 	return isBufferPrintable(buffer[:cnt]), nil

--- a/src/internal/string_function.go
+++ b/src/internal/string_function.go
@@ -169,3 +169,22 @@ func isTextFile(filename string) (bool, error) {
 	}
 	return isBufferPrintable(buffer[:cnt]), nil
 }
+
+
+// Although some characters like `\x0b`(vertical tab are printable) 
+// previewing them breaks the layout. 
+// So, among the "non-graphic" printable characters, we only need \n and \t 
+// Space and NBSP are already considered graphic by unicode.
+func makePrintable(line string)(string) {
+	var sb strings.Builder
+	// This has to be looped byte-wise, looping it rune-wise 
+	// or by using strings.Map would cause issues with strings like
+	// "(NBSP)\xa0"
+	for i:=0; i<len(line); i++ {
+		r := rune(line[i])
+		if unicode.IsGraphic(r) || r == rune('\t') || r == rune('\n') {
+			sb.WriteByte(line[i])
+		}
+	}
+	return sb.String()
+}

--- a/src/internal/string_function.go
+++ b/src/internal/string_function.go
@@ -172,7 +172,7 @@ func isTextFile(filename string) (bool, error) {
 }
 
 
-// Although some characters like `\x0b`(vertical tab are printable) 
+// Although some characters like `\x0b`(vertical tab) are printable, 
 // previewing them breaks the layout. 
 // So, among the "non-graphic" printable characters, we only need \n and \t 
 // Space and NBSP are already considered graphic by unicode.

--- a/src/internal/string_function.go
+++ b/src/internal/string_function.go
@@ -152,12 +152,12 @@ func isTextFile(filename string) (bool, error) {
 
 	reader := bufio.NewReader(file)
 	buffer := make([]byte, 1024)
-	_, err = reader.Read(buffer)
+	cnt, err := reader.Read(buffer)
 	if err != nil {
 		return false, err
 	}
 
-	for _, b := range buffer {
+	for _, b := range buffer[:cnt] {
 		if b == 0 {
 			return false, nil
 		}

--- a/src/internal/string_function_test.go
+++ b/src/internal/string_function_test.go
@@ -67,6 +67,9 @@ func TestIsBufferPrintable(t *testing.T) {
 		{"hello", true},
 		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", true},
 		{"Horizontal Tab and NewLine\t\t\n\n", true},
+		{"\xa0(NBSP)", true},
+		{"\x0b(Vertical Tab)", true},
+		{"\x0d(CR)", true},
 		{"ASCII control characters : \x00(NULL)", false},
 		{"\x05(ENQ)", false},
 		{"\x0f(SI)", false},
@@ -82,5 +85,35 @@ func TestIsBufferPrintable(t *testing.T) {
 			}
 		})
 	}
-
 }
+
+func TestMakePrintable(t *testing.T) {
+	var inputs = []struct {
+		input    string
+		expected string
+	} {
+		{"hello", "hello"},
+		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", "abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]"},
+		{"Horizontal Tab and NewLine\t\t\n\n", "Horizontal Tab and NewLine\t\t\n\n"},
+		{"(NBSP)\xa0\xa0\xa0\xa0;", "(NBSP)\xa0\xa0\xa0\xa0;"},
+		{"\x0b(Vertical Tab)", "(Vertical Tab)"},
+		{"\x0d(CR)", "(CR)"},
+		{"ASCII control characters : \x00(NULL)", "ASCII control characters : (NULL)"},
+		{"\x05(ENQ)", "(ENQ)"},
+		{"\x0f(SI)", "(SI)"},
+		{"\x1b(ESC)", "(ESC)"},
+		{"\x7f(DEL)", "(DEL)"},
+	}
+	for _, tt := range inputs {
+
+		t.Run(fmt.Sprintf("Make %q printable", tt.input), func(t* testing.T){
+			result := makePrintable(tt.input)
+			if result != tt.expected {
+				//t.Logf("length - %v, %v; bytes - %v, %v", 
+				//	len(tt.expected), len(result), []byte(tt.expected), []byte(result))
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+

--- a/src/internal/string_function_test.go
+++ b/src/internal/string_function_test.go
@@ -64,6 +64,7 @@ func TestIsBufferPrintable(t *testing.T) {
 		input    string
 		expected bool
 	} {
+		{"", true},
 		{"hello", true},
 		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", true},
 		{"Horizontal Tab and NewLine\t\t\n\n", true},
@@ -92,6 +93,7 @@ func TestMakePrintable(t *testing.T) {
 		input    string
 		expected string
 	} {
+		{"", ""},
 		{"hello", "hello"},
 		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", "abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]"},
 		{"Horizontal Tab and NewLine\t\t\n\n", "Horizontal Tab and NewLine\t\t\n\n"},

--- a/src/internal/string_function_test.go
+++ b/src/internal/string_function_test.go
@@ -57,3 +57,30 @@ func TestFilenameWithouText(t *testing.T) {
 		})
 	}
 }
+
+
+func TestIsBufferPrintable(t *testing.T) {
+	var inputs = []struct {
+		input    string
+		expected bool
+	} {
+		{"hello", true},
+		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", true},
+		{"Horizontal Tab and NewLine\t\t\n\n", true},
+		{"ASCII control characters : \x00(NULL)", false},
+		{"\x05(ENQ)", false},
+		{"\x0f(SI)", false},
+		{"\x1b(ESC)", false},
+		{"\x7f(DEL)", false},
+	}
+	for _, tt := range inputs {
+
+		t.Run(fmt.Sprintf("Testing if buffer %q is printable", tt.input), func(t* testing.T){
+			result := isBufferPrintable([]byte(tt.input))
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+
+}

--- a/src/internal/string_function_test.go
+++ b/src/internal/string_function_test.go
@@ -111,8 +111,6 @@ func TestMakePrintable(t *testing.T) {
 		t.Run(fmt.Sprintf("Make %q printable", tt.input), func(t* testing.T){
 			result := makePrintable(tt.input)
 			if result != tt.expected {
-				//t.Logf("length - %v, %v; bytes - %v, %v", 
-				//	len(tt.expected), len(result), []byte(tt.expected), []byte(result))
 				t.Errorf("Expected %v, got %v", tt.expected, result)
 			}
 		})


### PR DESCRIPTION
## What ?
- Fixed previews for text file with ASCII control characters to avoid layout breaking
- Improved code 
  - Improved filePreviewPanelRender : removed code duplication
  - Using strings.Builder while reading file content
  - Improve isTextFile check and add testcases
- Added tests for string functions
- Fixed isTextFile check by not checking more than the number bytes we read (See https://github.com/yorukot/superfile/pull/556) 

Fixes these issues https://github.com/yorukot/superfile/issues/554, https://github.com/yorukot/superfile/issues/495 

## Why ?
Fixes user facing bugs. Improves code quality.

## How do you know it works ?

<details>
<summary>Test cases passed</summary>

```fish
➜  ~/Workspace/kuknitin/superfile/src/internal git:(fix_preview) [6:31:04] git log --oneline | head -n 2
f6d81ae Allow empty file in isTextFile, add more testcases
ceee01d Fix layout breaking on reading files with ascii control characters
➜  ~/Workspace/kuknitin/superfile/src/internal git:(fix_preview) [6:31:16] go test
# github.com/shirou/gopsutil/disk
iostat_darwin.c:28:2: warning: 'IOMasterPort' is deprecated: first deprecated in macOS 12.0 [-Wdeprecated-declarations]
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOKit.framework/Headers/IOKitLib.h:143:1: note: 'IOMasterPort' has been explicitly marked deprecated here
PASS
ok  	github.com/yorukot/superfile/src/internal	0.469s
➜  ~/Workspace/kuknitin/superfile/src/internal git:(fix_preview) [6:31:23]
```
</details>

<details>
<summary>Testing of spf on files with control characters</summary>
Old spf

https://github.com/user-attachments/assets/19d2944d-dc19-40cc-978e-98b28116a305

New spf


https://github.com/user-attachments/assets/36224ca0-b7cb-4af2-bfca-a906454b8aea


</details>

