### PR TITLE
Fix incorrect failure reporting in delete operation

### DIFF
--- a/src/internal/file_operations.go
+++ b/src/internal/file_operations.go
@@ -147,11 +147,13 @@ func trashMacOrLinux(src string) error {
 		err := moveElement(src, filepath.Join(variable.HomeDir, ".Trash", filepath.Base(src)))
 		if err != nil {
 			outPutLog("Delete single item function move file to trash can error", err)
+			return err
 		}
 	} else {
 		err := trash.Trash(src)
 		if err != nil {
 			outPutLog("Paste item function move file to trash can error", err)
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
## What ?
Return the correct errors in trashMacOrLinux, instead of always returning nil

## Why ?
Even on failed deletion, the operations shows success.

## How do you know it works ?

Old spf doesn't report failure

https://github.com/user-attachments/assets/44dd7086-fa79-4683-a2ae-41c86880bff5

New spf reports failure

https://github.com/user-attachments/assets/ea02dc52-1e0d-4359-85d9-be87d3da75f8
