### PR TITLE
Move rename cursor to start before the extention

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -74,6 +74,12 @@ func (m *model) panelItemRename() {
 	if len(panel.element) == 0 {
 		return
 	}
+
+	cursorPos := strings.LastIndex(panel.element[panel.cursor].name, ".")
+	if cursorPos == -1 || panel.element[panel.cursor].directory {
+		cursorPos = len(panel.element[panel.cursor].name)
+	}
+
 	ti := textinput.New()
 	ti.Cursor.Style = filePanelCursorStyle
 	ti.Cursor.TextStyle = filePanelStyle
@@ -83,6 +89,7 @@ func (m *model) panelItemRename() {
 	ti.Placeholder = "New name"
 	ti.PlaceholderStyle = modalStyle
 	ti.SetValue(panel.element[panel.cursor].name)
+	ti.SetCursor(cursorPos)
 	ti.Focus()
 	ti.CharLimit = 156
 	ti.Width = m.fileModel.width - 4

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -76,8 +76,9 @@ func (m *model) panelItemRename() {
 	}
 
 	cursorPos := strings.LastIndex(panel.element[panel.cursor].name, ".")
-	if cursorPos == -1 || panel.element[panel.cursor].directory {
-		cursorPos = len(panel.element[panel.cursor].name)
+	nameLen := len(panel.element[panel.cursor].name)
+	if cursorPos == -1 || cursorPos == 0 && nameLen > 0 || panel.element[panel.cursor].directory {
+		cursorPos = nameLen
 	}
 
 	ti := textinput.New()


### PR DESCRIPTION
When renaming a file, the extention often stays the same. This change moves the cursor to the end of the name but before the extention.

(Underscore denotes cursor starting position)


`test_`
`test_.txt`
`.test_`
`.test_.txt`
`te.st_.txt`

Cursor position remains unaffected if the file is a directory