### PR TITLE
Fix crash when searching on WSL mounted drives

### DIFF
--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -169,7 +169,6 @@ func returnFolderElementBySearchString(location string, displayDotFile bool, sea
 			directory: item.IsDir(),
 			location:  folderElementLocation,
 		}
-
 	}
 
 	var options = fzf.DefaultOptions()

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -143,18 +143,18 @@ func returnFolderElementBySearchString(location string, displayDotFile bool, sea
 	items, err := os.ReadDir(location)
 	if err != nil {
 		outPutLog("Return folder element function error", err)
+		return []element{}
 	}
 
 	folderElementMap := map[string]element{}
 	fileAndDirectories := []string{}
 
 	for _, item := range items {
-		fileInfo, _ := item.Info()
-		if !displayDotFile && strings.HasPrefix(fileInfo.Name(), ".") {
+		fileInfo, err := item.Info()
+		if err != nil {
 			continue
 		}
-
-		if fileInfo == nil {
+		if !displayDotFile && strings.HasPrefix(fileInfo.Name(), ".") {
 			continue
 		}
 


### PR DESCRIPTION
This PR fixes Issue #551 where superfile crashes when searching on WSL-mounted drives (`/mnt/c`). 

### Changes :
- Better error handling in the `returnFolderElementBySearchString` function
- `item.Info()` errors are caught and skipped appropriately

### Testing :
- The fix has been tested locally on a WSL environment with `/mnt/c`
- Verified that the program no longer crashes and behaves as expected

This change is based on the original work by @lazysegtree, thanks for the guidance and opportunity!