### PR TITLE
Renaming feature for pinned directories

### DIFF
--- a/src/internal/get_data.go
+++ b/src/internal/get_data.go
@@ -59,7 +59,7 @@ func getPinnedDirectories() []directory {
 	directories := []directory{}
 	var paths []string
 	var pinnedDirs []struct {
-        Location string `json:"location"`
+		Location string `json:"location"`
 		Name     string `json:"name"`
 	}
 
@@ -68,18 +68,18 @@ func getPinnedDirectories() []directory {
 		outPutLog("Read superfile data error", err)
 	}
 
-    // Check if the data is in the old format
+	// Check if the data is in the old format
 	if err := json.Unmarshal(jsonData, &paths); err == nil {
 		for _, path := range paths {
 			directoryName := filepath.Base(path)
 			directories = append(directories, directory{location: path, name: directoryName})
 		}
-    // Check if the data is in the new format
+		// Check if the data is in the new format
 	} else if err := json.Unmarshal(jsonData, &pinnedDirs); err == nil {
 		for _, pinnedDir := range pinnedDirs {
 			directories = append(directories, directory{location: pinnedDir.Location, name: pinnedDir.Name})
 		}
-    // If the data is in neither format, log the error
+		// If the data is in neither format, log the error
 	} else {
 		outPutLog("Error parsing pinned data", err)
 	}

--- a/src/internal/get_data.go
+++ b/src/internal/get_data.go
@@ -58,17 +58,30 @@ func getWellKnownDirectories() []directory {
 func getPinnedDirectories() []directory {
 	directories := []directory{}
 	var paths []string
+	var pinnedDirs []struct {
+        Location string `json:"location"`
+		Name     string `json:"name"`
+	}
 
 	jsonData, err := os.ReadFile(variable.PinnedFile)
 	if err != nil {
 		outPutLog("Read superfile data error", err)
 	}
 
-	json.Unmarshal(jsonData, &paths)
-
-	for _, path := range paths {
-		directoryName := filepath.Base(path)
-		directories = append(directories, directory{location: path, name: directoryName})
+    // Check if the data is in the old format
+	if err := json.Unmarshal(jsonData, &paths); err == nil {
+		for _, path := range paths {
+			directoryName := filepath.Base(path)
+			directories = append(directories, directory{location: path, name: directoryName})
+		}
+    // Check if the data is in the new format
+	} else if err := json.Unmarshal(jsonData, &pinnedDirs); err == nil {
+		for _, pinnedDir := range pinnedDirs {
+			directories = append(directories, directory{location: pinnedDir.Location, name: pinnedDir.Name})
+		}
+    // If the data is in neither format, log the error
+	} else {
+		outPutLog("Error parsing pinned data", err)
 	}
 	return directories
 }

--- a/src/internal/handle_pinned_operations.go
+++ b/src/internal/handle_pinned_operations.go
@@ -1,0 +1,86 @@
+package internal
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/yorukot/superfile/src/config/icon"
+
+	variable "github.com/yorukot/superfile/src/config"
+)
+
+// Rename file where the cusror is located
+func (m *model) pinnedItemRename() {
+	sidebar := m.sidebarModel
+
+	pinnedBegin, pinnedEnd := pinnedIndexRange()
+	if sidebar.cursor < pinnedBegin || sidebar.cursor >= pinnedEnd {
+		return
+	}
+
+	nameLen := len(sidebar.directories[sidebar.cursor].name)
+	cursorPos := nameLen
+
+	ti := textinput.New()
+	ti.Cursor.Style = filePanelCursorStyle
+	ti.Cursor.TextStyle = filePanelStyle
+	ti.Prompt = filePanelCursorStyle.Render(icon.Cursor + " ")
+	ti.TextStyle = modalStyle
+	ti.Cursor.Blink = true
+	ti.Placeholder = "New name"
+	ti.PlaceholderStyle = modalStyle
+	ti.SetValue(sidebar.directories[sidebar.cursor].name)
+	ti.SetCursor(cursorPos)
+	ti.Focus()
+	ti.CharLimit = 156
+	ti.Width = Config.SidebarWidth - 4
+
+	m.sidebarModel.renaming = true
+	m.sidebarModel.rename = ti
+}
+
+// Cancel rename pinned directory
+func (m *model) cancelSidebarRename() {
+	sidebar := &m.sidebarModel
+	sidebar.rename.Blur()
+	sidebar.renaming = false
+}
+
+// Confirm rename pinned directory
+func (m *model) confirmSidebarRename() {
+	sidebar := m.sidebarModel
+
+	sidebar.directories[sidebar.cursor].name = sidebar.rename.Value()
+	// recover the state of rename
+	m.cancelSidebarRename()
+
+	type pinnedDir struct {
+		Location string `json:"location"`
+		Name     string `json:"name"`
+	}
+	var pinnedDirs []pinnedDir
+
+	pinnedBegin, pinnedEnd := pinnedIndexRange()
+	dirs := sidebar.directories[pinnedBegin:pinnedEnd]
+	for _, dir := range dirs {
+		pinnedDirs = append(pinnedDirs, pinnedDir{Location: dir.location, Name: dir.name})
+	}
+
+	jsonData, err := json.Marshal(pinnedDirs)
+	if err != nil {
+		outPutLog("Error marshaling pinned directories data")
+	}
+
+	err = os.WriteFile(variable.PinnedFile, jsonData, 0644)
+	if err != nil {
+		outPutLog("Error updating pinned directories data", err)
+	}
+}
+
+func pinnedIndexRange() (int, int) {
+	// pinned directories start after well-known directories and the divider
+	pinnedIndex := len(getWellKnownDirectories()) + 1
+	pinnedLen := len(getPinnedDirectories())
+	return pinnedIndex, pinnedIndex + pinnedLen
+}

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -11,13 +11,13 @@ func containsKey(v string, a []string) string {
 	return ""
 }
 
-// mainKey handles most of key commands in the regular state of the application. For 
+// mainKey handles most of key commands in the regular state of the application. For
 // keys that performs actions in multiple panels, like going up or down,
 // check the state of model m and handle properly.
-func (m *model) mainKey(msg string, cmd tea.Cmd) ( tea.Cmd) {
+func (m *model) mainKey(msg string, cmd tea.Cmd) tea.Cmd {
 	switch msg {
 
-    // If move up Key is pressed, check the current state and executes
+	// If move up Key is pressed, check the current state and executes
 	case containsKey(msg, hotkeys.ListUp):
 		if m.focusPanel == sidebarFocus {
 			m.controlSideBarListUp(false)
@@ -33,7 +33,7 @@ func (m *model) mainKey(msg string, cmd tea.Cmd) ( tea.Cmd) {
 			}()
 		}
 
-    // If move down Key is pressed, check the current state and executes
+		// If move down Key is pressed, check the current state and executes
 	case containsKey(msg, hotkeys.ListDown):
 		if m.focusPanel == sidebarFocus {
 			m.controlSideBarListDown(false)
@@ -49,11 +49,11 @@ func (m *model) mainKey(msg string, cmd tea.Cmd) ( tea.Cmd) {
 			}()
 		}
 
-  case containsKey(msg, hotkeys.PageUp):
-    m.controlFilePanelPgUp()
+	case containsKey(msg, hotkeys.PageUp):
+		m.controlFilePanelPgUp()
 
-  case containsKey(msg, hotkeys.PageDown):
-    m.controlFilePanelPgDown()
+	case containsKey(msg, hotkeys.PageDown):
+		m.controlFilePanelPgDown()
 
 	case containsKey(msg, hotkeys.ChangePanelMode):
 		m.changeFilePanelMode()
@@ -143,7 +143,7 @@ func (m *model) normalAndBrowserModeKey(msg string) {
 			m.sidebarSelectDirectory()
 		}
 		if m.focusPanel == sidebarFocus && (msg == containsKey(msg, hotkeys.FilePanelItemRename)) {
-            m.pinnedItemRename()
+			m.pinnedItemRename()
 		}
 		return
 	}
@@ -189,12 +189,12 @@ func (m *model) normalAndBrowserModeKey(msg string) {
 		m.searchBarFocus()
 	case containsKey(msg, hotkeys.CopyPath):
 		m.copyPath()
-  case containsKey(msg, hotkeys.CopyPWD):
-    m.copyPWD()
+	case containsKey(msg, hotkeys.CopyPWD):
+		m.copyPWD()
 	}
 }
 
-// Check the hotkey to cancel operation or create file 
+// Check the hotkey to cancel operation or create file
 func (m *model) typingModalOpenKey(msg string) {
 	switch msg {
 	case containsKey(msg, hotkeys.CancelTyping):
@@ -241,7 +241,7 @@ func (m *model) warnModalOpenKey(msg string) {
 
 			}
 		case confirmRenameItem:
-            m.confirmRename()
+			m.confirmRename()
 		}
 	}
 }
@@ -294,7 +294,7 @@ func (m *model) sidebarRenamingKey(msg string) {
 	case containsKey(msg, hotkeys.CancelTyping):
 		m.cancelSidebarRename()
 	case containsKey(msg, hotkeys.ConfirmTyping):
-        m.confirmSidebarRename()
+		m.confirmSidebarRename()
 	}
 }
 

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -142,6 +142,9 @@ func (m *model) normalAndBrowserModeKey(msg string) {
 		if m.focusPanel == sidebarFocus && (msg == containsKey(msg, hotkeys.Confirm)) {
 			m.sidebarSelectDirectory()
 		}
+		if m.focusPanel == sidebarFocus && (msg == containsKey(msg, hotkeys.FilePanelItemRename)) {
+            m.pinnedItemRename()
+		}
 		return
 	}
 	// Check if in the select mode and focusOn filepanel
@@ -283,6 +286,15 @@ func (m *model) renamingKey(msg string) {
 		} else {
 			m.confirmRename()
 		}
+	}
+}
+
+func (m *model) sidebarRenamingKey(msg string) {
+	switch msg {
+	case containsKey(msg, hotkeys.CancelTyping):
+		m.cancelSidebarRename()
+	case containsKey(msg, hotkeys.ConfirmTyping):
+        m.confirmSidebarRename()
 	}
 }
 

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -65,6 +65,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	m.updateFilePanelsState(msg, &cmd)
+    m.updateSidebarState(msg, &cmd)
 	m.sidebarModel.directories = getDirectories()
 
 	// check if there already have listening message
@@ -205,6 +206,8 @@ func (m *model) handleKeyInput(msg tea.KeyMsg, cmd tea.Cmd) tea.Cmd {
 		// If renaming a object
 	} else if m.fileModel.renaming {
 		m.renamingKey(msg.String())
+	} else if m.sidebarModel.renaming {
+		m.sidebarRenamingKey(msg.String())
 		// If search bar is open
 	} else if m.fileModel.filePanels[m.filePanelFocusIndex].searchBar.Focused() {
 		m.focusOnSearchbarKey(msg.String())
@@ -259,6 +262,18 @@ func (m *model) updateFilePanelsState(msg tea.Msg, cmd *tea.Cmd) {
 
 	if focusPanel.cursor < 0 {
 		focusPanel.cursor = 0
+	}
+}
+
+// Update the sidebar state. Change name of the renaming pinned directory.
+func (m *model) updateSidebarState(msg tea.Msg, cmd *tea.Cmd) {
+	sidebar := &m.sidebarModel
+	if sidebar.renaming {
+		sidebar.rename, *cmd = sidebar.rename.Update(msg)
+	}
+
+	if sidebar.cursor < 0 {
+		sidebar.cursor = 0
 	}
 }
 

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -65,7 +65,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	m.updateFilePanelsState(msg, &cmd)
-    m.updateSidebarState(msg, &cmd)
+	m.updateSidebarState(msg, &cmd)
 	m.sidebarModel.directories = getDirectories()
 
 	// check if there already have listening message
@@ -177,12 +177,12 @@ func (m *model) setHelpMenuSize() {
 // Identify the current state of the application m and properly handle the
 // msg keybind pressed
 func (m *model) handleKeyInput(msg tea.KeyMsg, cmd tea.Cmd) tea.Cmd {
-	
+
 	slog.Debug("model.handleKeyInput", "msg", msg, "typestr", msg.Type.String(),
-		"runes", msg.Runes, "type", int(msg.Type), "paste", msg.Paste, 
+		"runes", msg.Runes, "type", int(msg.Type), "paste", msg.Paste,
 		"alt", msg.Alt)
 	slog.Debug("model.handleKeyInput. model info. ",
-		"filePanelFocusIndex", m.filePanelFocusIndex, 
+		"filePanelFocusIndex", m.filePanelFocusIndex,
 		"filePanel.focusType", m.fileModel.filePanels[m.filePanelFocusIndex].focusType,
 		"filePanel.panelMode", m.fileModel.filePanels[m.filePanelFocusIndex].panelMode,
 		"typingModal.open", m.typingModal.open,
@@ -410,9 +410,9 @@ func (m *model) getFilePanelItems() {
 		nowTime := time.Now()
 		// Check last time each element was updated, if less then 3 seconds ignore
 		if filePanel.focusType == noneFocus && nowTime.Sub(filePanel.lastTimeGetElement) < 3*time.Second {
-      if !m.updatedToggleDotFile {
-        continue
-      }
+			if !m.updatedToggleDotFile {
+				continue
+			}
 		}
 
 		focusPanelReRender := false
@@ -443,23 +443,23 @@ func (m *model) getFilePanelItems() {
 		m.fileModel.filePanels[i].lastTimeGetElement = nowTime
 	}
 
-  m.updatedToggleDotFile = false
+	m.updatedToggleDotFile = false
 }
 
 // Close superfile application. Cd into the curent dir if CdOnQuit on and save
 // the path in state direcotory
 func (m *model) quitSuperfile() {
-    // close exiftool session
-    if Config.Metadata {
-        et.Close();
-    }
-    // cd on quit
-    currentDir := m.fileModel.filePanels[m.filePanelFocusIndex].location
-    variable.LastDir = currentDir
+	// close exiftool session
+	if Config.Metadata {
+		et.Close()
+	}
+	// cd on quit
+	currentDir := m.fileModel.filePanels[m.filePanelFocusIndex].location
+	variable.LastDir = currentDir
 
-    if Config.CdOnQuit {
-        // escape single quote
-        currentDir = strings.ReplaceAll(currentDir, "'", "'\\''")
-        os.WriteFile(variable.SuperFileStateDir+"/lastdir", []byte("cd '"+currentDir+"'"), 0755)
-    }
+	if Config.CdOnQuit {
+		// escape single quote
+		currentDir = strings.ReplaceAll(currentDir, "'", "'\\''")
+		os.WriteFile(variable.SuperFileStateDir+"/lastdir", []byte("cd '"+currentDir+"'"), 0755)
+	}
 }

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -63,7 +63,9 @@ func (m *model) sidebarRender() string {
 			cursor = icon.Cursor
 		}
 
-		if directory.location == m.fileModel.filePanels[m.filePanelFocusIndex].location {
+		if m.sidebarModel.renaming && i == m.sidebarModel.cursor {
+			s += m.sidebarModel.rename.View()
+		} else if directory.location == m.fileModel.filePanels[m.filePanelFocusIndex].location {
 			s += filePanelCursorStyle.Render(cursor+" ") + sidebarSelectedStyle.Render(truncateText(directory.name, Config.SidebarWidth-2, "..."))
 		} else {
 			s += filePanelCursorStyle.Render(cursor+" ") + sidebarStyle.Render(truncateText(directory.name, Config.SidebarWidth-2, "..."))

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -173,8 +173,8 @@ func (m *model) filePanelRender() string {
 				if filePanel.renaming && h == filePanel.cursor {
 					f[i] += filePanel.rename.View() + endl
 				} else {
-					_, err := os.ReadDir(filePanel.element[h].location);
-					f[i] += filePanelCursorStyle.Render(cursor+" ") + prettierName(filePanel.element[h].name, m.fileModel.width-5, filePanel.element[h].directory||(err == nil), isItemSelected, filePanelBGColor) + endl
+					_, err := os.ReadDir(filePanel.element[h].location)
+					f[i] += filePanelCursorStyle.Render(cursor+" ") + prettierName(filePanel.element[h].name, m.fileModel.width-5, filePanel.element[h].directory || (err == nil), isItemSelected, filePanelBGColor) + endl
 				}
 			}
 			cursorPosition := strconv.Itoa(filePanel.cursor + 1)
@@ -277,7 +277,7 @@ func (m *model) processBarRender() string {
 	return processRender
 }
 
-// This updates m.fileMetaData 
+// This updates m.fileMetaData
 func (m *model) metadataRender() string {
 	// process bar
 	metaDataBar := ""
@@ -556,9 +556,9 @@ func (m *model) sortOptionsRender() string {
 }
 
 func readFileContent(filepath string, maxLineLength int, previewLine int) (string, error) {
-	// String builder is much better for efficiency 
+	// String builder is much better for efficiency
 	// See - https://stackoverflow.com/questions/1760757/how-to-efficiently-concatenate-strings-in-go/47798475#47798475
-	var resultBuilder strings.Builder 
+	var resultBuilder strings.Builder
 	file, err := os.Open(filepath)
 	if err != nil {
 		return resultBuilder.String(), err
@@ -572,9 +572,9 @@ func readFileContent(filepath string, maxLineLength int, previewLine int) (strin
 		if len(line) > maxLineLength {
 			line = line[:maxLineLength]
 		}
-		// This is critical to avoid layout break, removes non Printable ASCII control characters. 
+		// This is critical to avoid layout break, removes non Printable ASCII control characters.
 		line = makePrintable(line)
-		resultBuilder.WriteString(line+"\n")
+		resultBuilder.WriteString(line + "\n")
 		lineCount++
 		if previewLine > 0 && lineCount >= previewLine {
 			break
@@ -647,8 +647,8 @@ func (m *model) filePreviewPanelRender() string {
 
 	if isImageFile(itemPath) {
 		if !m.fileModel.filePreview.open {
-            return box.Render("\n --- Preview panel is closed ---")
-        }
+			return box.Render("\n --- Preview panel is closed ---")
+		}
 		ansiRender, err := filepreview.ImagePreview(itemPath, m.fileModel.filePreview.width, previewLine, theme.FilePanelBG)
 		if err == image.ErrFormat {
 			return box.Render("\n --- " + icon.Error + " Unsupported image formats ---")
@@ -675,7 +675,7 @@ func (m *model) filePreviewPanelRender() string {
 	}
 
 	// At this point either format is not nil, or we can read the file
-	fileContent , err := readFileContent(itemPath, m.fileModel.width+20, previewLine)
+	fileContent, err := readFileContent(itemPath, m.fileModel.width+20, previewLine)
 	if err != nil {
 		outPutLog(err)
 		return box.Render("\n --- " + icon.Error + " Error open file ---")
@@ -684,7 +684,7 @@ func (m *model) filePreviewPanelRender() string {
 	// We know the format of file, and we can apply syntax highlighting
 	if format != nil {
 		background := ""
-		if ! Config.TransparentBackground {
+		if !Config.TransparentBackground {
 			background = theme.FilePanelBG
 		}
 		fileContent, err = ansichroma.HightlightString(fileContent, format.Config().Name, theme.CodeSyntaxHighlightTheme, background)

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -210,6 +210,8 @@ type sidebarModel struct {
 	directories []directory
 	renderIndex int
 	cursor      int
+	rename      textinput.Model
+	renaming    bool
 }
 
 type directory struct {


### PR DESCRIPTION
#575 

This pull request adds the renaming feature for pinned directories. This is done by storing both names and locations of the pinned directories in `pinned.json`. The inconsistency between old and new data format is handled.

The renaming interface is similar to the one in the file panel, with a `ctrl+r` hotkey. It is implemented by introducing a `textinput` in the `sidebarModel`.