### PR TITLE
Fix arch install instructions

### DIFF
--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -57,13 +57,13 @@ To uninstall, run the above `powershell` command with the modified URL:
 ###### Builds package from sources
 
 ```bash
-sudo pacman -S superfile
+yay -S superfile
 ```
 
 ###### Fetches prebuilt binaries from GitHub
 
 ```bash
-sudo pacman -S superfile-bin
+yay -S superfile-bin
 ```
 
 ### Homebrew


### PR DESCRIPTION
`superfile` and `superfile-bin` are in the AUR, not any official repos, so an AUR manager is needed like `yay` or `paru` instead of `pacman`.