### PR TITLE
Fix windows delete, open file and other improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/charmbracelet/x/ansi v0.4.5 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/hymkor/trash-go v0.2.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/hymkor/trash-go v0.2.0 h1:t51zidKT8WuMTeeiMBsJxx+BDwnJtaaf/ckpjle2GOE=
+github.com/hymkor/trash-go v0.2.0/go.mod h1:pZ07qBUuGdTWPdymNtE97NAXHDY5W/b5szvoBVOhJ3U=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -79,6 +79,9 @@ schema = 3
   [mod."github.com/hashicorp/go-multierror"]
     version = "v1.1.1"
     hash = "sha256-ANzPEUJIZIlToxR89Mn7Db73d9LGI51ssy7eNnUgmlA="
+  [mod."github.com/hymkor/trash-go"]
+    version = "v0.2.0"
+    hash = "sha256-p7zJYJpPjNAYKRNW7No+BXRemNabGp/No1mp9ItHXII="
   [mod."github.com/kdomanski/iso9660"]
     version = "v0.3.3"
     hash = "sha256-iMyzZnZCKXUfBKJDdqwEYyzcFKo/VEkoo4Lm/Ct8tj4="

--- a/src/internal/config_type.go
+++ b/src/internal/config_type.go
@@ -117,7 +117,8 @@ type ThemeType struct {
 type ConfigType struct {
 	Theme string `toml:"theme" comment:"More details are at https://superfile.netlify.app/configure/superfile-config/\nchange your theme"`
 
-	Editor                 string `toml:"editor" comment:"\nThe editor files/directories will be opened with. (leave blank to use the EDITOR environment variable)."`
+	FileEditor             string `toml:"file_editor" comment:"\nThe editor files will be opened with. (Leave blank to use the EDITOR environment variable)."`
+	DirEditor              string `toml:"dir_editor" comment:"\nThe editor directories will be opened with. (Leave blank to use the default editors)."`
 	AutoCheckUpdate        bool   `toml:"auto_check_update" comment:"\nAuto check for update"`
 	CdOnQuit               bool   `toml:"cd_on_quit" comment:"\nCd on quit (For more details, please check out https://superfile.netlify.app/configure/superfile-config/#cd_on_quit)"`
 	DefaultOpenFilePreview bool   `toml:"default_open_file_preview" comment:"\nWhether to open file preview automatically every time superfile is opened."`

--- a/src/internal/file_operations.go
+++ b/src/internal/file_operations.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/rkoesters/xdg/trash"
+	trash_win "github.com/hymkor/trash-go"
 	variable "github.com/yorukot/superfile/src/config"
 	"github.com/yorukot/superfile/src/config/icon"
 )
@@ -145,6 +146,12 @@ func copyFile(src, dst string, srcInfo os.FileInfo) error {
 func trashMacOrLinux(src string) error {
 	if runtime.GOOS == "darwin" {
 		err := moveElement(src, filepath.Join(variable.HomeDir, ".Trash", filepath.Base(src)))
+		if err != nil {
+			outPutLog("Delete single item function move file to trash can error", err)
+			return err
+		}
+	} else if runtime.GOOS == "windows" {
+		err := trash_win.Throw(src)
 		if err != nil {
 			outPutLog("Delete single item function move file to trash can error", err)
 			return err

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -358,7 +358,7 @@ func (m *model) returnMetaData() {
 		return
 	}
 
-	if Config.Metadata && checkIsSymlinked.Mode()&os.ModeSymlink == 0 {
+	if Config.Metadata && checkIsSymlinked.Mode()&os.ModeSymlink == 0 && et != nil {
 
 		fileInfos := et.ExtractMetadata(filePath)
 

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -583,22 +583,17 @@ func (m *model) openFileWithEditor() tea.Cmd {
 
 // Open directory with default editor
 func (m *model) openDirectoryWithEditor() tea.Cmd {
-	editor := Config.Editor
-	if editor == "" {
-		editor = os.Getenv("EDITOR")
-	}
-	// Make sure there is an editor
 	// Todo : Move hardcoded strings to constants : "windows", and editors
-	if editor == "" {
-		if runtime.GOOS == "windows" {
-			editor = "explorer"
-		} else if runtime.GOOS == "darwin" {
-			// open is command for MacOS Finder
-			editor = "open"
-		} else {
-			editor = "nano"
-		}
+	editor := ""
+	if runtime.GOOS == "windows" {
+		editor = "explorer"
+	} else if runtime.GOOS == "darwin" {
+		// open is command for MacOS Finder
+		editor = "open"
+	} else {
+		editor = "vi"
 	}
+
 	c := exec.Command(editor, m.fileModel.filePanels[m.filePanelFocusIndex].location)
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		return editorFinishedMsg{err}

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -560,7 +560,7 @@ func (m *model) compressFile() {
 func (m *model) openFileWithEditor() tea.Cmd {
 	panel := &m.fileModel.filePanels[m.filePanelFocusIndex]
 
-	editor := Config.Editor
+	editor := Config.FileEditor
 	if editor == "" {
 		editor = os.Getenv("EDITOR")
 	}
@@ -584,14 +584,17 @@ func (m *model) openFileWithEditor() tea.Cmd {
 // Open directory with default editor
 func (m *model) openDirectoryWithEditor() tea.Cmd {
 	// Todo : Move hardcoded strings to constants : "windows", and editors
-	editor := ""
-	if runtime.GOOS == "windows" {
-		editor = "explorer"
-	} else if runtime.GOOS == "darwin" {
-		// open is command for MacOS Finder
-		editor = "open"
-	} else {
-		editor = "vi"
+	editor := Config.DirEditor
+
+	if editor == "" {
+		if runtime.GOOS == "windows" {
+			editor = "explorer"
+		} else if runtime.GOOS == "darwin" {
+			// open is command for MacOS Finder
+			editor = "open"
+		} else {
+			editor = "vi"
+		}
 	}
 
 	c := exec.Command(editor, m.fileModel.filePanels[m.filePanelFocusIndex].location)

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -592,6 +592,9 @@ func (m *model) openDirectoryWithEditor() tea.Cmd {
 	if editor == "" {
 		if runtime.GOOS == "windows" {
 			editor = "explorer"
+		} else if runtime.GOOS == "darwin" {
+			// open is command for MacOS Finder
+			editor = "open"
 		} else {
 			editor = "nano"
 		}

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -450,7 +450,7 @@ func (m *model) getFilePanelItems() {
 // the path in state direcotory
 func (m *model) quitSuperfile() {
 	// close exiftool session
-	if Config.Metadata {
+	if Config.Metadata && et != nil {
 		et.Close()
 	}
 	// cd on quit

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -3,8 +3,11 @@
 # change your theme
 theme = 'catppuccin'
 # 
-# The editor files/directories will be opened with. (leave blank to use the EDITOR environment variable).
-editor = ""
+# The editor files will be opened with. (Leave blank to use the EDITOR environment variable).
+file_editor = ""
+# 
+# The editor directories will be opened with. (Leave blank to use the default editors).
+dir_editor = ""
 #
 # Auto check for update
 auto_check_update = true

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -25,7 +25,7 @@ file_panel_item_rename = ['ctrl+r', '']
 # file operations
 copy_items = ['ctrl+c', '']
 cut_items = ['ctrl+x', '']
-paste_items = ['ctrl+v', '']
+paste_items = ['ctrl+v', 'ctrl+w', '']
 delete_items = ['ctrl+d', 'delete', '']
 # compress and extract
 extract_file = ['ctrl+e', '']

--- a/testsuite/ReadMe.md
+++ b/testsuite/ReadMe.md
@@ -72,7 +72,7 @@ Notes
 ## Tips while running tests
 - Use `-d` or `--debug` to enable debug logs during test run.
 - If you see flakiness in test runs due to superfile being still open, consider using `--close-wait-time` options to increase wait time for superfile to close
+- Make sure that your hotkeys are set to default hotkeys. Tests use default hotkeys for now.
 - Use `-t` or `--tests` to only run specific tests
   - Example `python main.py -d -t RenameTest CopyTest`
-
 - If you see `libtmux` errors like `libtmux.exc.LibTmuxException: ['no server running on /private/tmp/tmux-501/superfile']` Make sure your python version is up to date

--- a/testsuite/core/keys.py
+++ b/testsuite/core/keys.py
@@ -32,6 +32,7 @@ KEY_CTRL_D : Keys = CtrlKeys('d')
 KEY_CTRL_M : Keys = CtrlKeys('m')
 KEY_CTRL_R : Keys = CtrlKeys('r')
 KEY_CTRL_V : Keys = CtrlKeys('v')
+KEY_CTRL_W : Keys = CtrlKeys('w')
 KEY_CTRL_X : Keys = CtrlKeys('x')
 
 # See https://vimdoc.sourceforge.net/htmldoc/digraph.html#digraph-table for key codes

--- a/testsuite/tests/copyw_test.py
+++ b/testsuite/tests/copyw_test.py
@@ -5,12 +5,11 @@ from core.environment import Environment
 import core.test_constants as tconst
 import core.keys as keys
 
-TESTROOT = Path("delete_ops")
-FILE1 = TESTROOT / "file_to_delete.txt"
+TESTROOT = Path("copyw_ops")
+FILE1 = TESTROOT / "file1.txt"
+FILE1_COPY1 = TESTROOT / "file1(1).txt"
 
-
-
-class DeleteTest(GenericTestImpl):
+class CopyWTest(GenericTestImpl):
 
     def __init__(self, test_env : Environment):
         super().__init__(
@@ -19,6 +18,6 @@ class DeleteTest(GenericTestImpl):
             start_dir=TESTROOT,
             test_dirs=[TESTROOT],
             test_files=[(FILE1, tconst.FILE_TEXT1)],
-            key_inputs=[keys.KEY_CTRL_D, keys.KEY_ENTER],
-            validate_not_exists=[FILE1]
+            key_inputs=[keys.KEY_CTRL_C, keys.KEY_CTRL_W],
+            validate_exists=[FILE1, FILE1_COPY1]
         )

--- a/testsuite/tests/delete_dir_test.py
+++ b/testsuite/tests/delete_dir_test.py
@@ -5,20 +5,22 @@ from core.environment import Environment
 import core.test_constants as tconst
 import core.keys as keys
 
-TESTROOT = Path("delete_ops")
-FILE1 = TESTROOT / "file_to_delete.txt"
+TESTROOT = Path("delete_dir")
+DIR1 = TESTROOT / "dir1"
+NESTED_DIR1 = DIR1 / "nested1"
+NESTED_DIR2 = DIR1 / "nested2"
+FILE1 = NESTED_DIR1 / "file1.txt"
 
 
-
-class DeleteTest(GenericTestImpl):
+class DeleteDirTest(GenericTestImpl):
 
     def __init__(self, test_env : Environment):
         super().__init__(
             test_env=test_env,
             test_root=TESTROOT,
             start_dir=TESTROOT,
-            test_dirs=[TESTROOT],
+            test_dirs=[TESTROOT, DIR1, NESTED_DIR1, NESTED_DIR2],
             test_files=[(FILE1, tconst.FILE_TEXT1)],
             key_inputs=[keys.KEY_CTRL_D, keys.KEY_ENTER],
-            validate_not_exists=[FILE1]
+            validate_not_exists=[DIR1, NESTED_DIR1, NESTED_DIR2, FILE1]
         )

--- a/website/src/content/docs/configure/custom-hotkeys.mdx
+++ b/website/src/content/docs/configure/custom-hotkeys.mdx
@@ -30,7 +30,7 @@ If you are a vim user, the default hotkeys may make you hate superfile.
 :::
 
 superfile default hotkeys design concept:
-- All hotkeys that will change to files use `qctrl+key` (As long as you don't press ctrl your files will always be safe).
+- All hotkeys that will change to files use `ctrl+key` (As long as you don't press ctrl your files will always be safe).
 - Non-control file classes use the first letters of words as hotkeys.
 
 <CodeBlock file="src/superfile_config/hotkeys.toml" />

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -24,9 +24,13 @@ To see the path locations of your superfile files, use the command `spf pl`.
 
 [Click here](/configure/custom-theme) for instructions to edit the theme.
 
-- ###### editor
+- ###### file_editor
 
-The editor your files/directories will be opened with (if blank, it will default to the EDITOR environment variable).
+The editor your files will be opened with (Leave blank to use the EDITOR environment variable. If EDITOR environment variable is not set, it will default to `nano` for MacOS/Linux, and `notepad` for Windows.
+
+- ###### dir_editor
+
+The editor your directories will be opened with (Leave blank to use defaults : `vi` - Linux, `open` - MacOS, `explorer` - Windows).
 
 - ###### auto_check_update
 

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -40,15 +40,13 @@ The editor your directories will be opened with (Leave blank to use defaults : `
 
 - ###### cd_on_quit
 
-:::note
-Doesn't work on Windows at the moment.
-:::
-
 `true` => When you exit superfile, changes the terminal path to the last file panel you used.
 
 `false` => When you exit superfile, the terminal path remains the same prior to superfile.
 
-After setting to `true`, you need to update your `.bashrc` file.
+After setting to `true`, you need to update your shell config file. Sample changes :
+
+##### MacOS/Linux (bash)
 
 Open the file:
 
@@ -65,6 +63,31 @@ Save, exit, and reload your `.bashrc` file:
 ```bash
 source ~/.bashrc
 ```
+
+##### Windows (Powershell)
+
+Open the file:
+
+```powershell
+notepad $PROFILE
+```
+
+Copy the following code into the file:
+
+<CodeBlock file="cd_on_quit/cd_on_quit.ps1" />
+
+Save, exit, and reload your profile.
+
+```powershell
+. $PROFILE
+```
+
+:::note
+You need to make sure powershell is allowed to execute script. If you get error like `running
+scripts is disabled on this system`. You need to allow it.
+
+Example command to enable - `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned` 
+:::
 
 - ###### default_open_file_preview
 

--- a/website/src/content/docs/getting-started/tutorial.md
+++ b/website/src/content/docs/getting-started/tutorial.md
@@ -147,16 +147,24 @@ To open a file with an editor, press `e`.
 
 To open the current directory with an editor, press `E` (shift+e).
 
-To change the default editor, you can set the `EDITOR` environment variable in your terminal. For example:
+To change the default file editor, you can set the `EDITOR` environment variable in your terminal or you can use the `file_editor` config option (take priority over `EDITOR` environment variable). 
+To change the default directory editor, you can use the `dir_editor` config option.
+For example:
 
 ```bash
 EDITOR=nvim
 ```
 
-This will set Neovim as your default editor. After setting this, the specified editor will be used when opening files with the `e` or `E` key bindings.
+This will set Neovim as your default file editor. After setting this, Neovim will be used when opening files with the `e` key bindings.
+
+```
+file_editor = nano
+dir_editor = vi
+```
+This will set `nano` as your default file editor, and `vi` as your default directory editor. After setting this, `nano` will be used when opening files with the `e` key bindings, and `vi` will be used to open current directory with `E` key bindings.
 
 :::caution
-If your editor does not support opening the current directory with an editor, you may encounter an error when pressing `E`.
+If your directory editor does not support opening the current directory with an editor, you may encounter an error when pressing `E`.
 :::
 
 (Sorry, this video has a little bit of lag)

--- a/website/src/content/docs/getting-started/tutorial.md
+++ b/website/src/content/docs/getting-started/tutorial.md
@@ -164,8 +164,8 @@ EDITOR=nvim
 This will set Neovim as your default file editor. After setting this, Neovim will be used when opening files with the `e` key bindings.
 
 ```
-file_editor = nano
-dir_editor = vi
+file_editor = "nano"
+dir_editor = "vi"
 ```
 
 These are changes in config file. See [superfile-config](/configure/superfile-config) for more info.

--- a/website/src/content/docs/getting-started/tutorial.md
+++ b/website/src/content/docs/getting-started/tutorial.md
@@ -135,6 +135,12 @@ To cut, you can press `ctrl`+`x`.
 
 Both cut and copied items are shown in the clipboard panel (lower-right corner). The progress of your operations is displayed in the processes panel (lower-left corner).
 
+To paste, you can press `ctrl`+`v` or `ctrl`+`w`.
+
+:::note
+In some terminals, for example Windows Powershell, `ctrl`+`v` pastes input from clipboard to terminal. So, `ctrl`+`v` might not work for paste. Either you can use `ctrl`+`w` key, or override default behaviour of `ctrl`+`v` on your terminal.
+:::
+
 To delete, you can press `ctrl`+`d`
 
 :::note
@@ -161,6 +167,8 @@ This will set Neovim as your default file editor. After setting this, Neovim wil
 file_editor = nano
 dir_editor = vi
 ```
+
+These are changes in config file. See [superfile-config](/configure/superfile-config) for more info.
 This will set `nano` as your default file editor, and `vi` as your default directory editor. After setting this, `nano` will be used when opening files with the `e` key bindings, and `vi` will be used to open current directory with `E` key bindings.
 
 :::caution

--- a/website/src/content/docs/list/hotkey-list.md
+++ b/website/src/content/docs/list/hotkey-list.md
@@ -59,7 +59,7 @@ These are the default hotkeys and you can [change](/configure/custom-hotkeys) th
 | Rename file or folder                                | `ctrl+r`           | `file_panel_item_rename`                                                               |
 | Copy file or folder (or both)                        | `ctrl+c`           | `copy_single_item` (normal mode) <br> `file_panel_select_mode_item_copy` (select mode) |
 | Cut file or folder (or both)                         | `ctrl+x`           | `file_panel_select_mode_item_cut`                                                      |
-| Paste all items in your clipboard                    | `ctrl+v`           | `paste_item`                                                                           |
+| Paste all items in your clipboard                    | `ctrl+v`, `ctrl+w` | `paste_item`                                                                           |
 | Delete file or folder (or both)                      | `ctrl+d`, `delete` | `delete_item` (normal mode) <br> `file_panel_select_mode_item_delete` (select mode)    |
 | Copy current file or directory path                  | `ctrl+p`           | `copy_path`                                                                            |
 | Extract zip file                                     | `ctrl+e`           | `extract_file` (normal mode)                                                           |


### PR DESCRIPTION
Used https://github.com/hymkor/trash-go, that works in windows

Fixes -  https://github.com/yorukot/superfile/issues/380 - Issue in delete

Fixes - https://github.com/yorukot/superfile/issues/335 - Issue in delete

Fixes - https://github.com/yorukot/superfile/issues/437 - Issue in opening files

Fixes - https://github.com/yorukot/superfile/issues/415 - Crash while running spf with metadata=true without exiftools installed

Adds documentation for - https://github.com/yorukot/superfile/issues/514, https://github.com/yorukot/superfile/issues/561 - Paste not working.

Adds documentation for - https://github.com/yorukot/superfile/issues/572 - cd_on_quit not working on windows.

Added `file_editor` and `dir_editor` config options
Fixed nano being used as opening application for directory.
Fixed file editor being "" in windows ( added notepad ) 
Fix usage of EDITOR(env variable for opening files) while opening directories with E

Also fixes editor being empty in windows, Removed pass by value for model obj, prevent copy for panel object.


<details><summary>Test for windows delete</summary>
<p>

![image](https://github.com/user-attachments/assets/c65be219-0b5c-41bd-8e18-1f613a5a3945)

![image](https://github.com/user-attachments/assets/ed8bb946-c885-4a2e-8cbb-1dc6495609c4)

![image](https://github.com/user-attachments/assets/1229ef4c-1ac9-4026-bd60-866c5226b2fd)

Also verified directory deletion

If you try to delete a directory where you lack permissions. This appears. Which is okay.
![image](https://github.com/user-attachments/assets/2d327d2e-b49a-477b-8409-47130e90fe7e)


</p>
</details> 

<details><summary>Successful test run in MacOS</summary>
<p>

```
➜  ~/Workspace/kuknitin/superfile/testsuite git:(fix_win_delete) [10:36:40] .venv/bin/python main.py
[2025-02-03 22:36:42 -    INFO] Testcases : [CopyDirTest, CutTest, DeleteDirTest, CopyWTest, CopyTest, DeleteTest, RenameTest]
[2025-02-03 22:36:42 -    INFO] Running test CopyDirTest
[2025-02-03 22:36:44 -    INFO] Passed test CopyDirTest
[2025-02-03 22:36:44 -    INFO] Running test CutTest
[2025-02-03 22:36:46 -    INFO] Passed test CutTest
[2025-02-03 22:36:46 -    INFO] Running test DeleteDirTest
[2025-02-03 22:36:48 -    INFO] Passed test DeleteDirTest
[2025-02-03 22:36:48 -    INFO] Running test CopyWTest
[2025-02-03 22:36:49 -    INFO] Passed test CopyWTest
[2025-02-03 22:36:49 -    INFO] Running test CopyTest
[2025-02-03 22:36:51 -    INFO] Passed test CopyTest
[2025-02-03 22:36:51 -    INFO] Running test DeleteTest
[2025-02-03 22:36:53 -    INFO] Passed test DeleteTest
[2025-02-03 22:36:53 -    INFO] Running test RenameTest
[2025-02-03 22:36:55 -    INFO] Passed test RenameTest
[2025-02-03 22:36:55 -    INFO] Finished running 7 test. 7 passed
➜  ~/Workspace/kuknitin/superfile/testsuite git:(fix_win_delete) [10:36:55]
```

</p>
</details> 

<details><summary>Test run in Linux</summary>
<p>

```
[opc@test-client-hyd-1 testsuite]$  .venv/bin/python main.py
[2025-02-03 12:06:57 -    INFO] Testcases : [CopyDirTest, CopyTest, CutTest, RenameTest, CopyWTest, DeleteTest, DeleteDirTest]
[2025-02-03 12:06:57 -    INFO] Running test CopyDirTest
[2025-02-03 12:06:59 -    INFO] Passed test CopyDirTest
[2025-02-03 12:06:59 -    INFO] Running test CopyTest
[2025-02-03 12:07:00 -    INFO] Passed test CopyTest
[2025-02-03 12:07:00 -    INFO] Running test CutTest
[2025-02-03 12:07:02 -    INFO] Passed test CutTest
[2025-02-03 12:07:02 -    INFO] Running test RenameTest
[2025-02-03 12:07:04 -    INFO] Passed test RenameTest
[2025-02-03 12:07:04 -    INFO] Running test CopyWTest
[2025-02-03 12:07:05 -    INFO] Passed test CopyWTest
[2025-02-03 12:07:05 -    INFO] Running test DeleteTest
[2025-02-03 12:07:07 -    INFO] Passed test DeleteTest
[2025-02-03 12:07:07 -    INFO] Running test DeleteDirTest
[2025-02-03 12:07:08 -    INFO] Passed test DeleteDirTest
[2025-02-03 12:07:08 -    INFO] Finished running 7 test. 7 passed
[opc@test-client-hyd-1 testsuite]$
```
</p>
</details> 

<details><summary>Test run in windows</summary>
<p>

```
PS C:\Users\nitin\Documents\Programming\superfile\testsuite> .venv\Scripts\python main.py --close-wait-time 4
[2025-02-03 22:37:21 -    INFO] Testcases : [CopyWTest, CopyDirTest, CopyTest, CutTest, DeleteDirTest, DeleteTest, RenameTest]
[2025-02-03 22:37:21 -    INFO] Running test CopyWTest
[2025-02-03 22:37:27 -    INFO] Passed test CopyWTest
[2025-02-03 22:37:27 -    INFO] Running test CopyDirTest
[2025-02-03 22:37:32 -    INFO] Passed test CopyDirTest
[2025-02-03 22:37:32 -    INFO] Running test CopyTest
[2025-02-03 22:37:38 -    INFO] Passed test CopyTest
[2025-02-03 22:37:38 -    INFO] Running test CutTest
[2025-02-03 22:37:43 -    INFO] Passed test CutTest
[2025-02-03 22:37:43 -    INFO] Running test DeleteDirTest
[2025-02-03 22:37:49 -    INFO] Passed test DeleteDirTest
[2025-02-03 22:37:49 -    INFO] Running test DeleteTest
[2025-02-03 22:37:54 -    INFO] Passed test DeleteTest
[2025-02-03 22:37:54 -    INFO] Running test RenameTest
[2025-02-03 22:38:00 -    INFO] Passed test RenameTest
[2025-02-03 22:38:00 -    INFO] Finished running 7 test. 7 passed
PS C:\Users\nitin\Documents\Programming\superfile\testsuite>
```
</p>
</details> 

Validating that pressing `E` (`Shift+e`) opened file explorer in windows, and finder in MacOS.

Validated that paste worked with `ctrl+w` 