### PR TITLE
feat: `--config-file` flag support

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -66,12 +66,26 @@ func Run(content embed.FS) {
 				Usage:   "Print the last dir to stdout on exit (to use for cd)",
 				Value:   false,
 			},
+			&cli.StringFlag{
+				Name:    "config-file",
+				Aliases: []string{"c"},
+				Usage:   "Specify the path to a different config file",
+				Value:   variable.ConfigFile, // Default to the existing config file path
+			},
 		},
 		Action: func(c *cli.Context) error {
 			// If no args are called along with "spf" use current dir
 			path := ""
 			if c.Args().Present() {
 				path = c.Args().First()
+			}
+
+			// Setting the config file path
+			variable.ConfigFile = c.String("config-file")
+
+			// Validate the config file exists
+			if _, err := os.Stat(variable.ConfigFile); os.IsNotExist(err) {
+				log.Fatalf("Error: Configuration file '%s' does not exist", variable.ConfigFile)
 			}
 
 			InitConfigFile()

--- a/website/src/content/docs/configure/config-file-path.md
+++ b/website/src/content/docs/configure/config-file-path.md
@@ -30,6 +30,14 @@ If you want to get the set path you can try `spf pl` which will print out the fi
 | :------------------------: | :----------------------------------------: | :------------------------: |
 | `~/.local/share/superfile` | `~/Library/Application Support/superfile/` | `%LOCALAPPDATA%/superfile` |
 
+### Changing Config File Path
+
+You can use the `-c` flag to specify a different path for the `config.toml` file:
+
+```bash
+spf -c /path/to/your/config.toml
+```
+
 #### Log directory
 
 |           Linux            |                   macOS                   |          Windows           |

--- a/website/src/content/docs/configure/custom-theme.mdx
+++ b/website/src/content/docs/configure/custom-theme.mdx
@@ -35,14 +35,6 @@ If you want to customize your own theme, you can go to `THEME_DIRECTORY/YOUR_THE
 
 Don't forget to change the `theme` variable in `config.toml` to your theme name.
 
-:::tip
-You can use the `-c` flag to specify a different path for the `config.toml` file:
-
-```bash
-spf -c /path/to/your/config.toml
-```
-:::
-
 [If you are satisfied with your theme, you might as well put it into the default theme list!](/how-to-contribute)
 
 ### Default theme

--- a/website/src/content/docs/configure/custom-theme.mdx
+++ b/website/src/content/docs/configure/custom-theme.mdx
@@ -35,6 +35,14 @@ If you want to customize your own theme, you can go to `THEME_DIRECTORY/YOUR_THE
 
 Don't forget to change the `theme` variable in `config.toml` to your theme name.
 
+:::tip
+You can use the `-c` flag to specify a different path for the `config.toml` file:
+
+```bash
+spf -c /path/to/your/config.toml
+```
+:::
+
 [If you are satisfied with your theme, you might as well put it into the default theme list!](/how-to-contribute)
 
 ### Default theme


### PR DESCRIPTION
#586

This will allow user's to simply specify the path to any different config file they want, so that they can quickly switch between themes and other configs using aliases.

