### PR TITLE
Document Windows scoop installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,22 @@ Visit warp.dev to learn more
 
 ## Installation
 
-### Quick install 
-
-Using bash (Support MacOS and linux)
+### MacOS and Linux
 
 ```bash
 bash -c "$(curl -sLo- https://superfile.netlify.app/install.sh)"
 ```
 
-Using powershell (Support Windows)
+### Windows
 
+#### Powershell
 ```powershell
 powershell -ExecutionPolicy Bypass -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.netlify.app/install.ps1'))"
+```
+
+#### [Scoop](https://scoop.sh/)
+```
+scoop install superfile
 ```
 
 ### More installation methods

--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -46,6 +46,12 @@ To uninstall, run the above `powershell` command with the modified URL:
 `https://superfile.netlify.app/uninstall.ps1`
 :::
 
+With [Scoop](https://scoop.sh/):
+
+```bash
+scoop install superfile
+```
+
 ## Community maintained packages
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/superfile.svg)](https://repology.org/project/superfile/versions)


### PR DESCRIPTION
The PR updates the installation documentation.

The ScoopInstaller/Main#6220 adds an extra Windows installation option for the `spf` Windows binary.
