### PR TITLE
(Hotfix) Revert changes in website that were not yet released in latest release

### DIFF
--- a/website/src/content/docs/configure/config-file-path.md
+++ b/website/src/content/docs/configure/config-file-path.md
@@ -30,14 +30,6 @@ If you want to get the set path you can try `spf pl` which will print out the fi
 | :------------------------: | :----------------------------------------: | :------------------------: |
 | `~/.local/share/superfile` | `~/Library/Application Support/superfile/` | `%LOCALAPPDATA%/superfile` |
 
-### Changing Config File Path
-
-You can use the `-c` flag to specify a different path for the `config.toml` file:
-
-```bash
-spf -c /path/to/your/config.toml
-```
-
 #### Log directory
 
 |           Linux            |                   macOS                   |          Windows           |

--- a/website/src/content/docs/configure/custom-hotkeys.mdx
+++ b/website/src/content/docs/configure/custom-hotkeys.mdx
@@ -30,7 +30,7 @@ If you are a vim user, the default hotkeys may make you hate superfile.
 :::
 
 superfile default hotkeys design concept:
-- All hotkeys that will change to files use `ctrl+key` (As long as you don't press ctrl your files will always be safe).
+- All hotkeys that will change to files use `qctrl+key` (As long as you don't press ctrl your files will always be safe).
 - Non-control file classes use the first letters of words as hotkeys.
 
 <CodeBlock file="src/superfile_config/hotkeys.toml" />

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -24,13 +24,9 @@ To see the path locations of your superfile files, use the command `spf pl`.
 
 [Click here](/configure/custom-theme) for instructions to edit the theme.
 
-- ###### file_editor
+- ###### editor
 
-The editor your files will be opened with (Leave blank to use the EDITOR environment variable. If EDITOR environment variable is not set, it will default to `nano` for MacOS/Linux, and `notepad` for Windows.
-
-- ###### dir_editor
-
-The editor your directories will be opened with (Leave blank to use defaults : `vi` - Linux, `open` - MacOS, `explorer` - Windows).
+The editor your files/directories will be opened with (if blank, it will default to the EDITOR environment variable).
 
 - ###### auto_check_update
 
@@ -40,13 +36,15 @@ The editor your directories will be opened with (Leave blank to use defaults : `
 
 - ###### cd_on_quit
 
+:::note
+Doesn't work on Windows at the moment.
+:::
+
 `true` => When you exit superfile, changes the terminal path to the last file panel you used.
 
 `false` => When you exit superfile, the terminal path remains the same prior to superfile.
 
-After setting to `true`, you need to update your shell config file. Sample changes :
-
-##### MacOS/Linux (bash)
+After setting to `true`, you need to update your `.bashrc` file.
 
 Open the file:
 
@@ -63,31 +61,6 @@ Save, exit, and reload your `.bashrc` file:
 ```bash
 source ~/.bashrc
 ```
-
-##### Windows (Powershell)
-
-Open the file:
-
-```powershell
-notepad $PROFILE
-```
-
-Copy the following code into the file:
-
-<CodeBlock file="cd_on_quit/cd_on_quit.ps1" />
-
-Save, exit, and reload your profile.
-
-```powershell
-. $PROFILE
-```
-
-:::note
-You need to make sure powershell is allowed to execute script. If you get error like `running
-scripts is disabled on this system`. You need to allow it.
-
-Example command to enable - `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned` 
-:::
 
 - ###### default_open_file_preview
 

--- a/website/src/content/docs/getting-started/tutorial.md
+++ b/website/src/content/docs/getting-started/tutorial.md
@@ -135,12 +135,6 @@ To cut, you can press `ctrl`+`x`.
 
 Both cut and copied items are shown in the clipboard panel (lower-right corner). The progress of your operations is displayed in the processes panel (lower-left corner).
 
-To paste, you can press `ctrl`+`v` or `ctrl`+`w`.
-
-:::note
-In some terminals, for example Windows Powershell, `ctrl`+`v` pastes input from clipboard to terminal. So, `ctrl`+`v` might not work for paste. Either you can use `ctrl`+`w` key, or override default behaviour of `ctrl`+`v` on your terminal.
-:::
-
 To delete, you can press `ctrl`+`d`
 
 :::note
@@ -153,26 +147,16 @@ To open a file with an editor, press `e`.
 
 To open the current directory with an editor, press `E` (shift+e).
 
-To change the default file editor, you can set the `EDITOR` environment variable in your terminal or you can use the `file_editor` config option (take priority over `EDITOR` environment variable). 
-To change the default directory editor, you can use the `dir_editor` config option.
-For example:
+To change the default editor, you can set the `EDITOR` environment variable in your terminal. For example:
 
 ```bash
 EDITOR=nvim
 ```
 
-This will set Neovim as your default file editor. After setting this, Neovim will be used when opening files with the `e` key bindings.
-
-```
-file_editor = "nano"
-dir_editor = "vi"
-```
-
-These are changes in config file. See [superfile-config](/configure/superfile-config) for more info.
-This will set `nano` as your default file editor, and `vi` as your default directory editor. After setting this, `nano` will be used when opening files with the `e` key bindings, and `vi` will be used to open current directory with `E` key bindings.
+This will set Neovim as your default editor. After setting this, the specified editor will be used when opening files with the `e` or `E` key bindings.
 
 :::caution
-If your directory editor does not support opening the current directory with an editor, you may encounter an error when pressing `E`.
+If your editor does not support opening the current directory with an editor, you may encounter an error when pressing `E`.
 :::
 
 (Sorry, this video has a little bit of lag)

--- a/website/src/content/docs/list/hotkey-list.md
+++ b/website/src/content/docs/list/hotkey-list.md
@@ -59,7 +59,7 @@ These are the default hotkeys and you can [change](/configure/custom-hotkeys) th
 | Rename file or folder                                | `ctrl+r`           | `file_panel_item_rename`                                                               |
 | Copy file or folder (or both)                        | `ctrl+c`           | `copy_single_item` (normal mode) <br> `file_panel_select_mode_item_copy` (select mode) |
 | Cut file or folder (or both)                         | `ctrl+x`           | `file_panel_select_mode_item_cut`                                                      |
-| Paste all items in your clipboard                    | `ctrl+v`, `ctrl+w` | `paste_item`                                                                           |
+| Paste all items in your clipboard                    | `ctrl+v`           | `paste_item`                                                                           |
 | Delete file or folder (or both)                      | `ctrl+d`, `delete` | `delete_item` (normal mode) <br> `file_panel_select_mode_item_delete` (select mode)    |
 | Copy current file or directory path                  | `ctrl+p`           | `copy_path`                                                                            |
 | Extract zip file                                     | `ctrl+e`           | `extract_file` (normal mode)                                                           |


### PR DESCRIPTION
Revert changes in website that were not yet released in latest release, and causing user experience inconsistency between docs and the release application.

For example see - https://github.com/yorukot/superfile/discussions/185#discussioncomment-12120579 
Users would try to use `file_editor` options as the website says. But it will not work, as its only just added in main branch, and not yet in the latest release `1.1.7.1` 

Same for `-c` flag and `debug` option.