### PR TITLE
fix: discrete timeout for http get version

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -259,7 +259,7 @@ func CheckForUpdates() {
 
 	if lastTime.IsZero() || currentTime.Sub(lastTime) >= 24*time.Hour {
 		client := &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: 5 * time.Second,
 		}
 		resp, err := client.Get(variable.LatestVersionURL)
 		if err != nil {

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -258,7 +258,10 @@ func CheckForUpdates() {
 	currentTime := time.Now()
 
 	if lastTime.IsZero() || currentTime.Sub(lastTime) >= 24*time.Hour {
-		resp, err := http.Get(variable.LatestVersionURL)
+		client := &http.Client{
+			Timeout: 10 * time.Second,
+		}
+		resp, err := client.Get(variable.LatestVersionURL)
 		if err != nil {
 			fmt.Println("Error checking for updates:", err)
 			return

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"runtime"
@@ -263,7 +264,7 @@ func CheckForUpdates() {
 		}
 		resp, err := client.Get(variable.LatestVersionURL)
 		if err != nil {
-			fmt.Println("Error checking for updates:", err)
+			slog.Error("Error checking for updates:", "error", err)
 			return
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
Fixes #630 issue 2

Set to 10s timeout, let me know if its too much / too little time.

```
> time ./bin/spf
Error checking for updates: Get "https://api.github.com/repos/yorukot/superfile/releases/latest": context deadline exceeded (Client.Timeout exceeded while awaiting headers)

________________________________________________________
Executed in   10.93 secs      fish           external
   usr time   73.50 millis  510.00 micros   72.99 millis
   sys time   16.63 millis  452.00 micros   16.18 millis
```