### PR TITLE
fix: openFileWithEditor bug

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -614,7 +614,12 @@ func (m *model) openDirectoryWithEditor() tea.Cmd {
 		}
 	}
 
-	c := exec.Command(editor, m.fileModel.filePanels[m.filePanelFocusIndex].location)
+	// Split the editor command into command and arguments
+	parts := strings.Fields(editor)
+	cmd := parts[0]
+	args := append(parts[1:], m.fileModel.filePanels[m.filePanelFocusIndex].location)
+
+	c := exec.Command(cmd, args...)
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		return editorFinishedMsg{err}
 	})

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -585,7 +585,13 @@ func (m *model) openFileWithEditor() tea.Cmd {
 			editor = "nano"
 		}
 	}
-	c := exec.Command(editor, panel.element[panel.cursor].location)
+
+	// Split the editor command into command and arguments
+	parts := strings.Fields(editor)
+	cmd := parts[0]
+	args := append(parts[1:], panel.element[panel.cursor].location)
+
+	c := exec.Command(cmd, args...)
 
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		return editorFinishedMsg{err}


### PR DESCRIPTION
This PR resolves a bug I discovered opening a file with default editor.

## Description of the bug

I am on macos and my `.zshrc` I have `EDITOR` defined as follows

```bash
export EDITOR="/usr/local/bin/code --wait"
```

which means that superfile cannot open a file selected using the `e` command


https://github.com/user-attachments/assets/8fbbb8fd-84b9-4b3e-95e5-65e443164a2e

## The fix

This PR fixes the bug by splitting the editor command so that the command is executed correctly using the args


https://github.com/user-attachments/assets/df7a158e-2093-413f-b583-b0bcfd75d0e5

