### PR TITLE
fix: Issue #631 raise an error when trying to extract a file (.zip_)

### DIFF
--- a/src/internal/file_operations_extract.go
+++ b/src/internal/file_operations_extract.go
@@ -37,6 +37,8 @@ func extractCompressFile(src, dest string) error {
 	x := &xtractr.XFile{
 		FilePath:  src,
 		OutputDir: dest,
+		FileMode:  0644,
+		DirMode:   0755,
 	}
 
 	_, _, _, err := xtractr.ExtractFile(x)

--- a/src/internal/file_operations_extract.go
+++ b/src/internal/file_operations_extract.go
@@ -1,13 +1,7 @@
 package internal
 
 import (
-	"archive/zip"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/progress"
@@ -15,20 +9,6 @@ import (
 	"github.com/yorukot/superfile/src/config/icon"
 	"golift.io/xtractr"
 )
-
-func getDefaultFileMode() os.FileMode {
-	if runtime.GOOS == "windows" {
-		return 0666
-	}
-	return 0644
-}
-
-func shouldSkipFile(name string) bool {
-	// Skip system files across platforms
-	return strings.HasPrefix(name, "__MACOSX/") ||
-		strings.EqualFold(name, "Thumbs.db") ||
-		strings.EqualFold(name, "desktop.ini")
-}
 
 func extractCompressFile(src, dest string) error {
 	id := shortuuid.New()
@@ -75,138 +55,6 @@ func extractCompressFile(src, dest string) error {
 	p.state = successful
 	p.done = 1
 	p.doneTime = time.Now()
-	message.processNewState = p
-	if len(channel) < 5 {
-		channel <- message
-	}
-
-	return nil
-}
-
-// Extract zip file
-func unzip(src, dest string) error {
-	id := shortuuid.New()
-	r, err := zip.OpenReader(src)
-	if err != nil {
-		return fmt.Errorf("failed to open zip: %w", err)
-	}
-	defer func() {
-		if err := r.Close(); err != nil {
-			outPutLog(fmt.Sprintf("Error closing zip reader: %v", err))
-		}
-	}()
-
-	totalFiles := len(r.File)
-	// progressbar
-	prog := progress.New(generateGradientColor())
-	prog.PercentageStyle = footerStyle
-	// channel message
-	p := process{
-		name:     icon.ExtractFile + icon.Space + "unzip file",
-		progress: prog,
-		state:    inOperation,
-		total:    totalFiles,
-		done:     0,
-		doneTime: time.Time{},
-	}
-
-	message := channelMessage{
-		messageId:       id,
-		messageType:     sendProcess,
-		processNewState: p,
-	}
-
-	// Closure to address file descriptors issue with all the deferred .Close() methods
-	extractAndWriteFile := func(f *zip.File) error {
-
-		rc, err := f.Open()
-		if err != nil {
-			return fmt.Errorf("failed to open file in zip: %w", err)
-		}
-		defer func() {
-			if err := rc.Close(); err != nil {
-				outPutLog(fmt.Sprintf("Error closing file reader: %v", err))
-			}
-		}()
-
-		path := filepath.Join(dest, f.Name)
-
-		// Cross-platform path security check
-		if !strings.HasPrefix(filepath.Clean(path), filepath.Clean(dest)+string(os.PathSeparator)) {
-			return fmt.Errorf("illegal file path: %s", path)
-		}
-
-		fileMode := f.Mode()
-		if f.FileInfo().IsDir() {
-			err := os.MkdirAll(path, fileMode)
-			if err != nil {
-				return fmt.Errorf("failed to create directory: %w", err)
-			}
-			return nil
-		}
-
-		// Create directory structure
-		if err := os.MkdirAll(filepath.Dir(path), fileMode); err != nil {
-			return fmt.Errorf("failed to create parent directory: %w", err)
-		}
-
-		// Try default permissions first
-		outFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, getDefaultFileMode())
-		if err != nil {
-			// Fall back to original file permissions
-			outFile, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileMode)
-			if err != nil {
-				return fmt.Errorf("failed to create file: %w", err)
-			}
-		}
-		defer func() {
-			if err := outFile.Close(); err != nil {
-				outPutLog(fmt.Sprintf("Error closing output file %s: %v", path, err))
-			}
-		}()
-
-		if _, err := io.Copy(outFile, rc); err != nil {
-			return fmt.Errorf("failed to write file content: %w", err)
-		}
-
-		return nil
-	}
-
-	for _, f := range r.File {
-		p.name = icon.ExtractFile + icon.Space + f.Name
-		if len(channel) < 5 {
-			message.processNewState = p
-			channel <- message
-		}
-
-		if shouldSkipFile(f.Name) {
-			p.done++
-			continue
-		}
-
-		err := extractAndWriteFile(f)
-		if err != nil {
-			p.state = failure
-			message.processNewState = p
-			channel <- message
-			outPutLog(fmt.Sprintf("Error extracting %s: %v", f.Name, err))
-			p.done++
-			continue
-		}
-		p.done++
-		if len(channel) < 5 {
-			message.processNewState = p
-			channel <- message
-		}
-	}
-
-	p.total = totalFiles
-	p.doneTime = time.Now()
-	if p.done == totalFiles {
-		p.state = successful
-	} else {
-		p.state = failure
-	}
 	message.processNewState = p
 	if len(channel) < 5 {
 		channel <- message

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -519,6 +519,12 @@ func (m *model) extractFile() {
 	var err error
 	panel := &m.fileModel.filePanels[m.filePanelFocusIndex]
 	ext := strings.ToLower(filepath.Ext(panel.element[panel.cursor].location))
+	err = isValidFileExtension(ext)
+	if err != nil {
+		slog.Error("Error extract file", "error", err)
+		return
+	}
+
 	outputDir := fileNameWithoutExtension(panel.element[panel.cursor].location)
 	outputDir, err = renameIfDuplicate(outputDir)
 	if err != nil {

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -519,9 +521,8 @@ func (m *model) extractFile() {
 	var err error
 	panel := &m.fileModel.filePanels[m.filePanelFocusIndex]
 	ext := strings.ToLower(filepath.Ext(panel.element[panel.cursor].location))
-	err = isValidFileExtension(ext)
-	if err != nil {
-		slog.Error("Error extract file", "error", err)
+	if !isExensionExtractable(ext) {
+		slog.Error(fmt.Sprintf("Error unexpected file extension type: %s", ext), "error", errors.ErrUnsupported)
 		return
 	}
 
@@ -537,19 +538,10 @@ func (m *model) extractFile() {
 		slog.Error("Error while making directory for extracting files", "error", err)
 		return
 	}
-	switch ext {
-	case ".zip":
-		err = unzip(panel.element[panel.cursor].location, outputDir)
-		if err != nil {
-			slog.Error("Error extract file", "error", err)
-			return
-		}
-	default:
-		err = extractCompressFile(panel.element[panel.cursor].location, outputDir)
-		if err != nil {
-			outPutLog("Error extract file", "error", err)
-			return
-		}
+	err = extractCompressFile(panel.element[panel.cursor].location, outputDir)
+	if err != nil {
+		slog.Error("Error extract file", "error", err)
+		return
 	}
 }
 

--- a/src/internal/string_function.go
+++ b/src/internal/string_function.go
@@ -2,12 +2,10 @@ package internal
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"math"
 	"os"
-	"regexp"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -156,20 +154,22 @@ func isBufferPrintable(buffer []byte) bool {
 	return true
 }
 
-// isValidFileExtension checks if a string is a valid file extension.
-// Returns nil if valid, otherwise returns an error with a descriptive message.
-func isValidFileExtension(ext string) error {
-	// Regular expression: starts with a dot, followed by 1+ alphanumeric characters
-	re := regexp.MustCompile(`^\.[a-zA-Z0-9]+$`)
-
-	if ext == "" {
-		return errors.New("file extension cannot be empty")
+// isExensionExtractable checks if a string is a valid compressed archive file extension.
+func isExensionExtractable(ext string) bool {
+	// Extensions based on the types that package: `xtractr` `ExtractFile` function handles.
+	validExtensions := map[string]struct{}{
+		".zip":     {},
+		".bz":      {},
+		".gz":      {},
+		".iso":     {},
+		".rar":     {},
+		".7z":      {},
+		".tar":     {},
+		".tar.gz":  {},
+		".tar.bz2": {},
 	}
-	if !re.MatchString(ext) {
-		return fmt.Errorf("%q is not a valid file extension", ext)
-	}
-
-	return nil
+	_, exists := validExtensions[strings.ToLower(ext)]
+	return exists
 }
 
 // Check file is text file or not

--- a/src/internal/string_function.go
+++ b/src/internal/string_function.go
@@ -2,10 +2,12 @@ package internal
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"math"
 	"os"
+	"regexp"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -152,6 +154,22 @@ func isBufferPrintable(buffer []byte) bool {
 		}
 	}
 	return true
+}
+
+// isValidFileExtension checks if a string is a valid file extension.
+// Returns nil if valid, otherwise returns an error with a descriptive message.
+func isValidFileExtension(ext string) error {
+	// Regular expression: starts with a dot, followed by 1+ alphanumeric characters
+	re := regexp.MustCompile(`^\.[a-zA-Z0-9]+$`)
+
+	if ext == "" {
+		return errors.New("file extension cannot be empty")
+	}
+	if !re.MatchString(ext) {
+		return fmt.Errorf("%q is not a valid file extension", ext)
+	}
+
+	return nil
 }
 
 // Check file is text file or not

--- a/src/internal/string_function_test.go
+++ b/src/internal/string_function_test.go
@@ -87,6 +87,34 @@ func TestIsBufferPrintable(t *testing.T) {
 	}
 }
 
+func TestIsValidFileExtension(t *testing.T) {
+	var inputs = []struct {
+		input         string
+		expectedError bool
+	}{
+		{".zip", true},
+		{".zip ", false},
+		{".zip_", false},
+		{"", false},
+		{".", false},
+		{".jpg", true},
+		{".123", true},       // Numeric extension is valid
+		{".a", true},         // Single-letter extensions are valid
+		{"zip", false},       // Missing dot
+		{".zip-file", false}, // Invalid character
+	}
+	for _, tt := range inputs {
+		err := isValidFileExtension(tt.input)
+		if (err != nil) != tt.expectedError {
+			fmt.Printf("Test failed for input %q: unexpected result\n", tt.input)
+		} else if err != nil {
+			fmt.Printf("validateFileExtension(%q) failed: %v\n", tt.input, err)
+		} else {
+			fmt.Printf("validateFileExtension(%q) passed\n", tt.input)
+		}
+	}
+}
+
 func TestMakePrintable(t *testing.T) {
 	var inputs = []struct {
 		input    string

--- a/src/internal/string_function_test.go
+++ b/src/internal/string_function_test.go
@@ -87,31 +87,34 @@ func TestIsBufferPrintable(t *testing.T) {
 	}
 }
 
-func TestIsValidFileExtension(t *testing.T) {
-	var inputs = []struct {
-		input         string
-		expectedError bool
+func TestIsExtensionExtractable(t *testing.T) {
+	inputs := []struct {
+		ext      string
+		expected bool
 	}{
 		{".zip", true},
-		{".zip ", false},
-		{".zip_", false},
-		{"", false},
-		{".", false},
-		{".jpg", true},
-		{".123", true},       // Numeric extension is valid
-		{".a", true},         // Single-letter extensions are valid
-		{"zip", false},       // Missing dot
-		{".zip-file", false}, // Invalid character
+		{".rar", true},
+		{".7z", true},
+		{".tar.gz", true},
+		{".tar.bz2", true},
+		{".exe", false},
+		{".txt", false},
+		{".tar", true},
+		{"", false},    // Empty string case
+		{".ZIP", true}, // Case sensitivity check
+		{".Zip", true}, // Case sensitivity check
+		{".bz", true},
+		{".gz", true},
+		{".iso", true},
 	}
+
 	for _, tt := range inputs {
-		err := isValidFileExtension(tt.input)
-		if (err != nil) != tt.expectedError {
-			fmt.Printf("Test failed for input %q: unexpected result\n", tt.input)
-		} else if err != nil {
-			fmt.Printf("validateFileExtension(%q) failed: %v\n", tt.input, err)
-		} else {
-			fmt.Printf("validateFileExtension(%q) passed\n", tt.input)
-		}
+		t.Run(tt.ext, func(t *testing.T) {
+			result := isExensionExtractable(tt.ext)
+			if result != tt.expected {
+				t.Errorf("isExensionExtractable (%q) = %v; want %v", tt.ext, result, tt.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Addresses issue #631 Unzipping a malformed/invalid zip file by raising an error if the extension is wrong.
- Added `isExensionExtractable` function to check against file types we can extract from the `xtractr` package. (return bool if we can extract or not)
- Removed internal unzip function, as `xtractr` can handle unzipping zip file.
- example log: `time=2025-02-21T10:53:00.459-08:00 level=ERROR msg="Error unexpected file extension type: .zip_" error="unsupported operation"`

Trial screenshot below (No progress in bottom left as also mentioned in issue):
![image](https://github.com/user-attachments/assets/e601ea6a-5e7f-42b1-afd5-8196c5e4afcc)

❓ This is my first PR and I'm a brand new beginner to superfile.
Where would I see these logged errors? I ran it with VScode and put some breakpoints in to ensure the code I was hitting was working as expected. And it made some `__debug_bin3073481771.exe` files. I'm running it on windows. But not sure how to introspect that file or where to see the errors.