### PR TITLE
Fail to cut and paste folder inside itself

### DIFF
--- a/src/internal/file_operations.go
+++ b/src/internal/file_operations.go
@@ -48,9 +48,6 @@ func getDriveLetter(path string) string {
 
 // moveElement moves a file or directory efficiently
 func moveElement(src, dst string) error {
-	if strings.HasPrefix(dst, src) {
-		return fmt.Errorf("failed to move: cannot move folder '%s' inside itself: '%s'", src, dst)
-	}
 	// Check if source and destination are on the same partition
 	sameDev, err := isSamePartition(src, dst)
 	if err != nil {

--- a/src/internal/file_operations.go
+++ b/src/internal/file_operations.go
@@ -46,6 +46,30 @@ func getDriveLetter(path string) string {
 	return strings.ToUpper(string(path[0]))
 }
 
+// isSubDir check if a path is inside another path to prevent unwanted recursive operations
+func isSubDir(src string, dst string) (bool, error) {
+	absSrc, err := filepath.Abs(src)
+	if err != nil {
+		return false, err
+	}
+
+	absDst, err := filepath.Abs(filepath.Dir(dst))
+	if err != nil {
+		return false, err
+	}
+
+	rel, err := filepath.Rel(absSrc, absDst)
+	if err != nil {
+		return false, err
+	}
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false, nil
+	}
+
+	return true, nil
+
+}
+
 // moveElement moves a file or directory efficiently
 func moveElement(src, dst string) error {
 	// Check if source and destination are on the same partition

--- a/src/internal/file_operations.go
+++ b/src/internal/file_operations.go
@@ -48,6 +48,9 @@ func getDriveLetter(path string) string {
 
 // moveElement moves a file or directory efficiently
 func moveElement(src, dst string) error {
+	if strings.HasPrefix(dst, src) {
+		return fmt.Errorf("failed to move: cannot move folder '%s' inside itself: '%s'", src, dst)
+	}
 	// Check if source and destination are on the same partition
 	sameDev, err := isSamePartition(src, dst)
 	if err != nil {

--- a/src/internal/file_operations.go
+++ b/src/internal/file_operations.go
@@ -62,7 +62,7 @@ func isSubDir(src string, dst string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return false, nil
 	}
 

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -473,8 +473,12 @@ func (m *model) pasteItem() {
 		errMessage := "cut item error"
 
 		dstPath := filepath.Join(panel.location, filepath.Base(filePath))
-		if strings.HasPrefix(dstPath, filePath) {
-			err = fmt.Errorf("failed to paste: cannot paste item '%s' into itself: %s", filePath, dstPath)
+		subDir, err := isSubDir(filePath, dstPath)
+
+		if err != nil {
+			// cannot compare source and destination paths, so just fail with the given error
+		} else if subDir {
+			err = fmt.Errorf("failed to paste: cannot paste item, '%s', into itself, %s", filePath, dstPath)
 		} else if m.copyItems.cut && !isExternalDiskPath(filePath) {
 			err = moveElement(filePath, dstPath)
 		} else {

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -470,10 +471,14 @@ func (m *model) pasteItem() {
 		}
 
 		errMessage := "cut item error"
-		if m.copyItems.cut && !isExternalDiskPath(filePath) {
-			err = moveElement(filePath, filepath.Join(panel.location, filepath.Base(filePath)))
+
+		dstPath := filepath.Join(panel.location, filepath.Base(filePath))
+		if strings.HasPrefix(dstPath, filePath) {
+			err = fmt.Errorf("failed to paste: cannot paste item '%s' into itself: %s", filePath, dstPath)
+		} else if m.copyItems.cut && !isExternalDiskPath(filePath) {
+			err = moveElement(filePath, dstPath)
 		} else {
-			err = pasteDir(filePath, filepath.Join(panel.location, filepath.Base(filePath)), id, m)
+			err = pasteDir(filePath, dstPath, id, m)
 			if err != nil {
 				errMessage = "paste item error"
 			} else {


### PR DESCRIPTION
Fails the _moveElement_ operation when trying to move something into itself.

For now, the only thing it does is failing the operation, but does not open a modal for warning. It leaves the process cancellation (UI) to the _pasteItem_ handler. If an modal is wanted, I can try to add to this PR, otherwise, it can be left like this - only failing but no communication to the user - with the issue solved.

Fixes #570 