### PR TITLE
fix: initial pinned.json had invalid json

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -141,7 +141,6 @@ func InitConfigFile() {
 
 	// Create files
 	if err := createFiles(
-		variable.PinnedFile,
 		variable.ToggleDotFile,
 		variable.LogFile,
 		variable.ThemeFileVersion,
@@ -157,6 +156,10 @@ func InitConfigFile() {
 
 	if err := writeConfigFile(variable.HotkeysFile, internal.HotkeysTomlString); err != nil {
 		log.Fatalln("Error writing config file:", err)
+	}
+
+	if err := initJsonFile(variable.PinnedFile); err != nil {
+		log.Fatalln("Error initializing json file:", err)
 	}
 }
 
@@ -223,6 +226,15 @@ func writeConfigFile(path, data string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		if err := os.WriteFile(path, []byte(data), 0644); err != nil {
 			return fmt.Errorf("failed to write config file %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func initJsonFile(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.WriteFile(path, []byte("null"), 0644); err != nil {
+			return fmt.Errorf("failed to initialize json file %s: %w", path, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Issue
At a fresh build and first run, the `pinned.json` file which stored the pinned directories is created and empty. This was causing an error during the parsing of its contents into JSON.

The log file was filled with this error:
`supefile.log`:
```
time=2025-02-26T17:23:31.026+11:00 level=ERROR msg="Error parsing pinned data" error="unexpected end of JSON input"
time=2025-02-26T17:23:31.063+11:00 level=ERROR msg="Error parsing pinned data" error="unexpected end of JSON input"
```
Its repeatable by deleting the `pinned.json` file and running spf. The error stops once a directory has been pinned. When unpinned again, `pinned.json` gets written with a valid JSON of "null", and the error doesn't appear again.

## FIx
 Initialize the pinned.json file if it doesnt exist with "null" to match the state after unpinning all directories.

