### PR TITLE
Refactor of wheel functions

### DIFF
--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -228,32 +228,22 @@ func (m *model) searchBarFocus() {
 // ======================================== File panel controller ========================================
 
 // Control file panel list up
-func (m *model) controlFilePanelListUp(wheel bool) {
-	runTime := 1
-	if wheel {
-		runTime = wheelRunTime
+func (panel *filePanel) listUp(mainPanelHeight int) {
+	if len(panel.element) == 0 {
+		return
 	}
-
-	for i := 0; i < runTime; i++ {
-		panel := m.fileModel.filePanels[m.filePanelFocusIndex]
-		if len(panel.element) == 0 {
-			return
+	if panel.cursor > 0 {
+		panel.cursor--
+		if panel.cursor < panel.render {
+			panel.render--
 		}
-		if panel.cursor > 0 {
-			panel.cursor--
-			if panel.cursor < panel.render {
-				panel.render--
-			}
+	} else {
+		if len(panel.element) > panelElementHeight(mainPanelHeight) {
+			panel.render = len(panel.element) - panelElementHeight(mainPanelHeight)
+			panel.cursor = len(panel.element) - 1
 		} else {
-			if len(panel.element) > panelElementHeight(m.mainPanelHeight) {
-				panel.render = len(panel.element) - panelElementHeight(m.mainPanelHeight)
-				panel.cursor = len(panel.element) - 1
-			} else {
-				panel.cursor = len(panel.element) - 1
-			}
+			panel.cursor = len(panel.element) - 1
 		}
-
-		m.fileModel.filePanels[m.filePanelFocusIndex] = panel
 	}
 }
 
@@ -498,22 +488,14 @@ func (m *model) sidebarSearchBarFocus() {
 // ======================================== Metadata controller ========================================
 
 // Control metadata panel up
-func (m *model) controlMetadataListUp(wheel bool) {
-	runTime := 1
-	if wheel {
-		runTime = wheelRunTime
-	}
-
-	if len(m.fileMetaData.metaData) == 0 {
+func (fm *fileMetadata) listUp() {
+	if len(fm.metaData) == 0 {
 		return
 	}
-
-	for i := 0; i < runTime; i++ {
-		if m.fileMetaData.renderIndex > 0 {
-			m.fileMetaData.renderIndex--
-		} else {
-			m.fileMetaData.renderIndex = len(m.fileMetaData.metaData) - 1
-		}
+	if fm.renderIndex > 0 {
+		fm.renderIndex--
+	} else {
+		fm.renderIndex = len(fm.metaData) - 1
 	}
 }
 
@@ -536,28 +518,21 @@ func (m *model) controlMetadataListDown(wheel bool) {
 // ======================================== Processbar controller ========================================
 
 // Control processbar panel list up
-func (m *model) controlProcessbarListUp(wheel bool) {
-	if len(m.processBarModel.processList) == 0 {
+func (p *processBarModel) listUp() {
+	if len(p.processList) == 0 {
 		return
 	}
-	runTime := 1
-	if wheel {
-		runTime = wheelRunTime
-	}
-
-	for i := 0; i < runTime; i++ {
-		if m.processBarModel.cursor > 0 {
-			m.processBarModel.cursor--
-			if m.processBarModel.cursor < m.processBarModel.render {
-				m.processBarModel.render--
-			}
+	if p.cursor > 0 {
+		p.cursor--
+		if p.cursor < p.render {
+			p.render--
+		}
+	} else {
+		if len(p.processList) <= 3 || (len(p.processList) <= 2 && footerHeight < 14) {
+			p.cursor = len(p.processList) - 1
 		} else {
-			if len(m.processBarModel.processList) <= 3 || (len(m.processBarModel.processList) <= 2 && footerHeight < 14) {
-				m.processBarModel.cursor = len(m.processBarModel.processList) - 1
-			} else {
-				m.processBarModel.render = len(m.processBarModel.processList) - 3
-				m.processBarModel.cursor = len(m.processBarModel.processList) - 1
-			}
+			p.render = len(p.processList) - 3
+			p.cursor = len(p.processList) - 1
 		}
 	}
 }

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -248,29 +248,19 @@ func (panel *filePanel) listUp(mainPanelHeight int) {
 }
 
 // Control file panel list down
-func (m *model) controlFilePanelListDown(wheel bool) {
-	runTime := 1
-	if wheel {
-		runTime = wheelRunTime
+func (panel *filePanel) listDown(mainPanelHeight int) {
+	if len(panel.element) == 0 {
+		return
 	}
-
-	for i := 0; i < runTime; i++ {
-		panel := m.fileModel.filePanels[m.filePanelFocusIndex]
-		if len(panel.element) == 0 {
-			return
+	if panel.cursor < len(panel.element)-1 {
+		panel.cursor++
+		if panel.cursor > panel.render+panelElementHeight(mainPanelHeight)-1 {
+			panel.render++
 		}
-		if panel.cursor < len(panel.element)-1 {
-			panel.cursor++
-			if panel.cursor > panel.render+panelElementHeight(m.mainPanelHeight)-1 {
-				panel.render++
-			}
-		} else {
-			panel.render = 0
-			panel.cursor = 0
-		}
-		m.fileModel.filePanels[m.filePanelFocusIndex] = panel
+	} else {
+		panel.render = 0
+		panel.cursor = 0
 	}
-
 }
 
 func (m *model) controlFilePanelPgUp() {
@@ -397,18 +387,6 @@ func (m *model) itemSelectDown(wheel bool) {
 
 // ======================================== Sidebar controller ========================================
 
-func (s *sidebarModel) controlListUp(wheel bool, mainPanelHeight int) {
-
-	// Todo : This snippet is duplicated everywhere. It can be better refractored outside
-	runTime := 1
-	if wheel {
-		runTime = wheelRunTime
-	}
-	for i := 0; i < runTime; i++ {
-		s.listUp(mainPanelHeight)
-	}
-}
-
 func (s *sidebarModel) listUp(mainPanelHeight int) {
 	slog.Debug("controlListUp called", "cursor", s.cursor,
 		"renderIndex", s.renderIndex, "directory count", len(s.directories))
@@ -431,18 +409,6 @@ func (s *sidebarModel) listUp(mainPanelHeight int) {
 		s.listUp(mainPanelHeight)
 	}
 
-}
-
-func (s *sidebarModel) controlListDown(wheel bool, mainPanelHeight int) {
-
-	// Todo : This snippet is duplicated everywhere. It can be better refractored outside
-	runTime := 1
-	if wheel {
-		runTime = wheelRunTime
-	}
-	for i := 0; i < runTime; i++ {
-		s.listDown(mainPanelHeight)
-	}
 }
 
 func (s *sidebarModel) listDown(mainPanelHeight int) {
@@ -500,18 +466,11 @@ func (fm *fileMetadata) listUp() {
 }
 
 // Control metadata panel down
-func (m *model) controlMetadataListDown(wheel bool) {
-	runTime := 1
-	if wheel {
-		runTime = wheelRunTime
-	}
-
-	for i := 0; i < runTime; i++ {
-		if m.fileMetaData.renderIndex < len(m.fileMetaData.metaData)-1 {
-			m.fileMetaData.renderIndex++
-		} else {
-			m.fileMetaData.renderIndex = 0
-		}
+func (fm *fileMetadata) listDown() {
+	if fm.renderIndex < len(fm.metaData)-1 {
+		fm.renderIndex++
+	} else {
+		fm.renderIndex = 0
 	}
 }
 
@@ -538,25 +497,17 @@ func (p *processBarModel) listUp() {
 }
 
 // Control processbar panel list down
-func (m *model) controlProcessbarListDown(wheel bool) {
-	if len(m.processBarModel.processList) == 0 {
+func (p *processBarModel) listDown() {
+	if len(p.processList) == 0 {
 		return
 	}
-
-	runTime := 1
-	if wheel {
-		runTime = wheelRunTime
-	}
-
-	for i := 0; i < runTime; i++ {
-		if m.processBarModel.cursor < len(m.processBarModel.processList)-1 {
-			m.processBarModel.cursor++
-			if m.processBarModel.cursor > m.processBarModel.render+2 {
-				m.processBarModel.render++
-			}
-		} else {
-			m.processBarModel.render = 0
-			m.processBarModel.cursor = 0
+	if p.cursor < len(p.processList)-1 {
+		p.cursor++
+		if p.cursor > p.render+2 {
+			p.render++
 		}
+	} else {
+		p.render = 0
+		p.cursor = 0
 	}
 }

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -21,7 +21,7 @@ func (m *model) mainKey(msg string, cmd tea.Cmd) tea.Cmd {
 	// If move up Key is pressed, check the current state and executes
 	case containsKey(msg, hotkeys.ListUp):
 		if m.focusPanel == sidebarFocus {
-			m.sidebarModel.controlListUp(false, m.mainPanelHeight)
+			m.sidebarModel.listUp(m.mainPanelHeight)
 		} else if m.focusPanel == processBarFocus {
 			m.processBarModel.listUp()
 		} else if m.focusPanel == metadataFocus {
@@ -37,13 +37,13 @@ func (m *model) mainKey(msg string, cmd tea.Cmd) tea.Cmd {
 		// If move down Key is pressed, check the current state and executes
 	case containsKey(msg, hotkeys.ListDown):
 		if m.focusPanel == sidebarFocus {
-			m.sidebarModel.controlListDown(false, m.mainPanelHeight)
+			m.sidebarModel.listDown(m.mainPanelHeight)
 		} else if m.focusPanel == processBarFocus {
-			m.controlProcessbarListDown(false)
+			m.processBarModel.listDown()
 		} else if m.focusPanel == metadataFocus {
-			m.controlMetadataListDown(false)
+			m.fileMetaData.listDown()
 		} else if m.focusPanel == nonePanelFocus {
-			m.controlFilePanelListDown(false)
+			m.fileModel.filePanels[m.filePanelFocusIndex].listDown(m.mainPanelHeight)
 			m.fileMetaData.renderIndex = 0
 			go func() {
 				m.returnMetaData()

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -23,11 +23,11 @@ func (m *model) mainKey(msg string, cmd tea.Cmd) tea.Cmd {
 		if m.focusPanel == sidebarFocus {
 			m.sidebarModel.controlListUp(false, m.mainPanelHeight)
 		} else if m.focusPanel == processBarFocus {
-			m.controlProcessbarListUp(false)
+			m.processBarModel.listUp()
 		} else if m.focusPanel == metadataFocus {
-			m.controlMetadataListUp(false)
+			m.fileMetaData.listUp()
 		} else if m.focusPanel == nonePanelFocus {
-			m.controlFilePanelListUp(false)
+			m.fileModel.filePanels[m.filePanelFocusIndex].listUp(m.mainPanelHeight)
 			m.fileMetaData.renderIndex = 0
 			go func() {
 				m.returnMetaData()

--- a/src/internal/wheel_function.go
+++ b/src/internal/wheel_function.go
@@ -21,11 +21,11 @@ func wheelMainAction(msg string, m *model, cmd tea.Cmd) tea.Cmd {
 		if m.focusPanel == sidebarFocus {
 			action = func() { m.sidebarModel.listDown(m.mainPanelHeight) }
 		} else if m.focusPanel == processBarFocus {
-			action = func() { m.controlProcessbarListDown(true) }
+			action = func() { m.processBarModel.listDown() }
 		} else if m.focusPanel == metadataFocus {
-			action = func() { m.controlMetadataListDown(true) }
+			action = func() { m.fileMetaData.listDown() }
 		} else if m.focusPanel == nonePanelFocus {
-			action = func() { m.controlFilePanelListDown(true) }
+			action = func() { m.fileModel.filePanels[m.filePanelFocusIndex].listDown(m.mainPanelHeight) }
 		}
 	}
 

--- a/src/internal/wheel_function.go
+++ b/src/internal/wheel_function.go
@@ -3,37 +3,42 @@ package internal
 import tea "github.com/charmbracelet/bubbletea"
 
 func wheelMainAction(msg string, m *model, cmd tea.Cmd) tea.Cmd {
+	var action func()
 	switch msg {
 
 	case "wheel up":
 		if m.focusPanel == sidebarFocus {
-			m.sidebarModel.controlListUp(true, m.mainPanelHeight)
+			action = func() { m.sidebarModel.listUp(m.mainPanelHeight) }
 		} else if m.focusPanel == processBarFocus {
-			m.controlProcessbarListUp(true)
+			action = func() { m.processBarModel.listUp() }
 		} else if m.focusPanel == metadataFocus {
-			m.controlMetadataListUp(true)
+			action = func() { m.fileMetaData.listUp() }
 		} else if m.focusPanel == nonePanelFocus {
-			m.controlFilePanelListUp(true)
-			m.fileMetaData.renderIndex = 0
-			go func() {
-				m.returnMetaData()
-			}()
+			action = func() { m.fileModel.filePanels[m.filePanelFocusIndex].listUp(m.mainPanelHeight) }
 		}
 
 	case "wheel down":
 		if m.focusPanel == sidebarFocus {
-			m.sidebarModel.controlListDown(true, m.mainPanelHeight)
+			action = func() { m.sidebarModel.listDown(m.mainPanelHeight) }
 		} else if m.focusPanel == processBarFocus {
-			m.controlProcessbarListDown(true)
+			action = func() { m.controlProcessbarListDown(true) }
 		} else if m.focusPanel == metadataFocus {
-			m.controlMetadataListDown(true)
+			action = func() { m.controlMetadataListDown(true) }
 		} else if m.focusPanel == nonePanelFocus {
-			m.controlFilePanelListDown(true)
-			m.fileMetaData.renderIndex = 0
-			go func() {
-				m.returnMetaData()
-			}()
+			action = func() { m.controlFilePanelListDown(true) }
 		}
 	}
+
+	for i := 0; i < wheelRunTime; i++ {
+		action()
+	}
+
+	if m.focusPanel == nonePanelFocus {
+		m.fileMetaData.renderIndex = 0
+		go func() {
+			m.returnMetaData()
+		}()
+	}
+
 	return cmd
 }


### PR DESCRIPTION
Removes code duplication. There was a for loop for wheelRuntime in each function.


Passing only minimum information to the function, instead of whole model structure. For Principle of Least Privilege or Loose coupling between functions, making them easier to write unit test for and more maintainable. Also clears the intent of the function, and gets rid of any possible unwanted side effects a function could have if it has access to more data than it needs.

The overall code flow remains exactly the same