### PR TITLE
add cd_on_quit for fish shell

### DIFF
--- a/cd_on_quit/cd_on_quit.fish
+++ b/cd_on_quit/cd_on_quit.fish
@@ -1,0 +1,18 @@
+function spf
+    set os $(uname -s)
+
+    if test "$os" = "Linux"
+        set spf_last_dir "$HOME/.local/state/superfile/lastdir"
+    end
+
+    if test "$os" = "Darwin"
+        set spf_last_dir "$HOME/Library/Application Support/superfile/lastdir"
+    end
+
+    command spf $argv
+
+    if test -f "$spf_last_dir"
+        source "$spf_last_dir"
+        rm -f -- "$spf_last_dir" >> /dev/null
+    end
+end


### PR DESCRIPTION
Closes #682

Follows a similar approach to the `cd_on_quit.sh`

I was trying to integrate the `--print-last-dir` option which was added in #488 so that this can become cross-platform similar to how [`lf`](https://github.com/gokcehan/lf) does it but was unable to... Anyone has any ideas for that?