### PR TITLE
Allow specifying directory icon color in theme files

### DIFF
--- a/src/config/icon/function.go
+++ b/src/config/icon/function.go
@@ -1,6 +1,6 @@
 package icon
 
-func InitIcon(nerdfont bool) {
+func InitIcon(nerdfont bool, directoryIconColor string) {
 	if !nerdfont {
 		Space = ""
 		SuperfileIcon = ""
@@ -33,5 +33,13 @@ func InitIcon(nerdfont bool) {
 		Search = ""
 		SortAsc = ""
 		SortDesc = ""
+	}
+
+	if directoryIconColor == "" {
+		directoryIconColor = "NONE" // Dark yellowish
+	}
+	Folders["folder"] = IconStyle{
+		Icon:  "",
+		Color: directoryIconColor,
 	}
 }

--- a/src/config/icon/icon.go
+++ b/src/config/icon/icon.go
@@ -408,9 +408,9 @@ var Folders = map[string]IconStyle{
 	".vscode":               {Icon: "\ue70c", Color: "#007acc"}, // VSCode folder - Blue
 	".vim":                  {Icon: "\ue62b", Color: "#019833"}, // Vim folder - Green
 	"config":                {Icon: "\ue5fc", Color: "#ffb86c"}, // Config folder - Light orange
-	"folder":                {Icon: "", Color: "NONE"},         // Generic folder - Dark yellowish
-	"hidden":                {Icon: "\uf023", Color: "#75715e"}, // Hidden folder - Dark yellowish
-	"node_modules":          {Icon: "\ue5fa", Color: "#cb3837"}, // Node modules folder - Red
+	// Item for Generic folder, with key "folder" is initialized in InitIcon()
+	"hidden":       {Icon: "\uf023", Color: "#75715e"}, // Hidden folder - Dark yellowish
+	"node_modules": {Icon: "\ue5fa", Color: "#cb3837"}, // Node modules folder - Red
 
 	"superfile": {Icon: "󰚝", Color: "#FF6F00"},
 }

--- a/src/internal/config_function.go
+++ b/src/internal/config_function.go
@@ -44,7 +44,7 @@ func initialConfig(dir string) (toggleDotFileBool bool, toggleFooter bool, first
 
 	loadThemeFile()
 
-	icon.InitIcon(Config.Nerdfont)
+	icon.InitIcon(Config.Nerdfont, theme.DirectoryIconColor)
 
 	toggleDotFileData, err := os.ReadFile(variable.ToggleDotFile)
 	if err != nil {

--- a/src/internal/config_type.go
+++ b/src/internal/config_type.go
@@ -84,12 +84,13 @@ type ThemeType struct {
 	ModalFG      string `toml:"modal_fg"`
 
 	// Special Color
-	Cursor        string   `toml:"cursor"`
-	Correct       string   `toml:"correct"`
-	Error         string   `toml:"error"`
-	Hint          string   `toml:"hint"`
-	Cancel        string   `toml:"cancel"`
-	GradientColor []string `toml:"gradient_color"`
+	Cursor             string   `toml:"cursor"`
+	Correct            string   `toml:"correct"`
+	Error              string   `toml:"error"`
+	Hint               string   `toml:"hint"`
+	Cancel             string   `toml:"cancel"`
+	GradientColor      []string `toml:"gradient_color"`
+	DirectoryIconColor string   `toml:"directory_icon_color"`
 
 	// File Panel Special Items
 	FilePanelTopDirectoryIcon string `toml:"file_panel_top_directory_icon"`

--- a/src/superfile_config/theme/catppuccin-latte.toml
+++ b/src/superfile_config/theme/catppuccin-latte.toml
@@ -42,6 +42,7 @@ hint = "#209fb5"    # Sapphire
 cancel = "#e64553"  # Maroon
 # Gradient color can only have two color!
 gradient_color = ["#1e66f5", "#ca9ee6"] # [Blue, Mauve]
+directory_icon_color = "#444444" # Darker shade of grey
 
 # ========= File Panel Special Items =========
 file_panel_top_directory_icon = "#40a02b" # Green


### PR DESCRIPTION
Fixes - https://github.com/yorukot/superfile/issues/685

I have made it so that it uses the default color if the `directory_icon_color` is not specified in theme.toml