### PR TITLE
Rename metadata strings (#691)

### DIFF
--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -319,12 +319,12 @@ func (m *model) returnMetaData() {
 	}
 
 	if fileInfo.IsDir() {
-		m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"FolderName", fileInfo.Name()})
+		m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"Name", fileInfo.Name()})
 		if m.focusPanel == metadataFocus {
-			m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"FolderSize", formatFileSize(dirSize(filePath))})
+			m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"Size", formatFileSize(dirSize(filePath))})
 		}
-		m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"FolderModifyDate", fileInfo.ModTime().String()})
-		m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"FolderPermissions", fileInfo.Mode().String()})
+		m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"Date Modified", fileInfo.ModTime().String()})
+		m.fileMetaData.metaData = append(m.fileMetaData.metaData, [2]string{"Permissions", fileInfo.Mode().String()})
 		message.metadata = m.fileMetaData.metaData
 		channel <- message
 		return
@@ -352,10 +352,10 @@ func (m *model) returnMetaData() {
 			}
 		}
 	} else {
-		fileName := [2]string{"FileName", fileInfo.Name()}
-		fileSize := [2]string{"FileSize", formatFileSize(fileInfo.Size())}
-		fileModifyData := [2]string{"FileModifyDate", fileInfo.ModTime().String()}
-		filePermissions := [2]string{"FilePermissions", fileInfo.Mode().String()}
+		fileName := [2]string{"Name", fileInfo.Name()}
+		fileSize := [2]string{"Size", formatFileSize(fileInfo.Size())}
+		fileModifyData := [2]string{"Date Modified", fileInfo.ModTime().String()}
+		filePermissions := [2]string{"Permissions", fileInfo.Mode().String()}
 
 		if Config.EnableMD5Checksum {
 			// Calculate MD5 checksum

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -337,7 +337,7 @@ func (m *model) metadataRender() string {
 	sort.Slice(m.fileMetaData.metaData, func(i, j int) bool {
 		// Initialising a new slice in each check by sort functions is too ineffinceint.
 		// Todo : Fix it
-		comparisonFields := []string{"FileName", "FileSize", "FolderName", "FolderSize", "FileModifyDate", "FileAccessDate"}
+		comparisonFields := []string{"Name", "Size", "Date Modified", "Date Accessed"}
 
 		for _, field := range comparisonFields {
 			if m.fileMetaData.metaData[i][0] == field {


### PR DESCRIPTION
Removed `File` and `Folder` from the metadata titles and changed them to title case.