### PR TITLE
feat: Open new FilePanels at current Folder

### DIFF
--- a/src/internal/config_function.go
+++ b/src/internal/config_function.go
@@ -89,6 +89,7 @@ func initialConfig(dir string) (toggleDotFileBool bool, toggleFooter bool, first
 
 	if err != nil {
 		firstFilePanelDir = variable.HomeDir
+		newFilePanelDir = firstFilePanelDir
 	}
 
 	slog.Debug("Runtime information", "runtime.GOOS", runtime.GOOS,

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -31,6 +31,7 @@ func (m *model) parentDirectory() {
 	fullPath := panel.location
 	parentDir := filepath.Dir(fullPath)
 	panel.location = parentDir
+	newFilePanelDir = panel.location
 	directoryRecord, hasRecord := panel.directoryRecord[panel.location]
 	if hasRecord {
 		panel.cursor = directoryRecord.directoryCursor
@@ -55,6 +56,7 @@ func (m *model) enterPanel() {
 			directoryRender: panel.render,
 		}
 		panel.location = panel.element[panel.cursor].location
+		newFilePanelDir = panel.location
 		directoryRecord, hasRecord := panel.directoryRecord[panel.location]
 		if hasRecord {
 			panel.cursor = directoryRecord.directoryCursor

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -135,6 +135,8 @@ func (m *model) sidebarSelectDirectory() {
 	}
 
 	panel.location = m.sidebarModel.directories[m.sidebarModel.cursor].location
+	newFilePanelDir = panel.location
+
 	directoryRecord, hasRecord := panel.directoryRecord[panel.location]
 	if hasRecord {
 		panel.cursor = directoryRecord.directoryCursor

--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -60,7 +60,7 @@ func (m *model) createNewFilePanel() {
 	}
 
 	m.fileModel.filePanels = append(m.fileModel.filePanels, filePanel{
-		location:        variable.HomeDir,
+		location:        newFilePanelDir,
 		sortOptions:     m.fileModel.filePanels[m.filePanelFocusIndex].sortOptions,
 		panelMode:       browserMode,
 		focusType:       secondFocus,
@@ -153,6 +153,8 @@ func (m *model) nextFilePanel() {
 	}
 
 	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = returnFocusType(m.focusPanel)
+	newFilePanelDir = m.fileModel.filePanels[m.filePanelFocusIndex].location
+
 }
 
 // Focus on previous file panel
@@ -165,6 +167,7 @@ func (m *model) previousFilePanel() {
 	}
 
 	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = returnFocusType(m.focusPanel)
+	newFilePanelDir = m.fileModel.filePanels[m.filePanelFocusIndex].location
 }
 
 // Focus on sidebar

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -33,9 +33,14 @@ var et *exiftool.Exiftool
 var channel = make(chan channelMessage, 1000)
 var progressBarLastRenderTime time.Time = time.Now()
 
+var newFilePanelDir string = variable.HomeDir
+
 // Initialize and return model with default configs
 func InitialModel(dir string, firstUseCheck, hasTrashCheck bool) model {
+
 	toggleDotFileBool, toggleFooter, firstFilePanelDir := initialConfig(dir)
+	newFilePanelDir = firstFilePanelDir
+
 	firstUse = firstUseCheck
 	hasTrash = hasTrashCheck
 	batCmd = checkBatCmd()


### PR DESCRIPTION
# Preamble
First of all thank you for your hard work. SuperFile has completely replace my previous Filebrowser "Ranger". I enjoy working with it.

With that said, there was one thing, that bothered me.

# Problem:
When opening a new FilePanel, it would always open at my HomeDir. That got a bit to annoying, since I tend to keep pretty deep folder structures.

# Solution:
Have the newFilePanel-Function use the location of the last focused FilePanel.

# Technical Implementation:
- A global Variable keeps track of the last Panels selected location.
- Changing focus between panels updates that variable to the location of the new focused panel.
- Changing directories also updates the variable to the newly selected directory.
- the `newFilePanel` Function then references that variable, instead of `variable.HomeDir`

# Demo
this video show the whole thing in action.

https://github.com/user-attachments/assets/12977ef5-f4f7-43b2-bd9f-416eb95b1089

