### PR TITLE
feat: open FilePanel to a specific path. (#443)

### DIFF
--- a/src/internal/config_function.go
+++ b/src/internal/config_function.go
@@ -89,6 +89,7 @@ func initialConfig(dir string) (toggleDotFileBool bool, toggleFooter bool, first
 
 	if err != nil {
 		firstFilePanelDir = variable.HomeDir
+		newFilePanelDir = firstFilePanelDir
 	}
 
 	slog.Debug("Runtime information", "runtime.GOOS", runtime.GOOS,

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -238,7 +238,7 @@ func (m *model) enterCommandLine() {
 
 	if err != nil {
 		slog.Error("Command execution failed", "error", err, "output", string(output))
-		fmt.Print("command failed ", output)
+		fmt.Print("command failed (see superfile.log)")
 		time.Sleep(1 * time.Second)
 		return
 	}

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -31,6 +31,7 @@ func (m *model) parentDirectory() {
 	fullPath := panel.location
 	parentDir := filepath.Dir(fullPath)
 	panel.location = parentDir
+	newFilePanelDir = panel.location
 	directoryRecord, hasRecord := panel.directoryRecord[panel.location]
 	if hasRecord {
 		panel.cursor = directoryRecord.directoryCursor
@@ -55,6 +56,7 @@ func (m *model) enterPanel() {
 			directoryRender: panel.render,
 		}
 		panel.location = panel.element[panel.cursor].location
+		newFilePanelDir = panel.location
 		directoryRecord, hasRecord := panel.directoryRecord[panel.location]
 		if hasRecord {
 			panel.cursor = directoryRecord.directoryCursor

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -135,6 +135,8 @@ func (m *model) sidebarSelectDirectory() {
 	}
 
 	panel.location = m.sidebarModel.directories[m.sidebarModel.cursor].location
+	newFilePanelDir = panel.location
+
 	directoryRecord, hasRecord := panel.directoryRecord[panel.location]
 	if hasRecord {
 		panel.cursor = directoryRecord.directoryCursor

--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -60,7 +60,7 @@ func (m *model) createNewFilePanel() {
 	}
 
 	m.fileModel.filePanels = append(m.fileModel.filePanels, filePanel{
-		location:        variable.HomeDir,
+		location:        newFilePanelDir,
 		sortOptions:     m.fileModel.filePanels[m.filePanelFocusIndex].sortOptions,
 		panelMode:       browserMode,
 		focusType:       secondFocus,
@@ -153,6 +153,8 @@ func (m *model) nextFilePanel() {
 	}
 
 	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = returnFocusType(m.focusPanel)
+	newFilePanelDir = m.fileModel.filePanels[m.filePanelFocusIndex].location
+
 }
 
 // Focus on previous file panel
@@ -165,6 +167,7 @@ func (m *model) previousFilePanel() {
 	}
 
 	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = returnFocusType(m.focusPanel)
+	newFilePanelDir = m.fileModel.filePanels[m.filePanelFocusIndex].location
 }
 
 // Focus on sidebar

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -33,9 +33,14 @@ var et *exiftool.Exiftool
 var channel = make(chan channelMessage, 1000)
 var progressBarLastRenderTime time.Time = time.Now()
 
+var newFilePanelDir string = variable.HomeDir
+
 // Initialize and return model with default configs
 func InitialModel(dir string, firstUseCheck, hasTrashCheck bool) model {
+
 	toggleDotFileBool, toggleFooter, firstFilePanelDir := initialConfig(dir)
+	newFilePanelDir = firstFilePanelDir
+
 	firstUse = firstUseCheck
 	hasTrash = hasTrashCheck
 	batCmd = checkBatCmd()


### PR DESCRIPTION
# Relations:
Issue / Feature Request: https://github.com/yorukot/superfile/issues/443
extends PR: https://github.com/yorukot/superfile/pull/732

# Problems:
Next to the above mentioned PR, this Pull-Request here solves 3 Problems.
1. ) Calling `spf` via the `command mode` does nothing but freeze.
2. ) There is no way to open a specific file path as a FilePanel yet (https://github.com/yorukot/superfile/issues/443)
3. ) If a command failes, there is no immediate feedback for the user.

# Solution:
- Make the `spf` command open a new FilePanel, when used inside `spf` itself.
- Provide at least some direct feedback, that a command has failed

# Technical implementation
- if a `spf [filepath]` is send, the `spf` is replaced through `echo`.
That way, we can let the Terminal parse the given Path.
- The returned Path is then validated and checked for it's existence.
- if it exists, a new FilePanel showing that Path is opened. (using the new functionality from PR: https://github.com/yorukot/superfile/pull/732)

# Demo

https://github.com/user-attachments/assets/389f14c8-2a6e-487c-a615-6f0687df0fb9

