### PR TITLE
Golangci lint fixes - 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -352,8 +352,7 @@ linters:
     - unparam # reports unused function parameters
     - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
     - usetesting # reports uses of functions with replacement inside the testing package
-    # Todo enable - many required fixes
-    # - wastedassign # finds wasted assignment statements
+    - wastedassign # finds wasted assignment statements
     # Todo enable - many fixes
     # - whitespace # detects leading and trailing whitespace
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -324,7 +324,7 @@ linters:
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
     - noctx # finds sending http request without context.Context
     # Todo enable : Needs some fixes
-    # - nolintlint # reports ill-formed or insufficient nolint directives
+    - nolintlint # reports ill-formed or insufficient nolint directives
     # Todo enable - maybe too strict for us
     # - nonamedreturns # reports all named returns
     - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -281,8 +281,7 @@ linters:
     - exhaustive # checks exhaustiveness of enum switch statements
     - exptostd # detects functions from golang.org/x/exp/ that can be replaced by std functions
     - fatcontext # detects nested contexts in loops
-    # Not needed. this blocks only fmt.Print family and is not useful right now
-    # - forbidigo # forbids identifiers
+    # - forbidigo # forbids identifiers # Not needed. this blocks only fmt.Print family and is not useful right now
     # Todo enable - need to make functions shorter
     #- funlen # tool for detection of long functions
     - gocheckcompilerdirectives # validates go compiler directive comments (//go:)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -395,7 +395,7 @@ linters:
     # - err113 # [too strict] checks the errors handling expressions
     # - errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
     # - forcetypeassert # [replaced by errcheck] finds forced type assertions
-    # Todo : rely on this, and skip seperate go fmt check in cicd
+    # Todo : rely on this, and skip separate go fmt check in cicd
     # - gofmt # [replaced by goimports] checks whether code was gofmt-ed
     # Todo : Check this
     #- gofumpt # [replaced by goimports, gofumports is not available yet] checks whether code was gofumpt-ed
@@ -404,8 +404,7 @@ linters:
     - grouper # analyzes expression groups
     - importas # enforces consistent import aliases
     - maintidx # measures the maintainability index of each function
-    # Todo - might enable this. This is not so bad
-    # - misspell # [useless] finds commonly misspelled English words in comments
+    - misspell # [useless] finds commonly misspelled English words in comments
     # - nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
     # Todo : might make tests parallel
     #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -278,11 +278,10 @@ linters:
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
     # Todo enable
     #- errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
-    # Todo enable - Need on small fix
-    #- exhaustive # checks exhaustiveness of enum switch statements
+    - exhaustive # checks exhaustiveness of enum switch statements
     - exptostd # detects functions from golang.org/x/exp/ that can be replaced by std functions
     - fatcontext # detects nested contexts in loops
-    # Todo enable - no . this blocks only fmt.Print family and is not useful right now
+    # Not needed. this blocks only fmt.Print family and is not useful right now
     # - forbidigo # forbids identifiers
     # Todo enable - need to make functions shorter
     #- funlen # tool for detection of long functions

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -299,7 +299,6 @@ linters:
     #- gocyclo # computes and checks the cyclomatic complexity of functions
     # Todo enable - too much for us
     #- godot # checks if comments end in a period
-    # Todo enable - one small fix
     - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
     - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - goprintffuncname # checks that printf-like functions are named with f at the end
@@ -323,8 +322,7 @@ linters:
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
     - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
-    # Todo enable : Need to fix one client.Get usage
-    # - noctx # finds sending http request without context.Context
+    - noctx # finds sending http request without context.Context
     # Todo enable : Needs some fixes
     # - nolintlint # reports ill-formed or insufficient nolint directives
     # Todo enable - maybe too strict for us

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -292,8 +292,7 @@ linters:
     - gochecksumtype # checks exhaustiveness on Go "sum types"
     # Todo enable - Need to refactor many functions
     # - gocognit # computes and checks the cognitive complexity of functions
-    # Todo enable - Need a few changes - easy
-    # - goconst # finds repeated strings that could be replaced by a constant
+    - goconst # finds repeated strings that could be replaced by a constant
     # Todo enable - Some few changes. There are good suggestions
     # - gocritic # provides diagnostics that check for bugs, performance and style issues
     # Todo enable

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -330,8 +330,7 @@ linters:
     # Todo enable - maybe too strict for us
     # - nonamedreturns # reports all named returns
     - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
-    # Todo enable : One small fix
-    # - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
+    - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
     - predeclared # finds code that shadows one of Go's predeclared identifiers
     - promlinter # checks Prometheus metrics naming via promlint
     - protogetter # reports direct reads from proto message fields when getters should be used
@@ -354,8 +353,7 @@ linters:
     # Todo enable - Might be too strict for us
     # - testpackage # makes you use a separate _test package
     - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
-    # Todo enable - One small change. Good find.
-    # - unconvert # removes unnecessary type conversions
+    - unconvert # removes unnecessary type conversions
     - unparam # reports unused function parameters
     - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
     - usetesting # reports uses of functions with replacement inside the testing package

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -300,7 +300,7 @@ linters:
     # Todo enable - too much for us
     #- godot # checks if comments end in a period
     # Todo enable - one small fix
-    #- goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
+    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
     - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - goprintffuncname # checks that printf-like functions are named with f at the end
     # Todo enable - ignore for a few int overflow, and fix file permissions

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -323,7 +323,6 @@ linters:
     - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
     - noctx # finds sending http request without context.Context
-    # Todo enable : Needs some fixes
     - nolintlint # reports ill-formed or insufficient nolint directives
     # Todo enable - maybe too strict for us
     # - nonamedreturns # reports all named returns
@@ -346,8 +345,7 @@ linters:
     # Todo enable : Many changes, but good changes.
     # - stylecheck # is a replacement for golint
     - testableexamples # checks if examples are testable (have an expected output)
-    # Todo enable - some test bugs. To be fixed
-    # - testifylint # checks usage of github.com/stretchr/testify
+    - testifylint # checks usage of github.com/stretchr/testify
     # Todo enable - Might be too strict for us
     # - testpackage # makes you use a separate _test package
     - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"embed"
+
 	"github.com/yorukot/superfile/src/cmd"
 )
 

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -4,8 +4,6 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"github.com/yorukot/superfile/src/internal/common"
-	"github.com/yorukot/superfile/src/internal/common/utils"
 	"io"
 	"log"
 	"log/slog"
@@ -13,6 +11,9 @@ import (
 	"os"
 	"runtime"
 	"time"
+
+	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/common/utils"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -97,7 +97,7 @@ func Run(content embed.FS) {
 			// Validate the config file exists
 			if configFileArg != "" {
 				if _, err := os.Stat(configFileArg); err != nil {
-					log.Fatalf("Error: While reading config file '%s' from arguement : %v", configFileArg, err)
+					log.Fatalf("Error: While reading config file '%s' from argument : %v", configFileArg, err)
 				} else {
 					variable.ConfigFile = configFileArg
 				}
@@ -107,7 +107,7 @@ func Run(content embed.FS) {
 
 			if hotkeyFileArg != "" {
 				if _, err := os.Stat(hotkeyFileArg); err != nil {
-					log.Fatalf("Error: While reading hotkey file '%s' from arguement : %v", hotkeyFileArg, err)
+					log.Fatalf("Error: While reading hotkey file '%s' from argument : %v", hotkeyFileArg, err)
 				} else {
 					variable.HotkeysFile = hotkeyFileArg
 				}

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -187,7 +187,7 @@ func InitConfigFile() {
 // We are initializing these, but not sure if we are ever using them
 func InitTrash() error {
 	// Create trash directories
-	if runtime.GOOS != "darwin" {
+	if runtime.GOOS != variable.OS_DARWIN {
 		err := createDirectories(
 			variable.CustomTrashDirectory,
 			variable.CustomTrashDirectoryFiles,

--- a/src/config/fixed_variable.go
+++ b/src/config/fixed_variable.go
@@ -17,6 +17,9 @@ const (
 	EmbedHotkeysFile         string = EmbedConfigDir + "/hotkeys.toml"
 	EmbedThemeDir            string = EmbedConfigDir + "/theme"
 	EmbedThemeCatppuccinFile string = EmbedThemeDir + "/catppuccin.toml"
+
+	OS_WINDOWS = "windows"
+	OS_DARWIN  = "darwin"
 )
 
 var (

--- a/src/config/fixed_variable.go
+++ b/src/config/fixed_variable.go
@@ -18,8 +18,11 @@ const (
 	EmbedThemeDir            string = EmbedConfigDir + "/theme"
 	EmbedThemeCatppuccinFile string = EmbedThemeDir + "/catppuccin.toml"
 
+	// These are used while comparing with runtime.GOOS
+	// OS_WINDOWS represents the Windows operating system identifier
 	OS_WINDOWS = "windows"
-	OS_DARWIN  = "darwin"
+	// OS_DARWIN represents the macOS (Darwin) operating system identifier
+	OS_DARWIN = "darwin"
 )
 
 var (

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -180,7 +180,6 @@ func WriteThemeFiles(content embed.FS) error {
 			continue
 		}
 		// This will not break in windows. This is a relative path for Embed FS. It uses "/" only
-		// nolint:govet // Suppress err shadowing
 		src, err := content.ReadFile(variable.EmbedThemeDir + "/" + file.Name())
 		if err != nil {
 			slog.Error("Error reading theme file from embed", "error", err)

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -1,10 +1,11 @@
 package common
 
 import (
+	"time"
+
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/exp/term/ansi"
 	"github.com/yorukot/superfile/src/config/icon"
-	"time"
 )
 
 const WheelRunTime = 5

--- a/src/internal/common/utils/bool_file_store.go
+++ b/src/internal/common/utils/bool_file_store.go
@@ -17,6 +17,9 @@ func ReadBoolFile(path string, defaultValue bool) bool {
 	}
 
 	// Not using strconv.ParseBool() as it allows other values like : "TRUE"
+	// Using exact string comparison with predefined constants ensures
+	// consistent behavior and prevents issues with case-insensitivity or
+	// unexpected values like "yes", "on", etc. that ParseBool would accept
 	switch string(data) {
 	case TRUE_STRING:
 		return true

--- a/src/internal/common/utils/bool_file_store.go
+++ b/src/internal/common/utils/bool_file_store.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+)
+
+// This file provides utilities for storing boolean values in a file
+
+// Read file with "true" / "false" as content. In case of issues, return defaultValue
+func ReadBoolFile(path string, defaultValue bool) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		slog.Error("Error in readBoolFile", "path", path, "error", err)
+		return defaultValue
+	}
+
+	// Not using strconv.ParseBool() as it allows other values like : "TRUE"
+	switch string(data) {
+	case TRUE_STRING:
+		return true
+	case FALSE_STRING:
+		return false
+	default:
+		return defaultValue
+	}
+}
+
+func WriteBoolFile(path string, value bool) error {
+	return os.WriteFile(path, []byte(strconv.FormatBool(value)), 0644)
+
+}

--- a/src/internal/common/utils/bool_file_store_test.go
+++ b/src/internal/common/utils/bool_file_store_test.go
@@ -1,0 +1,213 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	variable "github.com/yorukot/superfile/src/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadBoolFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name         string
+		fileContent  string
+		defaultValue bool
+		createFile   bool
+		expected     bool
+	}{
+		{
+			name:         "file contains true",
+			fileContent:  TRUE_STRING,
+			defaultValue: false,
+			createFile:   true,
+			expected:     true,
+		},
+		{
+			name:         "file contains false",
+			fileContent:  FALSE_STRING,
+			defaultValue: true,
+			createFile:   true,
+			expected:     false,
+		},
+		{
+			name:         "file contains invalid value",
+			fileContent:  "invalid",
+			defaultValue: true,
+			createFile:   true,
+			expected:     true,
+		},
+		{
+			name:         "file contains invalid value with default false",
+			fileContent:  "invalid",
+			defaultValue: false,
+			createFile:   true,
+			expected:     false,
+		},
+		{
+			name:         "file contains TRUE (uppercase)",
+			fileContent:  "TRUE",
+			defaultValue: false,
+			createFile:   true,
+			expected:     false, // Should not accept uppercase
+		},
+		{
+			name:         "file contains empty string",
+			fileContent:  "",
+			defaultValue: true,
+			createFile:   true,
+			expected:     true,
+		},
+		{
+			name:         "file does not exist - default true",
+			fileContent:  "",
+			defaultValue: true,
+			createFile:   false,
+			expected:     true,
+		},
+		{
+			name:         "file does not exist - default false",
+			fileContent:  "",
+			defaultValue: false,
+			createFile:   false,
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a unique file path for each test
+			filePath := filepath.Join(tempDir, tt.name+".txt")
+
+			// Create and write to the file if needed
+			if tt.createFile {
+				err := os.WriteFile(filePath, []byte(tt.fileContent), 0644)
+				require.NoError(t, err)
+			}
+
+			// Call the function
+			result := ReadBoolFile(filePath, tt.defaultValue)
+
+			// Assert the result
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestWriteBoolFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name  string
+		value bool
+	}{
+		{
+			name:  "write true value",
+			value: true,
+		},
+		{
+			name:  "write false value",
+			value: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a unique file path for each test
+			filePath := filepath.Join(tempDir, tt.name+".txt")
+
+			// Call the function
+			err := WriteBoolFile(filePath, tt.value)
+			require.NoError(t, err)
+
+			// Verify file content
+			content, err := os.ReadFile(filePath)
+			require.NoError(t, err)
+
+			expected := FALSE_STRING
+			if tt.value {
+				expected = TRUE_STRING
+			}
+
+			assert.Equal(t, expected, string(content))
+
+			// Verify permissions (Unix only)
+			if runtime.GOOS != variable.OS_WINDOWS {
+				info, err := os.Stat(filePath)
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(0644), info.Mode().Perm())
+			}
+		})
+	}
+}
+
+func TestWriteBoolFileError(t *testing.T) {
+	tempDir := t.TempDir()
+	nonExistentDir := filepath.Join(tempDir, "non_existent_dir", "file.txt")
+
+	err := WriteBoolFile(nonExistentDir, true)
+	assert.Error(t, err)
+}
+
+func TestReadBoolFilePermissionDenied(t *testing.T) {
+	// Skip on Windows as permission handling differs
+	if runtime.GOOS == variable.OS_WINDOWS {
+		t.Skip("Skipping permission test on Windows")
+	}
+
+	tempDir := t.TempDir()
+
+	// Create a file
+	filePath := filepath.Join(tempDir, "no_read_perm.txt")
+	err := os.WriteFile(filePath, []byte(TRUE_STRING), 0644)
+	require.NoError(t, err)
+
+	// Remove read permissions
+	err = os.Chmod(filePath, 0)
+	require.NoError(t, err)
+	defer os.Chmod(filePath, 0644) // Reset permissions for cleanup
+
+	// The function should return the default value when it can't read the file
+	result := ReadBoolFile(filePath, false)
+	assert.False(t, result)
+
+	result = ReadBoolFile(filePath, true)
+	assert.True(t, result)
+}
+
+func TestWriteBoolFilePermissionDenied(t *testing.T) {
+	// Skip on Windows as permission handling differs
+	if runtime.GOOS == variable.OS_WINDOWS {
+		t.Skip("Skipping permission test on Windows")
+	}
+
+	tempDir := t.TempDir()
+
+	// Make the directory read-only
+	err := os.Chmod(tempDir, 0500)
+	require.NoError(t, err)
+	defer os.Chmod(tempDir, 0700) // Reset permissions for cleanup
+
+	filePath := filepath.Join(tempDir, "readonly.txt")
+	err = WriteBoolFile(filePath, true)
+	assert.Error(t, err)
+}
+
+func TestReadBoolFile_CornerCases(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Test with a directory instead of a file
+	dirPath := filepath.Join(tempDir, "directory")
+	err := os.Mkdir(dirPath, 0755)
+	require.NoError(t, err)
+
+	// Should return the default value when path is a directory
+	result := ReadBoolFile(dirPath, true)
+	assert.True(t, result)
+}

--- a/src/internal/common/utils/consts.go
+++ b/src/internal/common/utils/consts.go
@@ -1,0 +1,6 @@
+package utils
+
+const (
+	TRUE_STRING  = "true"
+	FALSE_STRING = "false"
+)

--- a/src/internal/common/utils/file_utils.go
+++ b/src/internal/common/utils/file_utils.go
@@ -1,9 +1,12 @@
 package utils
 
-import "os"
-import "fmt"
-import "github.com/pelletier/go-toml/v2"
-import "reflect"
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/pelletier/go-toml/v2"
+)
 
 // Utility functions related to file operations
 

--- a/src/internal/common/utils/log_utils.go
+++ b/src/internal/common/utils/log_utils.go
@@ -1,7 +1,9 @@
 package utils
 
-import "log/slog"
-import "os"
+import (
+	"log/slog"
+	"os"
+)
 
 // Todo : Eventually we want to remove all such usage that can result in app exiting abruptly
 func LogAndExit(msg string, values ...any) {

--- a/src/internal/common/utils/shell_utils.go
+++ b/src/internal/common/utils/shell_utils.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	variable "github.com/yorukot/superfile/src/config"
 	"log/slog"
 	"os/exec"
 	"runtime"
 	"time"
+
+	variable "github.com/yorukot/superfile/src/config"
 )
 
 // Choose correct shell as per OS

--- a/src/internal/common/utils/shell_utils.go
+++ b/src/internal/common/utils/shell_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	variable "github.com/yorukot/superfile/src/config"
 	"log/slog"
 	"os/exec"
 	"runtime"
@@ -16,7 +17,7 @@ func ExecuteCommandInShell(timeLimit time.Duration, cmdDir string, shellCommand 
 	baseCmd := "/bin/sh"
 	args := []string{"-c", shellCommand}
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == variable.OS_WINDOWS {
 		baseCmd = "powershell.exe"
 		args[0] = "-Command"
 	}

--- a/src/internal/common/utils/ui_utils.go
+++ b/src/internal/common/utils/ui_utils.go
@@ -8,8 +8,8 @@ func FooterWidth(fullWidth int) int {
 }
 
 // Including borders
-func FullFooterHeight(footerHeight int, toogleFooter bool) int {
-	if toogleFooter {
+func FullFooterHeight(footerHeight int, toggleFooter bool) int {
+	if toggleFooter {
 		return footerHeight + 2
 	}
 	return 0

--- a/src/internal/common/utils/ui_utils.go
+++ b/src/internal/common/utils/ui_utils.go
@@ -6,3 +6,11 @@ package utils
 func FooterWidth(fullWidth int) int {
 	return fullWidth/3 - 2
 }
+
+// Including borders
+func FullFooterHeight(footerHeight int, toogleFooter bool) int {
+	if toogleFooter {
+		return footerHeight + 2
+	}
+	return 0
+}

--- a/src/internal/config_function.go
+++ b/src/internal/config_function.go
@@ -1,12 +1,13 @@
 package internal
 
 import (
-	"github.com/yorukot/superfile/src/internal/common/utils"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/yorukot/superfile/src/internal/common/utils"
 
 	"github.com/barasher/go-exiftool"
 	variable "github.com/yorukot/superfile/src/config"

--- a/src/internal/config_function.go
+++ b/src/internal/config_function.go
@@ -16,7 +16,7 @@ import (
 
 // initialConfig load and handle all configuration files (spf config,Hotkeys
 // themes) setted up. Returns absolute path of dir pointing to the file Panel
-func initialConfig(dir string) (toggleDotFileBool bool, toggleFooter bool, firstFilePanelDir string) {
+func initialConfig(dir string) (toggleDotFile bool, toggleFooter bool, firstFilePanelDir string) {
 	// Open log stream
 	file, err := os.OpenFile(variable.LogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 
@@ -43,29 +43,9 @@ func initialConfig(dir string) (toggleDotFileBool bool, toggleFooter bool, first
 
 	icon.InitIcon(common.Config.Nerdfont, common.Theme.DirectoryIconColor)
 
-	toggleDotFileData, err := os.ReadFile(variable.ToggleDotFile)
-	if err != nil {
-		slog.Error("Error while reading toggleDotFile data error:", "error", err)
-	}
-	if string(toggleDotFileData) == "true" {
-		toggleDotFileBool = true
-	} else if string(toggleDotFileData) == "false" {
-		toggleDotFileBool = false
-	} else {
-		toggleDotFileBool = false
-	}
+	toggleDotFile = utils.ReadBoolFile(variable.ToggleDotFile, false)
 
-	toggleFooterData, err := os.ReadFile(variable.ToggleFooter)
-	if err != nil {
-		slog.Error("Error while reading toggleFooter data error:", "error", err)
-	}
-	if string(toggleFooterData) == "true" {
-		toggleFooter = true
-	} else if string(toggleFooterData) == "false" {
-		toggleFooter = false
-	} else {
-		toggleFooter = true
-	}
+	toggleFooter = utils.ReadBoolFile(variable.ToggleFooter, true)
 
 	common.LoadThemeConfig()
 	common.LoadPrerenderedVariables()
@@ -91,5 +71,5 @@ func initialConfig(dir string) (toggleDotFileBool bool, toggleFooter bool, first
 	slog.Debug("Runtime information", "runtime.GOOS", runtime.GOOS,
 		"start directory", firstFilePanelDir)
 
-	return toggleDotFileBool, toggleFooter, firstFilePanelDir
+	return toggleDotFile, toggleFooter, firstFilePanelDir
 }

--- a/src/internal/default_config.go
+++ b/src/internal/default_config.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Generate and return model containing default configurations for interface
-func defaultModelConfig(toggleDotFileBool bool, toggleFooter bool, firstFilePanelDir string) model {
+func defaultModelConfig(toggleDotFile bool, toggleFooter bool, firstFilePanelDir string) model {
 	return model{
 		filePanelFocusIndex: 0,
 		focusPanel:          nonePanelFocus,
@@ -57,7 +57,7 @@ func defaultModelConfig(toggleDotFileBool bool, toggleFooter bool, firstFilePane
 			open:        false,
 		},
 		promptModal:   prompt.DefaultModel(),
-		toggleDotFile: toggleDotFileBool,
+		toggleDotFile: toggleDotFile,
 		toggleFooter:  toggleFooter,
 	}
 }

--- a/src/internal/file_operations.go
+++ b/src/internal/file_operations.go
@@ -28,7 +28,7 @@ func isSamePartition(path1, path2 string) (bool, error) {
 		return false, fmt.Errorf("failed to get absolute path of the second path: %v", err)
 	}
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == variable.OS_WINDOWS {
 		// On Windows, we can check if both paths are on the same drive (same letter)
 		drive1 := getDriveLetter(absPath1)
 		drive2 := getDriveLetter(absPath2)
@@ -145,9 +145,9 @@ func copyFile(src, dst string, srcInfo os.FileInfo) error {
 // Move file to trash can and can auto switch macos trash can or linux trash can
 func trashMacOrLinux(src string) error {
 	var err error
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == variable.OS_DARWIN {
 		err = moveElement(src, filepath.Join(variable.DarwinTrashDirectory, filepath.Base(src)))
-	} else if runtime.GOOS == "windows" {
+	} else if runtime.GOOS == variable.OS_WINDOWS {
 		err = trash_win.Throw(src)
 	} else {
 		err = trash.Trash(src)

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -4,8 +4,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yorukot/superfile/src/internal/common"
 	"io"
 	"log/slog"
 	"os"
@@ -17,6 +15,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	variable "github.com/yorukot/superfile/src/config"
+	"github.com/yorukot/superfile/src/internal/common"
 
 	"github.com/lithammer/shortuuid"
 	"github.com/reinhrst/fzf-lib"
@@ -34,7 +36,7 @@ func isExternalDiskPath(path string) bool {
 	// This is very vague. You cannot tell if a path is belonging to an external partition
 	// if you dont define the source path to compare with
 	// But making this true will cause slow file operations based on current implementation
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == variable.OS_WINDOWS {
 		return false
 	}
 
@@ -51,7 +53,7 @@ func isExternalDiskPath(path string) bool {
 }
 
 func shouldListDisk(mountPoint string) bool {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == variable.OS_WINDOWS {
 		// We need to get C:, D: drive etc in the list
 		return true
 	}
@@ -88,7 +90,7 @@ func diskName(mountPoint string) string {
 	// In windows we dont want to use filepath.Base as it returns "\" for when
 	// mountPoint is any drive root "C:", "D:", etc. Hence causing same name
 	// for each drive
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == variable.OS_WINDOWS {
 		return mountPoint
 	}
 
@@ -101,7 +103,7 @@ func diskName(mountPoint string) string {
 func diskLocation(mountPoint string) string {
 	// In windows if you are in "C:\some\path", "cd C:" will not cd to root of C: drive
 	// but "cd C:\" will
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == variable.OS_WINDOWS {
 		return filepath.Join(mountPoint, "\\")
 	}
 	return mountPoint

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -588,7 +588,7 @@ func getElementIcon(file string, IsDir bool) icon.IconStyle {
 }
 
 // TeaUpdate : Utility to send update to model , majorly used in tests
-// Not using pointer reciever as this is more like a utility, than
+// Not using pointer receiver as this is more like a utility, than
 // a member function of model
 func TeaUpdate(m *model, msg tea.Msg) (tea.Cmd, error) {
 	resModel, cmd := m.Update(msg)

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"github.com/yorukot/superfile/src/internal/common"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -11,6 +10,9 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	variable "github.com/yorukot/superfile/src/config"
+	"github.com/yorukot/superfile/src/internal/common"
 
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/progress"
@@ -576,9 +578,8 @@ func (m *model) openFileWithEditor() tea.Cmd {
 	}
 
 	// Make sure there is an editor
-	// Todo : Move hardcoded strings to constants : "windows", and editors
 	if editor == "" {
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == variable.OS_WINDOWS {
 			editor = "notepad"
 		} else {
 			editor = "nano"
@@ -599,13 +600,12 @@ func (m *model) openFileWithEditor() tea.Cmd {
 
 // Open directory with default editor
 func (m *model) openDirectoryWithEditor() tea.Cmd {
-	// Todo : Move hardcoded strings to constants : "windows", and editors
 	editor := common.Config.DirEditor
 
 	if editor == "" {
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == variable.OS_WINDOWS {
 			editor = "explorer"
-		} else if runtime.GOOS == "darwin" {
+		} else if runtime.GOOS == variable.OS_DARWIN {
 			// open is command for MacOS Finder
 			editor = "open"
 		} else {

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -228,7 +228,7 @@ func (m *model) deleteMultipleItems() {
 		}
 	}
 
-	// This feels a bit fuzzy and unclean. Todo : Review and simplifiy this.
+	// This feels a bit fuzzy and unclean. Todo : Review and simplify this.
 	// We should never get to this condition of panel.cursor getting negative
 	// and if we do, we should error log that.
 	if panel.cursor >= len(panel.element)-len(panel.selected)-1 {

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"github.com/yorukot/superfile/src/internal/common/utils"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -91,9 +92,9 @@ func (m *model) enterPanel() {
 		}
 
 		openCommand := "xdg-open"
-		if runtime.GOOS == "darwin" {
+		if runtime.GOOS == variable.OS_DARWIN {
 			openCommand = "open"
-		} else if runtime.GOOS == "windows" {
+		} else if runtime.GOOS == variable.OS_WINDOWS {
 
 			dllpath := filepath.Join(os.Getenv("SYSTEMROOT"), "System32", "rundll32.exe")
 			dllfile := "url.dll,FileProtocolHandler"
@@ -172,38 +173,24 @@ func (panel *filePanel) singleItemSelect() {
 
 // Toggle dotfile display or not
 func (m *model) toggleDotFileController() {
-	newToggleDotFile := ""
-	if m.toggleDotFile {
-		newToggleDotFile = "false"
-		m.toggleDotFile = false
-	} else {
-		newToggleDotFile = "true"
-		m.toggleDotFile = true
-	}
+	m.toggleDotFile = !m.toggleDotFile
 	m.updatedToggleDotFile = true
-	err := os.WriteFile(variable.ToggleDotFile, []byte(newToggleDotFile), 0644)
+	err := utils.WriteBoolFile(variable.ToggleDotFile, m.toggleDotFile)
 	if err != nil {
-		slog.Error("Error while pinned folder function updatedData superfile data", "error", err)
+		slog.Error("Error while updating toggleDotFile data", "error", err)
 	}
 
 }
 
 // Toggle dotfile display or not
 func (m *model) toggleFooterController() {
-	newToggleFooterFile := ""
-	if m.toggleFooter {
-		newToggleFooterFile = "false"
-		m.toggleFooter = false
-	} else {
-		newToggleFooterFile = "true"
-		m.toggleFooter = true
-	}
-	err := os.WriteFile(variable.ToggleFooter, []byte(newToggleFooterFile), 0644)
+	m.toggleFooter = !m.toggleFooter
+	err := utils.WriteBoolFile(variable.ToggleFooter, m.toggleFooter)
 	if err != nil {
-		slog.Error("Error while Toggle footer function updatedData superfile data", "error", err)
+		slog.Error("Error while updating toggleFooter data", "error", err)
 	}
+	// Todo : Revisit this. Is this really need here, is this correct ?
 	m.setHeightValues(m.fullHeight)
-
 }
 
 // Focus on search bar

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -1,12 +1,13 @@
 package internal
 
 import (
-	"github.com/yorukot/superfile/src/internal/common/utils"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+
+	"github.com/yorukot/superfile/src/internal/common/utils"
 
 	variable "github.com/yorukot/superfile/src/config"
 )

--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/yorukot/superfile/src/internal/common"
 	"log/slog"
 	"os"
 	"path/filepath"
+
+	"github.com/yorukot/superfile/src/internal/common"
 
 	variable "github.com/yorukot/superfile/src/config"
 )

--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/yorukot/superfile/src/internal/common"
 	"log/slog"
@@ -58,7 +59,7 @@ func (m *model) pinnedDirectory() {
 // Create new file panel
 func (m *model) createNewFilePanel(location string) error {
 	if len(m.fileModel.filePanels) == m.fileModel.maxFilePanel {
-		return fmt.Errorf("maximum panel count reached")
+		return errors.New("maximum panel count reached")
 	}
 
 	if location == "" {

--- a/src/internal/handle_panel_up_down_test.go
+++ b/src/internal/handle_panel_up_down_test.go
@@ -25,14 +25,14 @@ func genProcessBarModel(count int, cursor int, render int) processBarModel {
 }
 
 func Test_cntRenderableProcess(t *testing.T) {
-	assert.Equal(t, cntRenderableProcess(4), 1)
-	assert.Equal(t, cntRenderableProcess(5), 2)
-	assert.Equal(t, cntRenderableProcess(6), 2)
-	assert.Equal(t, cntRenderableProcess(7), 2)
-	assert.Equal(t, cntRenderableProcess(8), 3)
-	assert.Equal(t, cntRenderableProcess(9), 3)
-	assert.Equal(t, cntRenderableProcess(10), 3)
-	assert.Equal(t, cntRenderableProcess(11), 4)
+	assert.Equal(t, 1, cntRenderableProcess(4))
+	assert.Equal(t, 2, cntRenderableProcess(5))
+	assert.Equal(t, 2, cntRenderableProcess(6))
+	assert.Equal(t, 2, cntRenderableProcess(7))
+	assert.Equal(t, 3, cntRenderableProcess(8))
+	assert.Equal(t, 3, cntRenderableProcess(9))
+	assert.Equal(t, 3, cntRenderableProcess(10))
+	assert.Equal(t, 4, cntRenderableProcess(11))
 }
 
 func Test_processBarModelUpDown(t *testing.T) {

--- a/src/internal/handle_pinned_operations.go
+++ b/src/internal/handle_pinned_operations.go
@@ -2,9 +2,10 @@ package internal
 
 import (
 	"encoding/json"
-	"github.com/yorukot/superfile/src/internal/common"
 	"log/slog"
 	"os"
+
+	"github.com/yorukot/superfile/src/internal/common"
 
 	variable "github.com/yorukot/superfile/src/config"
 )

--- a/src/internal/internal_consts.go
+++ b/src/internal/internal_consts.go
@@ -13,3 +13,5 @@ var diskDividerDir = directory{
 
 // superfile logo + blank line + search bar
 const sideBarInitialHeight = 3
+
+const invalidTypeString = "InvalidType"

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -1,9 +1,10 @@
 package internal
 
 import (
-	"github.com/yorukot/superfile/src/internal/common"
 	"log/slog"
 	"slices"
+
+	"github.com/yorukot/superfile/src/internal/common"
 
 	tea "github.com/charmbracelet/bubbletea"
 	variable "github.com/yorukot/superfile/src/config"

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Todo : Replace usage of this with direct slices.Contains call
-// This fucntion is not required
+// This function is not required
 func containsKey(v string, a []string) string {
 	if slices.Contains(a, v) {
 		return v

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -82,7 +82,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.updateFilePanelsState(msg, &cmd)
 
 	if m.sidebarModel.searchBar.Value() != "" {
-		// Todo : All updates of sideBar must be moved to seperate struct functions
+		// Todo : All updates of sideBar must be moved to separate struct functions
 		// we have to keep the state of sidebar consistent, and keep values of
 		// cursor, directories, renderIndex sane for each update, and it has to
 		// take care at one single place, not everywhere we use sideBar
@@ -576,7 +576,7 @@ func (m *model) getFilePanelItems() {
 	m.updatedToggleDotFile = false
 }
 
-// Close superfile application. Cd into the curent dir if CdOnQuit on and save
+// Close superfile application. Cd into the current dir if CdOnQuit on and save
 // the path in state direcotory
 func (m *model) quitSuperfile() {
 	// close exiftool session

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -34,11 +34,11 @@ var progressBarLastRenderTime time.Time = time.Now()
 
 // Initialize and return model with default configs
 func InitialModel(dir string, firstUseCheck, hasTrashCheck bool) model {
-	toggleDotFileBool, toggleFooter, firstFilePanelDir := initialConfig(dir)
+	toggleDotFile, toggleFooter, firstFilePanelDir := initialConfig(dir)
 	firstUse = firstUseCheck
 	hasTrash = hasTrashCheck
 	batCmd = checkBatCmd()
-	return defaultModelConfig(toggleDotFileBool, toggleFooter, firstFilePanelDir)
+	return defaultModelConfig(toggleDotFile, toggleFooter, firstFilePanelDir)
 }
 
 // Init function to be called by Bubble tea framework, sets windows title,
@@ -182,8 +182,8 @@ func (m *model) setHeightValues(height int) {
 	// Todo : Make it grow even more for bigger screen sizes.
 	// Todo : Calculate the value , instead of manually hard coding it.
 
-	// Main panel height = Total terminal height - footer height - 2(footer border) - 2(file panel border)
-	m.mainPanelHeight = height - m.footerHeight - 2 - 2
+	// Main panel height = Total terminal height- 2(file panel border) - footer height
+	m.mainPanelHeight = height - 2 - utils.FullFooterHeight(m.footerHeight, m.toggleFooter)
 }
 
 // Set help menu size
@@ -536,6 +536,8 @@ func (m *model) getFilePanelItems() {
 		nowTime := time.Now()
 		// Check last time each element was updated, if less then 3 seconds ignore
 		if filePanel.focusType == noneFocus && nowTime.Sub(filePanel.lastTimeGetElement) < 3*time.Second {
+			// Todo : revisit this. This feels like a duct tape solution of an actual
+			// deep rooted problem. This feels very hacky.
 			if !m.updatedToggleDotFile {
 				continue
 			}

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -3,8 +3,6 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"github.com/yorukot/superfile/src/internal/common"
-	"github.com/yorukot/superfile/src/internal/common/utils"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -12,6 +10,9 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/common/utils"
 
 	"github.com/barasher/go-exiftool"
 	"github.com/charmbracelet/bubbles/textinput"

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/common/utils"
@@ -329,7 +330,7 @@ func (m *model) applyPromptModalAction(action common.ModelAction) {
 		actionErr = m.createNewFilePanel(action.Location)
 		successMsg = "New panel opened"
 	default:
-		actionErr = fmt.Errorf("unhandled action type")
+		actionErr = errors.New("unhandled action type")
 	}
 
 	if actionErr != nil {
@@ -349,7 +350,7 @@ func (m *model) applyShellCommandAction(shellCommand string) {
 
 	if err != nil {
 		slog.Error("Command execution failed", "retCode", retCode,
-			"error", err, "output", string(output))
+			"error", err, "output", output)
 		return
 	}
 }

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -114,11 +114,14 @@ func (m *model) handleChannelMessage(msg channelMessage) {
 		m.warnModal = msg.warnModal
 	case sendMetadata:
 		m.fileMetaData.metaData = msg.metadata
-	default:
+	case sendProcess:
 		if !arrayContains(m.processBarModel.processList, msg.messageId) {
 			m.processBarModel.processList = append(m.processBarModel.processList, msg.messageId)
 		}
 		m.processBarModel.process[msg.messageId] = msg.processNewState
+	default:
+		slog.Error("Unhandled channelMessageType in handleChannelMessage()",
+			"messageType", msg.messageType)
 	}
 }
 

--- a/src/internal/model_prompt_test.go
+++ b/src/internal/model_prompt_test.go
@@ -10,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/common/utils"
 	"github.com/yorukot/superfile/src/internal/ui/prompt"
@@ -73,18 +74,18 @@ func TestModel_Update_Prompt(t *testing.T) {
 		m := defaultModelConfig(false, false, "/")
 		firstUse = false
 		_, err := TeaUpdate(&m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenCommandLine[0]))
-		assert.Nil(t, err, "Opening the prompt should not produce an error")
+		require.NoError(t, err, "Opening the prompt should not produce an error")
 		assert.True(t, m.promptModal.IsOpen())
 	})
 
 	t.Run("Split Panel", func(t *testing.T) {
 		m := defaultModelConfig(false, false, "/")
 		firstUse = false
-		assert.Equal(t, 1, len(m.fileModel.filePanels))
+		assert.Len(t, m.fileModel.filePanels, 1)
 		_, _ = TeaUpdate(&m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
 		_, _ = TeaUpdate(&m, utils.TeaRuneKeyMsg(prompt.SplitCommand))
 		_, err := TeaUpdate(&m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.Nil(t, err, "Opening the prompt should not produce an error")
-		assert.Equal(t, 2, len(m.fileModel.filePanels))
+		require.NoError(t, err, "Opening the prompt should not produce an error")
+		assert.Len(t, m.fileModel.filePanels, 2)
 	})
 }

--- a/src/internal/model_prompt_test.go
+++ b/src/internal/model_prompt_test.go
@@ -3,15 +3,16 @@ package internal
 import (
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/common/utils"
 	"github.com/yorukot/superfile/src/internal/ui/prompt"
-	"os"
-	"path/filepath"
-	"runtime"
-	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -54,7 +54,7 @@ func (s *sidebarModel) directoriesRender(mainPanelHeight int, curFilePanelFileLo
 	// Cursor should always point to a valid directory at this point
 	if s.isCursorInvalid() {
 		slog.Error("Unexpected situation in sideBar Model. "+
-			"Cursor is at invalid postion, while there are valide directories", "cursor", s.cursor,
+			"Cursor is at invalid position, while there are valide directories", "cursor", s.cursor,
 			"directory count", len(s.directories))
 		return ""
 	}

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/yorukot/superfile/src/internal/common"
-	"github.com/yorukot/superfile/src/internal/common/utils"
 	"image"
 	"log/slog"
 	"os"
@@ -15,6 +13,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/common/utils"
 
 	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/charmbracelet/lipgloss"

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -109,22 +109,22 @@ func (m *model) filePanelRender() string {
 		m.fileModel.filePanels[i] = filePanel
 
 		f[i] += common.FilePanelTopDirectoryIconStyle.Render(" "+icon.Directory+icon.Space) + common.FilePanelTopPathStyle.Render(truncateTextBeginning(filePanel.location, m.fileModel.width-4, "...")) + "\n"
-		filePanelWidth := 0
-		footerBorderWidth := 0
+		var filePanelWidth int
+		footerBorderWidth := m.fileModel.width + 15
 
+		// Todo : Move this to a utility function and clarify the calculation via comments
+		// Maybe even write unit tests
 		if (m.fullWidth-common.Config.SidebarWidth-(4+(len(m.fileModel.filePanels)-1)*2))%len(m.fileModel.filePanels) != 0 && i == len(m.fileModel.filePanels)-1 {
 			if m.fileModel.filePreview.open {
 				filePanelWidth = m.fileModel.width
 			} else {
 				filePanelWidth = (m.fileModel.width + (m.fullWidth-common.Config.SidebarWidth-(4+(len(m.fileModel.filePanels)-1)*2))%len(m.fileModel.filePanels))
 			}
-			footerBorderWidth = m.fileModel.width + 15
 		} else {
 			filePanelWidth = m.fileModel.width
-			footerBorderWidth = m.fileModel.width + 15
 		}
 
-		sortDirectionString := ""
+		var sortDirectionString string
 		if filePanel.sortOptions.data.reversed {
 			if common.Config.Nerdfont {
 				sortDirectionString = icon.SortDesc
@@ -138,7 +138,7 @@ func (m *model) filePanelRender() string {
 				sortDirectionString = "A"
 			}
 		}
-		sortTypeString := ""
+		var sortTypeString string
 		if filePanelWidth < 23 {
 			sortTypeString = sortDirectionString
 		} else {
@@ -284,8 +284,8 @@ func (m *model) processBarRender() string {
 
 		curProcess := processes[i]
 		curProcess.progress.Width = utils.FooterWidth(m.fullWidth) - 3
-		symbol := ""
-		cursor := ""
+		var symbol string
+		var cursor string
 		if i == m.processBarModel.cursor {
 			cursor = common.FooterCursorStyle.Render("┃ ")
 		} else {
@@ -312,9 +312,7 @@ func (m *model) processBarRender() string {
 
 func (m *model) wrapProcessBardBorder(processRender string) string {
 	courseNumber := 0
-	if len(m.processBarModel.processList) == 0 {
-		courseNumber = 0
-	} else {
+	if len(m.processBarModel.processList) != 0 {
 		courseNumber = m.processBarModel.cursor + 1
 	}
 	bottomBorder := common.GenerateFooterBorder(fmt.Sprintf("%s/%s", strconv.Itoa(courseNumber), strconv.Itoa(len(m.processBarModel.processList))), utils.FooterWidth(m.fullWidth)-3)
@@ -415,8 +413,8 @@ func (m *model) clipboardRender() string {
 			}
 		}
 	}
-	bottomWidth := 0
 
+	var bottomWidth int
 	if m.fullWidth%3 != 0 {
 		bottomWidth = utils.FooterWidth(m.fullWidth + m.fullWidth%3 + 2)
 	} else {
@@ -786,7 +784,6 @@ func (m *model) filePreviewPanelRender() string {
 }
 
 func getBatSyntaxHighlightedContent(itemPath string, previewLine int, background string) (string, error) {
-	fileContent := ""
 	// --plain: use the plain style without line numbers and decorations
 	// --force-colorization: force colorization for non-interactive shell output
 	// --line-range <:m>: only read from line 1 to line "m"
@@ -804,7 +801,7 @@ func getBatSyntaxHighlightedContent(itemPath string, previewLine int, background
 		return "", err
 	}
 
-	fileContent = string(fileContentBytes)
+	fileContent := string(fileContentBytes)
 	if !common.Config.TransparentBackground {
 		fileContent = setBatBackground(fileContent, background)
 	}

--- a/src/internal/sidebar.go
+++ b/src/internal/sidebar.go
@@ -80,7 +80,7 @@ func (s *sidebarModel) updateRenderIndex(mainPanelHeight int) {
 
 	curEndIndex := s.lastRenderedIndex(mainPanelHeight, s.renderIndex)
 
-	// Case II : new cursor also comes in range of rendered directores
+	// Case II : new cursor also comes in range of rendered directories
 	// Taking this case later avoid extra lastRenderedIndex() call
 	if s.renderIndex <= s.cursor && s.cursor <= curEndIndex {
 		// no need to update s.renderIndex

--- a/src/internal/sidebar_test.go
+++ b/src/internal/sidebar_test.go
@@ -1,9 +1,10 @@
 package internal
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func dirSlice(count int) []directory {

--- a/src/internal/sidebar_test.go
+++ b/src/internal/sidebar_test.go
@@ -311,7 +311,7 @@ func Test_firstRenderIndex(t *testing.T) {
 			explanation:        "Large panel should show all directories from start",
 		},
 		{
-			name:               "Assymetric sidebar with few directories",
+			name:               "Asymetric sidebar with few directories",
 			sidebar:            sidebar_b,
 			mainPanelHeight:    12,
 			endIndex:           4, // Last disk dir in sidebar_b

--- a/src/internal/string_function.go
+++ b/src/internal/string_function.go
@@ -3,13 +3,14 @@ package internal
 import (
 	"bufio"
 	"fmt"
-	"github.com/yorukot/superfile/src/internal/common"
 	"io"
 	"math"
 	"os"
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/yorukot/superfile/src/internal/common"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/exp/term/ansi"

--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+
 	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/common/utils"
 )

--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/common/utils"
 )
 
 // reset the items slice and set the cut value
@@ -18,8 +19,11 @@ func (m *model) validateLayout() error {
 	if 0 < m.footerHeight && m.footerHeight < common.MinFooterHeight {
 		return fmt.Errorf("footerHeight %v is too small", m.footerHeight)
 	}
+	if !m.toggleFooter && m.footerHeight != 0 {
+		return fmt.Errorf("footer closed and footerHeight %v is non zero", m.footerHeight)
+	}
 	// PanelHeight + 2 lines (main border) + actual footer height
-	if m.fullHeight != (m.mainPanelHeight+2)+(m.footerHeight+2) {
+	if m.fullHeight != (m.mainPanelHeight+2)+utils.FullFooterHeight(m.footerHeight, m.toggleFooter) {
 		return fmt.Errorf("Invalid model layout, fullHeight : %v, mainPanelHeight : %v, footerHeight : %v\n",
 			m.fullHeight, m.mainPanelHeight, m.footerHeight)
 	}
@@ -52,7 +56,7 @@ func (f focusPanelType) String() string {
 	case metadataFocus:
 		return "metadataFocus"
 	default:
-		return "Invalid"
+		return invalidTypeString
 	}
 }
 
@@ -65,8 +69,9 @@ func (f filePanelFocusType) String() string {
 	case focus:
 		return "focus"
 	default:
-		return "Invalid"
+		return invalidTypeString
 	}
+
 }
 
 func (p panelMode) String() string {
@@ -76,6 +81,6 @@ func (p panelMode) String() string {
 	case browserMode:
 		return "browserMode"
 	default:
-		return "Invalid"
+		return invalidTypeString
 	}
 }

--- a/src/internal/ui/prompt/model.go
+++ b/src/internal/ui/prompt/model.go
@@ -2,11 +2,12 @@ package prompt
 
 import (
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yorukot/superfile/src/internal/common"
 	"log/slog"
 	"slices"
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/yorukot/superfile/src/internal/common"
 
 	"github.com/yorukot/superfile/src/config/icon"
 )

--- a/src/internal/ui/prompt/model_test.go
+++ b/src/internal/ui/prompt/model_test.go
@@ -3,12 +3,13 @@ package prompt
 import (
 	"flag"
 	"fmt"
+	"os"
+	"testing"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/common/utils"
-	"os"
-	"testing"
 )
 
 // Initialize the globals we need for testing

--- a/src/internal/ui/prompt/model_test.go
+++ b/src/internal/ui/prompt/model_test.go
@@ -63,7 +63,7 @@ func TestModel_HandleUpdate(t *testing.T) {
 			assert.Equal(t, openAfterEnter, m.IsOpen())
 			assert.Equal(t, common.NoAction{}, action)
 			assert.Equal(t, "", m.resultMsg)
-			assert.Equal(t, true, m.actionSuccess)
+			assert.True(t, m.actionSuccess)
 			assert.True(t, m.validate())
 		}
 
@@ -173,20 +173,20 @@ func TestMode_HandleResults(t *testing.T) {
 
 		// Validate close happens when closeOnSuccess is true
 		assert.True(t, m.actionSuccess)
-		assert.Equal(t, m.resultMsg, "Command exited with status 0")
+		assert.Equal(t, "Command exited with status 0", m.resultMsg)
 		assert.False(t, m.IsOpen())
 
 		m.Open(true)
 		m.HandleShellCommandResults(1, "")
 		assert.False(t, m.actionSuccess)
-		assert.Equal(t, m.resultMsg, "Command exited with status 1")
+		assert.Equal(t, "Command exited with status 1", m.resultMsg)
 		assert.True(t, m.IsOpen())
 
 		m.closeOnSuccess = false
 		m.HandleShellCommandResults(0, "")
 		// Validate that close does not happen when closeOnSuccess is true
 		assert.True(t, m.actionSuccess)
-		assert.Equal(t, m.resultMsg, "Command exited with status 0")
+		assert.Equal(t, "Command exited with status 0", m.resultMsg)
 		assert.True(t, m.IsOpen())
 
 	})

--- a/src/internal/ui/prompt/tokenize.go
+++ b/src/internal/ui/prompt/tokenize.go
@@ -3,11 +3,12 @@ package prompt
 import (
 	"errors"
 	"fmt"
-	"github.com/yorukot/superfile/src/internal/common/utils"
 	"log/slog"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/yorukot/superfile/src/internal/common/utils"
 )
 
 // split into tokens

--- a/src/internal/ui/prompt/tokenize.go
+++ b/src/internal/ui/prompt/tokenize.go
@@ -1,6 +1,7 @@
 package prompt
 
 import (
+	"errors"
 	"fmt"
 	"github.com/yorukot/superfile/src/internal/common/utils"
 	"log/slog"
@@ -32,7 +33,7 @@ func resolveShellSubstitution(subCmdTimeout time.Duration, command string, cwdLo
 				// Look for Ending '}'
 				end := findEndingBracket(cmdRunes, i+1, '{', '}')
 				if end == -1 {
-					return "", fmt.Errorf("unexpected error in tokenization")
+					return "", errors.New("unexpected error in tokenization")
 				}
 				if end == len(cmdRunes) {
 					return "", curlyBracketMatchError()
@@ -56,7 +57,7 @@ func resolveShellSubstitution(subCmdTimeout time.Duration, command string, cwdLo
 				// Look for ending ')'
 				end := findEndingBracket(cmdRunes, i+1, '(', ')')
 				if end == -1 {
-					return "", fmt.Errorf("unexpected error in tokenization")
+					return "", errors.New("unexpected error in tokenization")
 				}
 
 				if end == len(cmdRunes) {

--- a/src/internal/ui/prompt/tokenize_test.go
+++ b/src/internal/ui/prompt/tokenize_test.go
@@ -3,8 +3,9 @@ package prompt
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/src/internal/ui/prompt/tokenize_test.go
+++ b/src/internal/ui/prompt/tokenize_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -171,7 +172,7 @@ func Test_resolveShellSubstitution(t *testing.T) {
 			if err != nil {
 				assert.True(t, tt.isErrorExpected)
 				if tt.errorToMatch != nil {
-					assert.ErrorAs(t, err, &tt.errorToMatch)
+					assert.ErrorIs(t, err, tt.errorToMatch)
 				}
 			}
 		})
@@ -180,8 +181,8 @@ func Test_resolveShellSubstitution(t *testing.T) {
 	t.Run("Testing shell substitution timeout", func(t *testing.T) {
 		result, err := resolveShellSubstitution(shellSubTimeoutInTests, "$(sleep 0.1)", defaultTestCwd)
 		assert.Empty(t, result)
-		assert.NotNil(t, err)
-		assert.ErrorAs(t, err, &context.DeadlineExceeded)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 }
 

--- a/src/internal/ui/prompt/utils.go
+++ b/src/internal/ui/prompt/utils.go
@@ -2,8 +2,9 @@ package prompt
 
 import (
 	"fmt"
-	"github.com/yorukot/superfile/src/internal/common"
 	"strings"
+
+	"github.com/yorukot/superfile/src/internal/common"
 )
 
 func getPromptAction(shellMode bool, value string, cwdLocation string) (common.ModelAction, error) {

--- a/src/internal/ui/prompt/utils_test.go
+++ b/src/internal/ui/prompt/utils_test.go
@@ -1,9 +1,10 @@
 package prompt
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/yorukot/superfile/src/internal/common"
-	"testing"
 )
 
 func TestModel_getPromptAction(t *testing.T) {

--- a/src/internal/wheel_function.go
+++ b/src/internal/wheel_function.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"github.com/yorukot/superfile/src/internal/common"
 	"log/slog"
+
+	"github.com/yorukot/superfile/src/internal/common"
 )
 
 func wheelMainAction(msg string, m *model) {

--- a/src/pkg/file_preview/image_preview.go
+++ b/src/pkg/file_preview/image_preview.go
@@ -1,6 +1,7 @@
 package filepreview
 
 import (
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -153,9 +154,9 @@ func adjustOrientation(img image.Image, orientation int) image.Image {
 
 func hexToColor(hex string) (color.RGBA, error) {
 	if len(hex) != 7 || hex[0] != '#' {
-		return color.RGBA{}, fmt.Errorf("invalid hex color format")
+		return color.RGBA{}, errors.New("invalid hex color format")
 	}
-	values, err := strconv.ParseUint(string(hex[1:]), 16, 32)
+	values, err := strconv.ParseUint(hex[1:], 16, 32)
 	if err != nil {
 		return color.RGBA{}, err
 	}

--- a/testsuite/Notes.md
+++ b/testsuite/Notes.md
@@ -6,7 +6,7 @@
   - If first key is `Ctrl+C`, its always received as `C`
 - Note : You must keep your focus on the terminal for the entire duration of test run. `pyautogui` sends keypress to process on focus.
 
-# Todos
+# To-dos
 - Write testsuite to validate new files getting created on first launch
   - We recently had a bug slip into main, where lastVersionFile would not get written
 

--- a/testsuite/Notes.md
+++ b/testsuite/Notes.md
@@ -6,6 +6,10 @@
   - If first key is `Ctrl+C`, its always received as `C`
 - Note : You must keep your focus on the terminal for the entire duration of test run. `pyautogui` sends keypress to process on focus.
 
+# Todos
+- Write testsuite to validate new files getting created on first launch
+  - We recently had a bug slip into main, where lastVersionFile would not get written
+
 ## Input to spf
 
 ### Pyautogui alternatives


### PR DESCRIPTION
Fixes

```bash

➜  ~/Workspace/kuknitin/superfile git:(golangci_lint_fixes_test) [9:23:36] golangci-lint run
src/internal/model_render.go:112:3: assigned to filePanelWidth, but reassigned without using the value (wastedassign)
		filePanelWidth := 0
		^
src/internal/model_render.go:113:3: assigned to footerBorderWidth, but reassigned without using the value (wastedassign)
		footerBorderWidth := 0
		^
src/internal/model_render.go:127:3: assigned to sortDirectionString, but reassigned without using the value (wastedassign)
		sortDirectionString := ""
		^
src/internal/model_render.go:141:3: assigned to sortTypeString, but reassigned without using the value (wastedassign)
		sortTypeString := ""
		^
src/internal/model_render.go:288:3: assigned to cursor, but reassigned without using the value (wastedassign)
		cursor := ""
		^
src/internal/model_render.go:314:2: assigned to courseNumber, but reassigned without using the value (wastedassign)
	courseNumber := 0
	^
src/internal/model_render.go:418:2: assigned to bottomWidth, but reassigned without using the value (wastedassign)
	bottomWidth := 0
	^
src/internal/model_render.go:789:2: assigned to fileContent, but reassigned without using the value (wastedassign)
	fileContent := ""
	^
➜  ~/Workspace/kuknitin/superfile git:(golangci_lint_fixes_test) ✗ [9:24:14]

```