### PR TITLE
feat: Allow specifying multiple panels at startup

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -84,9 +84,9 @@ func Run(content embed.FS) {
 		},
 		Action: func(c *cli.Context) error {
 			// If no args are called along with "spf" use current dir
-			path := ""
+			firstFilePanelDirs := []string{""}
 			if c.Args().Present() {
-				path = c.Args().First()
+				firstFilePanelDirs = c.Args().Slice()
 			}
 
 			variable.UpdateVarFromCliArgs(c)
@@ -100,7 +100,7 @@ func Run(content embed.FS) {
 
 			firstUse := checkFirstUse()
 
-			p := tea.NewProgram(internal.InitialModel(path, firstUse, hasTrash), tea.WithAltScreen(), tea.WithMouseCellMotion())
+			p := tea.NewProgram(internal.InitialModel(firstFilePanelDirs, firstUse, hasTrash), tea.WithAltScreen(), tea.WithMouseCellMotion())
 			if _, err := p.Run(); err != nil {
 				utils.PrintfAndExit("Alas, there's been an error: %v", err)
 			}

--- a/src/internal/default_config.go
+++ b/src/internal/default_config.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Generate and return model containing default configurations for interface
-func defaultModelConfig(toggleDotFile bool, toggleFooter bool, firstFilePanelDir string) model {
+func defaultModelConfig(toggleDotFile bool, toggleFooter bool, firstFilePanelDirs []string) model {
 	return model{
 		filePanelFocusIndex: 0,
 		focusPanel:          nonePanelFocus,
@@ -23,28 +23,7 @@ func defaultModelConfig(toggleDotFile bool, toggleFooter bool, firstFilePanelDir
 			searchBar:   common.GenerateSearchBar(),
 		},
 		fileModel: fileModel{
-			filePanels: []filePanel{
-				{
-					render:   0,
-					cursor:   0,
-					location: firstFilePanelDir,
-					sortOptions: sortOptionsModel{
-						width:  20,
-						height: 4,
-						open:   false,
-						cursor: common.Config.DefaultSortType,
-						data: sortOptionsModelData{
-							options:  []string{"Name", "Size", "Date Modified"},
-							selected: common.Config.DefaultSortType,
-							reversed: common.Config.SortOrderReversed,
-						},
-					},
-					panelMode:        browserMode,
-					focusType:        focus,
-					directoryRecords: make(map[string]directoryRecord),
-					searchBar:        common.GenerateSearchBar(),
-				},
-			},
+			filePanels: filePanelSlice(firstFilePanelDirs),
 			filePreview: filePreviewPanel{
 				open: common.Config.DefaultOpenFilePreview,
 			},

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -37,12 +37,12 @@ var progressBarLastRenderTime = time.Now()                      //nolint: gochec
 // is passed to tea.NewProgram() which accepts tea.Model
 // Either way type 'model' is not exported, so there is not way main package can
 // be aware of it, and use it directly
-func InitialModel(dir string, firstUseCheck, hasTrashCheck bool) tea.Model {
-	toggleDotFile, toggleFooter, firstFilePanelDir := initialConfig(dir)
+func InitialModel(firstFilePanelDirs []string, firstUseCheck, hasTrashCheck bool) tea.Model {
+	toggleDotFile, toggleFooter := initialConfig(firstFilePanelDirs)
 	firstUse = firstUseCheck
 	hasTrash = hasTrashCheck
 	batCmd = checkBatCmd()
-	return defaultModelConfig(toggleDotFile, toggleFooter, firstFilePanelDir)
+	return defaultModelConfig(toggleDotFile, toggleFooter, firstFilePanelDirs)
 }
 
 // Init function to be called by Bubble tea framework, sets windows title,

--- a/src/internal/model_prompt_test.go
+++ b/src/internal/model_prompt_test.go
@@ -70,7 +70,7 @@ func TestModel_Update_Prompt(t *testing.T) {
 	// too big Shell command output
 
 	t.Run("Basic Prompt Opening", func(t *testing.T) {
-		m := defaultModelConfig(false, false, "/")
+		m := defaultModelConfig(false, false, []string{"/"})
 		firstUse = false
 		_, err := TeaUpdate(&m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenCommandLine[0]))
 		require.NoError(t, err, "Opening the prompt should not produce an error")
@@ -78,7 +78,7 @@ func TestModel_Update_Prompt(t *testing.T) {
 	})
 
 	t.Run("Split Panel", func(t *testing.T) {
-		m := defaultModelConfig(false, false, "/")
+		m := defaultModelConfig(false, false, []string{"/"})
 		firstUse = false
 		assert.Len(t, m.fileModel.filePanels, 1)
 		_, _ = TeaUpdate(&m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))

--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -44,6 +44,39 @@ func (d directory) requiredHeight() int {
 	return 1
 }
 
+// ================ filepanel
+
+func filePanelSlice(dir []string) []filePanel {
+	res := make([]filePanel, len(dir))
+	for i := range dir {
+		res[i] = defaultFilePanel(dir[i])
+	}
+	return res
+}
+
+func defaultFilePanel(dir string) filePanel {
+	return filePanel{
+		render:   0,
+		cursor:   0,
+		location: dir,
+		sortOptions: sortOptionsModel{
+			width:  20,
+			height: 4,
+			open:   false,
+			cursor: common.Config.DefaultSortType,
+			data: sortOptionsModelData{
+				options:  []string{"Name", "Size", "Date Modified"},
+				selected: common.Config.DefaultSortType,
+				reversed: common.Config.SortOrderReversed,
+			},
+		},
+		panelMode:        browserMode,
+		focusType:        focus,
+		directoryRecords: make(map[string]directoryRecord),
+		searchBar:        common.GenerateSearchBar(),
+	}
+}
+
 // ================ String method for easy logging =====================
 
 func (f focusPanelType) String() string {


### PR DESCRIPTION
Fixes 
- #286


Test

```
➜  ~/Workspace/kuknitin/superfile git:(multiple_panel_at_startup) [7:07:36] spft "~" "." "/"
➜  ~/Workspace/kuknitin/superfile git:(multiple_panel_at_startup) [7:11:18]
```

<img width="1147" alt="image" src="https://github.com/user-attachments/assets/3a214f1f-f9b6-417b-96cb-47fc7997c58d" />


Too many panels

```
➜  ~/Workspace/kuknitin/superfile git:(multiple_panel_at_startup) [7:12:41] spft --print-last-dir "~" "." "/" "." "." "."
/Users/kuknitin
➜  ~/Workspace/kuknitin/superfile git:(multiple_panel_at_startup) [7:13:13]
```

<img width="1147" alt="image" src="https://github.com/user-attachments/assets/2ebe508a-1370-4bad-a11a-0d64819a4658" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Now supports specifying multiple starting directories for file panels, offering a broader configuration experience.

- **Refactor**
  - Streamlined initialization and configuration logic to handle a list of directory inputs along with appropriate defaults.

- **Tests**
  - Updated validation to ensure the new multi-directory input is processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->