### PR TITLE
fix: Correctly resolve path in open and cd prompt actions

### DIFF
--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -25,6 +25,7 @@ func (m *model) pinnedDirectory() {
 // Create new file panel
 func (m *model) createNewFilePanel(location string) error {
 	if len(m.fileModel.filePanels) == m.fileModel.maxFilePanel {
+		// Todo : Define as a predefined error in errors.go
 		return errors.New("maximum panel count reached")
 	}
 

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -313,7 +313,7 @@ func (m *model) applyPromptModalAction(action common.ModelAction) {
 		actionErr = m.updateCurrentFilePanelDir(action.Location)
 		successMsg = "Panel directory changed"
 	case common.OpenPanelAction:
-		actionErr = m.createNewFilePanel(action.Location)
+		actionErr = m.createNewFilePanelRelativeToCurrent(action.Location)
 		successMsg = "New panel opened"
 	default:
 		actionErr = errors.New("unhandled action type")
@@ -345,21 +345,23 @@ func (m *model) splitPanel() error {
 	return m.createNewFilePanel(m.fileModel.filePanels[m.filePanelFocusIndex].location)
 }
 
-func (m *model) updateCurrentFilePanelDir(dir string) error {
-	currentPath := m.fileModel.filePanels[m.filePanelFocusIndex].location
-	newPath := dir
-	if !filepath.IsAbs(dir) {
-		// Assume relative path from current
-		newPath = filepath.Join(currentPath, dir)
-	}
+func (m *model) createNewFilePanelRelativeToCurrent(path string) error {
+	currentDir := m.fileModel.filePanels[m.filePanelFocusIndex].location
+	return m.createNewFilePanel(utils.ResolveAbsPath(currentDir, path))
+}
 
-	if info, err := os.Stat(newPath); err != nil {
-		return fmt.Errorf("%s : no such file or directory, stats err : %w", newPath, err)
+// simulates a 'cd' action
+func (m *model) updateCurrentFilePanelDir(path string) error {
+	currentDir := m.fileModel.filePanels[m.filePanelFocusIndex].location
+	path = utils.ResolveAbsPath(currentDir, path)
+
+	if info, err := os.Stat(path); err != nil {
+		return fmt.Errorf("%s : no such file or directory, stats err : %w", path, err)
 	} else if !info.IsDir() {
-		return fmt.Errorf("%s is not a directory", newPath)
+		return fmt.Errorf("%s is not a directory", path)
 	}
 
-	m.fileModel.filePanels[m.filePanelFocusIndex].location = newPath
+	m.fileModel.filePanels[m.filePanelFocusIndex].location = path
 	return nil
 }
 

--- a/src/internal/utils/file_utils.go
+++ b/src/internal/utils/file_utils.go
@@ -3,8 +3,11 @@ package utils
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 
+	"github.com/adrg/xdg"
 	"github.com/pelletier/go-toml/v2"
 )
 
@@ -94,4 +97,19 @@ func LoadTomlFile(filePath string, defaultData string, target interface{}, fixFl
 		PrintfAndExit("Error while writing config file : %v", err)
 	}
 	return false
+}
+
+// If path is not absolute, then append to currentDir and get absolute path
+// Resolve paths starting with "~"
+// currentDir should be an absolute path
+func ResolveAbsPath(currentDir string, path string) string {
+	if strings.HasPrefix(path, "~") {
+		// We dont use variable.HomeDir here, as the util package cannot have dependency
+		// on variable package
+		path = strings.Replace(path, "~", xdg.Home, 1)
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(currentDir, path)
+	}
+	return filepath.Clean(path)
 }

--- a/src/internal/utils/file_utils_test.go
+++ b/src/internal/utils/file_utils_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveAbsPath(t *testing.T) {
+	testdata := []struct {
+		name        string
+		cwd         string
+		path        string
+		expectedRes string
+	}{
+		{
+			name:        "Path cleaup Test 1",
+			cwd:         "/",
+			path:        "////",
+			expectedRes: "/",
+		},
+		{
+			name:        "Basic test",
+			cwd:         "/abc",
+			path:        "def",
+			expectedRes: "/abc/def",
+		},
+		{
+			name:        "Ignore cwd for abs path",
+			cwd:         "/abc",
+			path:        "/def",
+			expectedRes: "/def",
+		},
+		{
+			name:        "Path cleanup Test 2",
+			cwd:         "///abc",
+			path:        "./././def",
+			expectedRes: "/abc/def",
+		},
+		{
+			name:        "Basic test with ~",
+			cwd:         "/",
+			path:        "~",
+			expectedRes: xdg.Home,
+		},
+		{
+			name:        "~ should not be resolved if not first",
+			cwd:         "abc",
+			path:        "x/~",
+			expectedRes: "abc/x/~",
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedRes, ResolveAbsPath(tt.cwd, tt.path))
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling of directory paths and path resolution for file panels, enhancing clarity and consistency when opening or navigating panels.
	- Simplified and unified path normalization and tilde expansion logic.
- **New Features**
	- Introduced a utility for resolving and normalizing file paths, including support for `~` expansion.
- **Bug Fixes**
	- Improved error handling for invalid or inaccessible directories when configuring start directories.
- **Tests**
	- Added tests to verify correct path resolution and normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->