### PR TITLE
fix: create item check for dot-entries

### DIFF
--- a/src/internal/common/style.go
+++ b/src/internal/common/style.go
@@ -49,6 +49,7 @@ var (
 	ModalCancel     lipgloss.Style
 	ModalConfirm    lipgloss.Style
 	ModalTitleStyle lipgloss.Style
+	ModalErrorStyle lipgloss.Style
 )
 
 var (
@@ -204,7 +205,7 @@ func LoadThemeConfig() {
 	ModalCancel = lipgloss.NewStyle().Foreground(modalCancelFGColor).Background(modalCancelBGColor)
 	ModalConfirm = lipgloss.NewStyle().Foreground(modalConfirmFGColor).Background(modalConfirmBGColor)
 	ModalTitleStyle = lipgloss.NewStyle().Foreground(hintColor).Background(ModalBGColor)
-
+	ModalErrorStyle = lipgloss.NewStyle().Foreground(errorColor).Background(ModalBGColor)
 	// Help Menu Style
 	HelpMenuHotkeyStyle = lipgloss.NewStyle().Foreground(helpMenuHotkeyColor).Background(ModalBGColor)
 	HelpMenuTitleStyle = lipgloss.NewStyle().Foreground(helpMenuTitleColor).Background(ModalBGColor)

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -242,14 +242,14 @@ func removeElementByValue(slice []string, value string) []string {
 	return newSlice
 }
 
-func isValidFileName(name string) bool {
+func checkFileNameValidity(name string) error {
 	switch {
 	case name == ".", name == "..":
-		return false
+		return fmt.Errorf("file name cannot be '.' or '..'")
 	case strings.HasSuffix(name, fmt.Sprintf("%c.", filepath.Separator)), strings.HasSuffix(name, fmt.Sprintf("%c..", filepath.Separator)):
-		return false
+		return fmt.Errorf("file name cannot end with '/.' or '/..'")
 	default:
-		return true
+		return nil
 	}
 }
 

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -242,6 +242,17 @@ func removeElementByValue(slice []string, value string) []string {
 	return newSlice
 }
 
+func isValidFileName(name string) bool {
+	switch {
+	case name == ".", name == ".":
+		return false
+	case strings.HasSuffix(name, "/."), strings.HasSuffix(name, "/.."):
+		return false
+	default:
+		return true
+	}
+}
+
 func renameIfDuplicate(destination string) (string, error) {
 	info, err := os.Stat(destination)
 	if os.IsNotExist(err) {

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -245,9 +246,9 @@ func removeElementByValue(slice []string, value string) []string {
 func checkFileNameValidity(name string) error {
 	switch {
 	case name == ".", name == "..":
-		return fmt.Errorf("file name cannot be '.' or '..'")
+		return errors.New("file name cannot be '.' or '..'")
 	case strings.HasSuffix(name, fmt.Sprintf("%c.", filepath.Separator)), strings.HasSuffix(name, fmt.Sprintf("%c..", filepath.Separator)):
-		return fmt.Errorf("file name cannot end with '/.' or '/..'")
+		return fmt.Errorf("file name cannot end with '%c.' or '%c..'", filepath.Separator, filepath.Separator)
 	default:
 		return nil
 	}

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -244,9 +244,9 @@ func removeElementByValue(slice []string, value string) []string {
 
 func isValidFileName(name string) bool {
 	switch {
-	case name == ".", name == ".":
+	case name == ".", name == "..":
 		return false
-	case strings.HasSuffix(name, "/."), strings.HasSuffix(name, "/.."):
+	case strings.HasSuffix(name, fmt.Sprintf("%c.", filepath.Separator)), strings.HasSuffix(name, fmt.Sprintf("%c..", filepath.Separator)):
 		return false
 	default:
 		return true

--- a/src/internal/function_test.go
+++ b/src/internal/function_test.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -168,7 +167,6 @@ func TestReturnDirElement(t *testing.T) {
 }
 
 func TestCheckFileNameValidity(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		input   string
@@ -224,7 +222,7 @@ func TestCheckFileNameValidity(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				assert.True(t, strings.Contains(err.Error(), tt.errMsg))
+				assert.Contains(t, err.Error(), tt.errMsg)
 			}
 		})
 	}

--- a/src/internal/function_test.go
+++ b/src/internal/function_test.go
@@ -183,17 +183,17 @@ func TestCheckFileNameValidity(t *testing.T) {
 			name:    "invalid - double dot",
 			input:   "..",
 			wantErr: true,
-			errMsg:  "file name cnnot be '.' or '..'",
+			errMsg:  "file name cannot be '.' or '..'",
 		}, {
 			name:    "invalid - ends with /.. (platform separator)",
 			input:   fmt.Sprintf("testDir%c..", filepath.Separator),
 			wantErr: true,
-			errMsg:  "file name cannot end with '/.' or '/..'",
+			errMsg:  fmt.Sprintf("file name cannot end with '%c.' or '%c..'", filepath.Separator, filepath.Separator),
 		}, {
 			name:    "invalid - ends with /. (platform separator)",
 			input:   fmt.Sprintf("testDir%c.", filepath.Separator),
 			wantErr: true,
-			errMsg:  "file name cannot end with '/.' or '/..'",
+			errMsg:  fmt.Sprintf("file name cannot end with '%c.' or '%c..'", filepath.Separator, filepath.Separator),
 		}, {
 			name:    "valid - normal file name",
 			input:   "valid_file.txt",
@@ -219,15 +219,13 @@ func TestCheckFileNameValidity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := checkFileNameValidity(tt.input)
-			if (err != nil) != tt.wantErr {
-				if (err != nil) != tt.wantErr {
-					t.Errorf("checkFileNameValidity(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
-				}
-				if err != nil && !strings.Contains(err.Error(), tt.errMsg) {
-					t.Errorf("checkFileNameValidity(%q) error = %q, want to contain %q", tt.input, err.Error(), tt.errMsg)
-				}
+
+			if !tt.wantErr {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), tt.errMsg))
 			}
 		})
 	}
-
 }

--- a/src/internal/function_test.go
+++ b/src/internal/function_test.go
@@ -1,7 +1,9 @@
 package internal
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,4 +165,69 @@ func TestReturnDirElement(t *testing.T) {
 			assert.Equal(t, tt.expectedElemNames, actualNames)
 		})
 	}
+}
+
+func TestCheckFileNameValidity(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "Invalid - single dot",
+			input:   ".",
+			wantErr: true,
+			errMsg:  "file name cannot be '.' or '..'",
+		}, {
+			name:    "invalid - double dot",
+			input:   "..",
+			wantErr: true,
+			errMsg:  "file name cnnot be '.' or '..'",
+		}, {
+			name:    "invalid - ends with /.. (platform separator)",
+			input:   fmt.Sprintf("testDir%c..", filepath.Separator),
+			wantErr: true,
+			errMsg:  "file name cannot end with '/.' or '/..'",
+		}, {
+			name:    "invalid - ends with /. (platform separator)",
+			input:   fmt.Sprintf("testDir%c.", filepath.Separator),
+			wantErr: true,
+			errMsg:  "file name cannot end with '/.' or '/..'",
+		}, {
+			name:    "valid - normal file name",
+			input:   "valid_file.txt",
+			wantErr: false,
+		},
+		{
+			name:    "valid - contains dot inside",
+			input:   "some.folder.name/file.txt",
+			wantErr: false,
+		},
+		{
+			name:    "valid - ends with dot not after separator",
+			input:   "somefile.",
+			wantErr: false,
+		},
+		{
+			name:    "valid - ends with .. not after separator",
+			input:   "somefile..",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkFileNameValidity(tt.input)
+			if (err != nil) != tt.wantErr {
+				if (err != nil) != tt.wantErr {
+					t.Errorf("checkFileNameValidity(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				}
+				if err != nil && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("checkFileNameValidity(%q) error = %q, want to contain %q", tt.input, err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+
 }

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -28,6 +28,7 @@ func (m *model) createItem() {
 	}
 
 	defer func() {
+		m.typingModal.errorMesssage = ""
 		m.typingModal.open = false
 		m.typingModal.textInput.Blur()
 	}()

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -20,15 +20,17 @@ func (m *model) cancelWarnModal() {
 
 // Confirm to create file or directory
 func (m *model) createItem() {
-	// Reset the typingModal in all cases
+
+	if err := checkFileNameValidity(m.typingModal.textInput.Value()); err != nil {
+		m.typingModal.errorMesssage = err.Error()
+		slog.Error("Errow while createItem during item creation", "error", err)
+		return
+	}
+
 	defer func() {
 		m.typingModal.open = false
 		m.typingModal.textInput.Blur()
 	}()
-
-	if isValid := isValidFileName(m.typingModal.textInput.Value()); !isValid {
-		return
-	}
 
 	path := filepath.Join(m.typingModal.location, m.typingModal.textInput.Value())
 	if !strings.HasSuffix(m.typingModal.textInput.Value(), string(filepath.Separator)) {
@@ -44,7 +46,6 @@ func (m *model) createItem() {
 		}
 		defer f.Close()
 	} else {
-		// Directory creation
 		err := os.MkdirAll(path, 0755)
 		if err != nil {
 			slog.Error("Error while createItem during directory creation", "error", err)

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -24,6 +24,7 @@ func (m *model) createItem() {
 	if err := checkFileNameValidity(m.typingModal.textInput.Value()); err != nil {
 		m.typingModal.errorMesssage = err.Error()
 		slog.Error("Errow while createItem during item creation", "error", err)
+
 		return
 	}
 

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -25,6 +25,11 @@ func (m *model) createItem() {
 		m.typingModal.open = false
 		m.typingModal.textInput.Blur()
 	}()
+
+	if isValid := isValidFileName(m.typingModal.textInput.Value()); !isValid {
+		return
+	}
+
 	path := filepath.Join(m.typingModal.location, m.typingModal.textInput.Value())
 	if !strings.HasSuffix(m.typingModal.textInput.Value(), string(filepath.Separator)) {
 		path, _ = renameIfDuplicate(path)

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -20,7 +20,6 @@ func (m *model) cancelWarnModal() {
 
 // Confirm to create file or directory
 func (m *model) createItem() {
-
 	if err := checkFileNameValidity(m.typingModal.textInput.Value()); err != nil {
 		m.typingModal.errorMesssage = err.Error()
 		slog.Error("Errow while createItem during item creation", "error", err)

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -205,6 +205,7 @@ func (m *model) normalAndBrowserModeKey(msg string) {
 func (m *model) typingModalOpenKey(msg string) {
 	switch {
 	case slices.Contains(common.Hotkeys.CancelTyping, msg):
+		m.typingModal.errorMesssage = ""
 		m.cancelTypingModal()
 	case slices.Contains(common.Hotkeys.ConfirmTyping, msg):
 		m.createItem()

--- a/src/internal/model_file_operations_test.go
+++ b/src/internal/model_file_operations_test.go
@@ -36,7 +36,7 @@ func TestCopy(t *testing.T) {
 		// Everything that doesn't have anything to do with copy paste
 
 		// validate file1
-		// Todo : improve the interface we use to interact with filepaneltestChildDir
+		// Todo : improve the interface we use to interact with filepanel
 
 		// Todo : file1.txt should not be duplicated
 
@@ -79,7 +79,8 @@ func TestCopy(t *testing.T) {
 	})
 }
 
-func TestFileNaming(t *testing.T) {
+func TestFileCreation(t *testing.T) {
+	// Todo Also add directory creation test to this
 	curTestDir := filepath.Join(testDir, "TestNaming")
 	testParentDir := filepath.Join(curTestDir, "parentDir")
 	testChildDir := filepath.Join(testParentDir, "childDir")
@@ -99,7 +100,7 @@ func TestFileNaming(t *testing.T) {
 		{"invalid single dot", ".", true},
 		{"invalid double dot", "..", true},
 		{"invalid trailing slash-dot", fmt.Sprintf("test%c.", filepath.Separator), true},
-		{"invalid trailig slash-dot-dot", fmt.Sprintf("test%c..", filepath.Separator), true},
+		{"invalid trailing slash-dot-dot", fmt.Sprintf("test%c..", filepath.Separator), true},
 		{"valid name with trailing .", "abc.", false},
 	}
 
@@ -118,7 +119,8 @@ func TestFileNaming(t *testing.T) {
 		if tt.expectedError {
 			assert.NotEqual(t, "", m.typingModal.errorMesssage, "expected an error for input: %q", tt.fileName)
 		} else {
-			assert.Equal(t, "", m.typingModal.errorMesssage, "did not expect an error for input: %q", tt.fileName)
+			assert.Empty(t, m.typingModal.errorMesssage, "expected an error for input: %q", tt.fileName)
+			assert.FileExists(t, filepath.Join(testChildDir, tt.fileName), "expected file to be created: %q", tt.fileName)
 		}
 	}
 }

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -492,10 +492,10 @@ func (m *model) typineModalRender() string {
 
 	var err string
 	if m.typingModal.errorMesssage != "" {
-		err = common.ModalErrorStyle.Render(m.typingModal.errorMesssage)
+		err = "\n\n" + common.ModalErrorStyle.Render(m.typingModal.errorMesssage)
 	}
-
-	return common.ModalBorderStyle(common.ModalHeight, common.ModalWidth).Render(fileLocation + "\n" + m.typingModal.textInput.View() + "\n\n" + tip + "\n\n" + err + "\n")
+	// Todo : Move this all to rendering package to avoid specifying newlines manually
+	return common.ModalBorderStyle(common.ModalHeight, common.ModalWidth).Render(fileLocation + "\n" + m.typingModal.textInput.View() + "\n\n" + tip + err)
 }
 
 func (m *model) introduceModalRender() string {

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -490,7 +490,13 @@ func (m *model) typineModalRender() string {
 		lipgloss.NewStyle().Background(common.ModalBGColor).Render("           ") +
 		cancel
 
-	return common.ModalBorderStyle(common.ModalHeight, common.ModalWidth).Render(fileLocation + "\n" + m.typingModal.textInput.View() + "\n\n" + tip)
+	var err string
+	if m.typingModal.errorMesssage != "" {
+		err = lipgloss.NewStyle().Foreground(lipgloss.Color("9")).
+			BorderForeground(lipgloss.Color("9")).Render(lipgloss.NewStyle().Border(lipgloss.DoubleBorder()).Width(44).Render(m.typingModal.errorMesssage))
+	}
+
+	return common.ModalBorderStyle(common.ModalHeight, common.ModalWidth).Render(fileLocation + "\n" + m.typingModal.textInput.View() + "\n\n" + tip + "\n\n" + err)
 }
 
 func (m *model) introduceModalRender() string {

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -492,11 +492,10 @@ func (m *model) typineModalRender() string {
 
 	var err string
 	if m.typingModal.errorMesssage != "" {
-		err = lipgloss.NewStyle().Foreground(lipgloss.Color("9")).
-			BorderForeground(lipgloss.Color("9")).Render(lipgloss.NewStyle().Border(lipgloss.DoubleBorder()).Width(44).Render(m.typingModal.errorMesssage))
+		err = common.ModalErrorStyle.Render(m.typingModal.errorMesssage)
 	}
 
-	return common.ModalBorderStyle(common.ModalHeight, common.ModalWidth).Render(fileLocation + "\n" + m.typingModal.textInput.View() + "\n\n" + tip + "\n\n" + err)
+	return common.ModalBorderStyle(common.ModalHeight, common.ModalWidth).Render(fileLocation + "\n" + m.typingModal.textInput.View() + "\n\n" + tip + "\n\n" + err + "\n")
 }
 
 func (m *model) introduceModalRender() string {

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -145,9 +145,10 @@ type warnModal struct {
 }
 
 type typingModal struct {
-	location  string
-	open      bool
-	textInput textinput.Model
+	location      string
+	open          bool
+	textInput     textinput.Model
+	errorMesssage string
 }
 
 // File metadata


### PR DESCRIPTION
Solves #566

### Solution
Added util function to check for the cases where name:
- equals `.` or `..`
- has suffix `/.` or `/..`
can be used for any further invalid names that may need a check.

Implementation allows for names that might end with dot(s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added filename validation to prevent invalid names like ".", "..", or those ending with "/." or "/..".
  - Display of error messages in the file naming modal for invalid filenames.
  - Automatic clearing of error messages when cancelling file creation.
- **Bug Fixes**
  - Enhanced validation to block invalid filenames and improve user feedback during file creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->