### PR TITLE
fix: convert unicode space to normal space, use rendered in file preview to fix layout bugs, Release 1.3.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
         packages = rec {
           superfile = pkgs.buildGoApplication {
             pname = "superfile";
-            version = "1.2.1";
+            version = "1.3.0";
             src = ./.;
             modules = ./gomod2nix.toml;
           };

--- a/release/release.sh
+++ b/release/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash -euo pipefail
 
 projectName="superfile"
-version="v1.2.1"
+version="v1.3.0"
 osList=("darwin" "linux" "windows")
 archList=("amd64" "arm64")
 mkdir dist

--- a/src/config/fixed_variable.go
+++ b/src/config/fixed_variable.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	CurrentVersion      = "v1.2.1"
+	CurrentVersion      = "v1.3.0"
 	LatestVersionURL    = "https://api.github.com/repos/yorukot/superfile/releases/latest"
 	LatestVersionGithub = "github.com/yorukot/superfile/releases/latest"
 

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -32,7 +32,17 @@ var (
 	FilePanelTopDirectoryIcon string
 	FilePanelNoneText         string
 
+	FilePreviewNoContentText           string
+	FilePreviewNoFileInfoText          string
+	FilePreviewUnsupportedFormatText   string
+	FilePreviewDirectoryUnreadableText string
+	FilePreviewEmptyText               string
+
 	LipglossError string
+)
+
+var (
+	UnsupportedPreviewFormats = []string{".pdf", ".torrent"}
 )
 
 // No dependencies
@@ -59,4 +69,10 @@ func LoadPrerenderedVariables() {
 
 	FilePanelTopDirectoryIcon = FilePanelTopDirectoryIconStyle.Render(" " + icon.Directory + icon.Space)
 	FilePanelNoneText = FilePanelStyle.Render(" " + icon.Error + "  No such file or directory")
+
+	FilePreviewNoContentText = "--- " + icon.Error + " No content to preview ---"
+	FilePreviewNoFileInfoText = "--- " + icon.Error + " Could not get file info ---"
+	FilePreviewUnsupportedFormatText = "--- " + icon.Error + " Unsupported formats ---"
+	FilePreviewDirectoryUnreadableText = "--- " + icon.Error + " Cannot read directory ---"
+	FilePreviewEmptyText = "--- Empty ---"
 }

--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -206,6 +206,13 @@ func MakePrintableWithEscCheck(line string, allowEsc bool) string {
 			sb.WriteRune(r)
 			continue
 		}
+		// It needs to be handled separately since considered a space,
+		// Since we are using ansi.StringWidth() for truncation, and \t is
+		// considered zero width
+		if r == '\t' {
+			sb.WriteString("    ")
+			continue
+		}
 		if r == 0x1b {
 			if allowEsc {
 				sb.WriteRune(r)
@@ -220,10 +227,9 @@ func MakePrintableWithEscCheck(line string, allowEsc bool) string {
 				r = ' '
 			}
 			sb.WriteRune(r)
-
 			continue
 		}
-		if unicode.IsGraphic(r) || r == rune('\t') || r == rune('\n') {
+		if unicode.IsGraphic(r) || r == rune('\n') {
 			sb.WriteRune(r)
 		}
 	}

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -127,7 +127,7 @@ func TestMakePrintable(t *testing.T) {
 		{"", ""},
 		{"hello", "hello"},
 		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", "abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]"},
-		{"Horizontal Tab and NewLine\t\t\n\n", "Horizontal Tab and NewLine\t\t\n\n"},
+		{"Horizontal Tab and NewLine\t\t\n\n", "Horizontal Tab and NewLine        \n\n"},
 		{"(NBSP)\u00a0\u00a0\u00a0\u00a0;", "(NBSP)\u00a0\u00a0\u00a0\u00a0;"},
 		{"\x0b(Vertical Tab)", "(Vertical Tab)"},
 		{"\x0d(CR)", "(CR)"},

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -141,12 +141,14 @@ func TestMakePrintable(t *testing.T) {
 		{"Invalid Unicodes\ufffd", "Invalid Unicodes"},
 		{"Invalid Unicodes\xa0", "Invalid Unicodes"},
 		{"Ascii color sequence\x1b[38;2;230;219;116;48;2;39;40;34m\ue68f \x1b[0m", "Ascii color sequence\x1b[38;2;230;219;116;48;2;39;40;34m\ue68f \x1b[0m"},
+		{"Unicodes spaces\u202f\u205f\u2029", "Unicodes spaces   "},
+		{"IDEOGRAPHIC SPACE\u3000", "IDEOGRAPHIC SPACE "},
 	}
 	for _, tt := range inputs {
 		t.Run(fmt.Sprintf("Make %q printable", tt.input), func(t *testing.T) {
 			result := MakePrintable(tt.input)
 			if result != tt.expected {
-				t.Errorf("Expected %v, got %v", tt.expected, result)
+				t.Errorf("Expected '%v', got '%v' (input : '%v')", tt.expected, result, tt.input)
 			}
 		})
 	}

--- a/src/internal/model_render_test.go
+++ b/src/internal/model_render_test.go
@@ -1,0 +1,148 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/charmbracelet/x/exp/term/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilePreviewRenderWithDimensions(t *testing.T) {
+	// Test that
+	// 1 - we can truncate width and height
+	// 2 - We add extra whitespace to make up for width and height
+	// 3 - Emojis and special unicodes characters can be rendered and Special characters - ~!@#$%^&*()_+-={}\""
+	// 4 - File with spaces, tabs, unicode spaces, etc, is rendered correctly
+	// 5 - File with problematic characters like ascii control char, invalid unicodes etc,
+	//     is cleaned up
+
+	// Additional tests
+	// 1 - File with ascii color sequences can be rendered correctly
+	// 2 - Test all cases - unsupported file, non text file
+	curTestDir := filepath.Join(testDir, "TestFilePreviewRender")
+
+	// Cleanup is taken care by TestMain()
+	setupDirectories(t, curTestDir)
+
+	testdata := []struct {
+		name            string
+		fileContent     string
+		fileName        string
+		height          int
+		width           int
+		expectedPreview string
+	}{
+		{
+			name: "Basic test",
+			fileContent: "" +
+				"abcd\n" +
+				"1234",
+			fileName: "basic.txt",
+			height:   2,
+			width:    4,
+			expectedPreview: "" +
+				"abcd\n" +
+				"1234",
+		},
+		{
+			name: "Width and height truncation",
+			fileContent: "" +
+				"abcd\n" +
+				"1234\n" +
+				"WXYZ",
+			fileName: "truncate.txt",
+			height:   2,
+			width:    3,
+			expectedPreview: "" +
+				"abc\n" +
+				"123",
+		},
+		{
+			name: "Whitespace filling",
+			fileContent: "" +
+				"abc\n" +
+				"123",
+			fileName: "fill.txt",
+			height:   3,
+			width:    4,
+			expectedPreview: "" +
+				"abc \n" +
+				"123 \n" +
+				"    ",
+		},
+		{
+			name: "Special char, Emojies and special unicodes",
+			fileContent: "" +
+				"✅\uf410\U000f0868abcdABCD0123~\n" +
+				"!@#$%^&*()_+-={}|:\"<>?,./;'[]",
+			fileName: "special.txt",
+			height:   2,
+			width:    30,
+			expectedPreview: "" +
+				"✅\uf410\U000f0868abcdABCD0123~             \n" +
+				"!@#$%^&*()_+-={}|:\"<>?,./;'[] ",
+		},
+		{
+			// Contains various Unicode whitespace characters:
+			// U+00A0 (NO-BREAK SPACE)
+			// U+202F (NARROW NO-BREAK SPACE)
+			// U+205F (MEDIUM MATHEMATICAL SPACE)
+			// U+2029 (PARAGRAPH SEPARATOR)
+			name: "Whitespace handling",
+			fileContent: "" +
+				"\n" +
+				"\t1\t\t2\t\n" +
+				"0\u00a01\u00a02\u202f3\u205f4\u20295\u202f6\u205f7\u2029\n" +
+				"0\u30001\u30002",
+			fileName: "whitespace.txt",
+			height:   5,
+			width:    12,
+			expectedPreview: "" +
+				"            \n" +
+				"    1       \n" +
+				"0\u00a01\u00a02 3 4 5 \n" +
+				"0 1 2       \n" +
+				"            ",
+		},
+		{
+			// Contains control characters:
+			// \x0b (Vertical Tab)
+			// \x0d (Carriage Return)
+			// \x00 (Null)
+			// \x05 (Enquiry)
+			// \x0f (Shift In)
+			// \x7f (Delete)
+			// \xa0 (Non-breaking space)
+			// \ufffd (Replacement character)
+			name: "Invalid character cleanup",
+			fileContent: "" +
+				"\x0b\x0d\x00\x05\x0f\x7f\xa0\ufffd",
+			fileName: "invalid.txt",
+			height:   2,
+			width:    10,
+			expectedPreview: "" +
+				"          \n" +
+				"          ",
+		},
+	}
+
+	for i, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			curDir := filepath.Join(curTestDir, "dir"+strconv.Itoa(i))
+			setupDirectories(t, curDir)
+			filePath := filepath.Join(curDir, tt.fileName)
+			err := os.WriteFile(filePath, []byte(tt.fileContent), 0644)
+			require.NoError(t, err)
+
+			m := defaultTestModel(curDir)
+
+			res := ansi.Strip(m.filePreviewPanelRenderWithDimensions(tt.height, tt.width))
+
+			assert.Equal(t, tt.expectedPreview, res, "filePath = %s", filePath)
+		})
+	}
+}

--- a/src/internal/ui/rendering/content_renderer.go
+++ b/src/internal/ui/rendering/content_renderer.go
@@ -45,11 +45,14 @@ func (r *ContentRenderer) AddLineWithCustomTruncate(lineStr string, truncateStyl
 			slog.Error("Max lines reached", "maxLines", r.maxLines)
 			return
 		}
-		// Some characters like "\t" are considered 1 width
-		line = TruncateBasedOnStyle(line, r.maxLineWidth, truncateStyle)
+		// Sanitazation should be done before truncate. Sanitization can increase width
+		// For ex: Converting problematic unicode nbsp to spaces.
 		if r.sanitizeContent {
 			line = common.MakePrintableWithEscCheck(line, true)
 		}
+		// Some characters like "\t" are considered 1 width
+		line = TruncateBasedOnStyle(line, r.maxLineWidth, truncateStyle)
+
 		r.lines = append(r.lines, line)
 	}
 }

--- a/src/internal/ui/rendering/content_renderer_test.go
+++ b/src/internal/ui/rendering/content_renderer_test.go
@@ -23,7 +23,7 @@ func TestContentRendererBasic(t *testing.T) {
 			"12345\n" +
 			"123\n" +
 			"12...\n" +
-			"\t1234"
+			"    1"
 		assert.Equal(t, expected, res, "Basic truncation, and adding lines")
 
 		r.ClearLines()

--- a/src/internal/ui/rendering/renderer_core.go
+++ b/src/internal/ui/rendering/renderer_core.go
@@ -80,7 +80,6 @@ func (r *Renderer) Render() string {
 	}
 	contentStr := strings.TrimSuffix(content.String(), "\n")
 	res := r.Style().Render(contentStr)
-
 	// Post rendering validations - Maybe we can return an error instead of logging
 	maxW := 0
 	for line := range strings.Lines(res) {

--- a/src/internal/ui/rendering/renderer_test.go
+++ b/src/internal/ui/rendering/renderer_test.go
@@ -178,8 +178,9 @@ func TestSections(t *testing.T) {
 			trucateheight:  false,
 			expected: "" +
 				"╭──────╮\n" +
-				"│      │\n" +
-				"╰──────╯",
+				"│      │",
+			// Border breaks here, because lipgloss creates a 3 line string, and
+			// our renderer, than manually adjusts it.
 		},
 		{
 			name:           "Minimal heightBorderless",
@@ -188,7 +189,7 @@ func TestSections(t *testing.T) {
 			borderRequired: false,
 			lines:          []string{sectionStr, "L1", sectionStr, sectionStr},
 			trucateheight:  false,
-			expected:       "        ",
+			expected:       "",
 		},
 		{
 			name:           "No Border",

--- a/src/internal/ui/spf_renderers.go
+++ b/src/internal/ui/spf_renderers.go
@@ -52,6 +52,20 @@ func FilePanelRenderer(totalHeight int, totalWidth int, filePanelFocussed bool) 
 	return r
 }
 
+func FilePreviewPanelRenderer(totalHeight int, totalWidth int) *rendering.Renderer {
+	cfg := rendering.DefaultRendererConfig(totalHeight, totalWidth)
+	cfg.ContentFGColor = common.FilePanelFGColor
+	cfg.ContentBGColor = common.FilePanelBGColor
+	cfg.BorderRequired = false
+
+	r, err := rendering.NewRenderer(cfg)
+	if err != nil {
+		slog.Error("Error in creating renderer. Falling back to default renderer", "error", err)
+		r = &rendering.Renderer{}
+	}
+	return r
+}
+
 func PromptRenderer(totalHeight int, totalWidth int) *rendering.Renderer {
 	cfg := rendering.DefaultRendererConfig(totalHeight, totalWidth)
 	cfg.TruncateHeight = true

--- a/website/public/install.ps1
+++ b/website/public/install.ps1
@@ -22,7 +22,7 @@ Write-Host -ForegroundColor Red         "                    `$`$/              
 Write-Host ""
 
 $package = "superfile"
-$version = "1.2.1"
+$version = "1.3.0"
 
 $installInstructions = @'
 This installer is only available for Windows.

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -39,7 +39,7 @@ if [ $? -ne 0 ]; then
 fi
 
 package=superfile
-version=1.2.1
+version=1.3.0
 arch=$(uname -m)
 os=$(uname -s)
 

--- a/website/public/uninstall.ps1
+++ b/website/public/uninstall.ps1
@@ -22,7 +22,7 @@ Write-Host -ForegroundColor Red         "                    `$`$/              
 Write-Host ""
 
 $package = "superfile"
-$version = "1.2.1"
+$version = "1.3.0"
 
 $installInstructions = @'
 This uninstaller is only available for Windows.

--- a/website/src/content/docs/list/hotkey-list.md
+++ b/website/src/content/docs/list/hotkey-list.md
@@ -65,5 +65,5 @@ These are the default hotkeys and you can [change](/configure/custom-hotkeys) th
 | Copy current file or directory path                  | `ctrl+p`           | `copy_path`                                                                            |
 | Extract zip file                                     | `ctrl+e`           | `extract_file` (normal mode)                                                           |
 | Zip file or folder to .zip file                      | `ctrl+a`           | `compress_file` (normal mode)                                                          |
-| Open file with your default editor                   | `e`                | `oepn_file_with_editor` (normal node)                                                  |
+| Open file with your default editor                   | `e`                | `open_file_with_editor` (normal node)                                                  |
 | Open current directory with default editor           | `E` (shift+e)      | `current_directory_with_editor` (normal node)                                          |


### PR DESCRIPTION
Fixes 
- https://github.com/yorukot/superfile/issues/793
- Root cause - https://github.com/charmbracelet/x/issues/466

Also fixes
- https://github.com/yorukot/superfile/issues/697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new status messages for file preview states, including unsupported formats, unreadable directories, and empty content.
  - File preview now supports more robust handling and display of various file types and formats.

- **Improvements**
  - Enhanced file preview rendering for better consistency and modularity.
  - Improved handling of Unicode spaces, tabs, and control characters in file previews.
  - File preview panel now displays without a border for a cleaner look.
  - Output rendering truncates content exceeding panel dimensions to fit display constraints.
  - Adjusted rendering order to sanitize content before truncation for accurate display.

- **Bug Fixes**
  - Fixed issues with tab and multi-byte space rendering in previews and content panels.
  - Adjusted truncation logic to account for changes in line width after sanitizing content.

- **Tests**
  - Updated and expanded test cases to cover new Unicode and tab handling logic.
  - Added comprehensive tests for file preview rendering with various content and dimension constraints.
  - Improved test output for easier debugging.

- **Documentation**
  - Corrected a typo in the hotkey variable name for opening files with the default editor.

- **Chores**
  - Updated version number to 1.3.0 across build, release, and installation scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->