### PR TITLE
feat: Add 'Type' option for sorting by file extension with fallback t…

### DIFF
--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -129,6 +129,33 @@ func returnDirElement(location string, displayDotFile bool, sortOptions sortOpti
 			fileInfoJ, _ := dirEntries[j].Info()
 			return fileInfoI.ModTime().After(fileInfoJ.ModTime()) != reversed
 		}
+	case "Type":
+		order = func(i, j int) bool {
+			// One of them is a directory, and the other is not
+			if dirEntries[i].IsDir() != dirEntries[j].IsDir() {
+				return dirEntries[i].IsDir()
+			}
+
+			var extI, extJ string
+			if !dirEntries[i].IsDir() {
+				extI = strings.ToLower(filepath.Ext(dirEntries[i].Name()))
+			}
+			if !dirEntries[j].IsDir() {
+				extJ = strings.ToLower(filepath.Ext(dirEntries[j].Name()))
+			}
+
+			// Compare by extension/type
+			if extI != extJ {
+				return (extI < extJ) != reversed
+			}
+
+			// If same type, fall back to name
+			if common.Config.CaseSensitiveSort {
+				return (dirEntries[i].Name() < dirEntries[j].Name()) != reversed
+			}
+
+			return (strings.ToLower(dirEntries[i].Name()) < strings.ToLower(dirEntries[j].Name())) != reversed
+		}
 	}
 
 	sort.Slice(dirEntries, order)

--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -55,7 +55,7 @@ func defaultFilePanel(dir string) filePanel {
 			open:   false,
 			cursor: common.Config.DefaultSortType,
 			data: sortOptionsModelData{
-				options:  []string{"Name", "Size", "Date Modified"},
+				options:  []string{"Name", "Size", "Date Modified", "Type"},
 				selected: common.Config.DefaultSortType,
 				reversed: common.Config.SortOrderReversed,
 			},


### PR DESCRIPTION
This PR adds a new sort mode: "Type", which sorts files by their extensions while keeping directories grouped at the top. If types match, it falls back to name sorting and respects the CaseSensitiveSort config.

Directories sorted above files
Files sorted by lowercase extension
Fallback: name sort (case-sensitive if enabled)
Integrated into returnDirElement alongside existing sort modes