### PR TITLE
fix: Use ansi.TruncateLeft and remove buggy cutLeft

### DIFF
--- a/src/pkg/string_function/overplace.go
+++ b/src/pkg/string_function/overplace.go
@@ -3,15 +3,15 @@
 // These code is from the https://github.com/charmbracelet/lipgloss/pull/102
 // Thanks a lot!!!!!
 
+// Edit - cutLeft has been replaced with charmansi.TruncateLeft. See https://github.com/charmbracelet/lipgloss/pull/102#issuecomment-2900110821
+
 // =======================================================================================================================
 package stringfunction
 
 import (
-	"bytes"
 	"strings"
 
-	charmansi "github.com/charmbracelet/x/exp/term/ansi"
-	"github.com/mattn/go-runewidth"
+	charmansi "github.com/charmbracelet/x/ansi"
 	ansi "github.com/muesli/reflow/ansi"
 	"github.com/muesli/reflow/truncate"
 	"github.com/muesli/termenv"
@@ -100,7 +100,7 @@ func PlaceOverlay(x, y int, fg, bg string, opts ...WhitespaceOption) string {
 		b.WriteString(fgLine)
 		pos += ansi.PrintableRuneWidth(fgLine)
 
-		right := cutLeft(bgLine, pos)
+		right := charmansi.TruncateLeft(bgLine, pos, "")
 		bgWidth = ansi.PrintableRuneWidth(bgLine)
 		rightWidth := ansi.PrintableRuneWidth(right)
 		if rightWidth <= bgWidth-pos {
@@ -110,47 +110,6 @@ func PlaceOverlay(x, y int, fg, bg string, opts ...WhitespaceOption) string {
 		b.WriteString(right)
 	}
 
-	return b.String()
-}
-
-// cutLeft cuts printable characters from the left.
-// This function is heavily based on muesli's ansi and truncate packages.
-func cutLeft(s string, cutWidth int) string {
-	var (
-		pos    int
-		isAnsi bool
-		ab     bytes.Buffer
-		b      bytes.Buffer
-	)
-	for _, c := range s {
-		var w int
-		if c == ansi.Marker || isAnsi {
-			isAnsi = true
-			ab.WriteRune(c)
-			if ansi.IsTerminator(c) {
-				isAnsi = false
-				if bytes.HasSuffix(ab.Bytes(), []byte("[0m")) {
-					ab.Reset()
-				}
-			}
-		} else {
-			w = runewidth.RuneWidth(c)
-		}
-
-		if pos >= cutWidth {
-			if b.Len() == 0 {
-				if ab.Len() > 0 {
-					b.Write(ab.Bytes())
-				}
-				if pos-cutWidth > 1 {
-					b.WriteByte(' ')
-					continue
-				}
-			}
-			b.WriteRune(c)
-		}
-		pos += w
-	}
 	return b.String()
 }
 


### PR DESCRIPTION
See 
- https://github.com/charmbracelet/lipgloss/pull/102#issuecomment-2900110821

Fixes
- https://github.com/yorukot/superfile/issues/497
- https://github.com/yorukot/superfile/issues/449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved reliability by replacing a custom string truncation method with a standardized external library for handling left-side string truncation, ensuring better support for special characters and formatting.
- **Documentation**
  - Updated inline comments to reflect the change in truncation method and provide reference information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->