### PR TITLE
fix: Correct icons for clipboards files

### DIFF
--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -81,7 +82,7 @@ func PrettierDirectoryPreviewName(name string, isDir bool, bgColor lipgloss.Colo
 }
 
 func ClipboardPrettierName(name string, width int, isDir bool, isSelected bool) string {
-	style := GetElementIcon(name, isDir, Config.Nerdfont)
+	style := GetElementIcon(filepath.Base(name), isDir, Config.Nerdfont)
 	if isSelected {
 		return StringColorRender(lipgloss.Color(style.Color), FooterBGColor).
 			Background(FooterBGColor).


### PR DESCRIPTION
This PR closes #832

The issue is that `ClipboardPrettierName(name string, width int, isDir bool, isSelected bool) string`, which is called when rendering the clipboard panel, is called with the file full path (e.g. `/home/name/Documents/file.txt`) . But `GetElementIcon(file string, isDir bool, nerdFont bool) icon.Style`, witch is used to retrived the file icon, expect only the file base name (e.g. `file.txt`). So for files like `go.mod` that relies on the full base name to get the icon, the full path of the file will be given and not just the base name.

After the changes:
![image](https://github.com/user-attachments/assets/95592596-adcb-429a-a477-25fe35e7d279)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved icon selection for clipboard items by basing it on the filename instead of the full file path, resulting in more accurate icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->