### PR TITLE
Fix sorting in file panel when using search bar

### DIFF
--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -557,7 +557,7 @@ func (m *model) getFilePanelItems() {
 
 		// Get file names based on search bar filter
 		if filePanel.searchBar.Value() != "" {
-			fileElement = returnDirElementBySearchString(filePanel.location, m.toggleDotFile, filePanel.searchBar.Value())
+			fileElement = returnDirElementBySearchString(filePanel.location, m.toggleDotFile, filePanel.searchBar.Value(), filePanel.sortOptions.data)
 		} else {
 			fileElement = returnDirElement(filePanel.location, m.toggleDotFile, filePanel.sortOptions.data)
 		}


### PR DESCRIPTION
Related to issue #851

Refactored sorting logic to ensure it works correctly when using the search bar.
Updated returnDirElementBySearchString to apply sorting to search results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for sorting search results in directory listings by name, size, or date modified, with customizable order.

- **Refactor**
  - Improved and unified sorting logic for both normal and search-filtered directory views for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->