### PR TITLE
fix: handle UTF-8 BOM in file reader

### DIFF
--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 	"image"
 	"log/slog"
 	"os"
@@ -546,7 +548,8 @@ func readFileContent(filepath string, maxLineLength int, previewLine int) (strin
 	}
 	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
+	reader := transform.NewReader(file, unicode.BOMOverride(unicode.UTF8.NewDecoder()))
+	scanner := bufio.NewScanner(reader)
 	lineCount := 0
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/text/encoding/unicode"
-	"golang.org/x/text/transform"
 	"image"
 	"log/slog"
 	"os"
@@ -17,6 +15,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 
 	"github.com/yorukot/superfile/src/internal/ui"
 


### PR DESCRIPTION
Relates to the #840 

Conclusion: hidden BOM character in the preview panel broke the entire layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file reading to correctly handle UTF-8 encoded files with Byte Order Marks (BOM), ensuring accurate display of file contents.
- **Tests**
  - Added tests to verify correct handling and removal of UTF-8 BOM in file content reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->