### PR TITLE
fix icon displayed on spf prompt when nerdfont disabled

### DIFF
--- a/src/internal/ui/prompt/model.go
+++ b/src/internal/ui/prompt/model.go
@@ -18,9 +18,16 @@ func DefaultModel(maxHeight int, width int) Model {
 		common.Hotkeys.OpenCommandLine[0], common.Config.ShellCloseOnSuccess, maxHeight, width)
 }
 
+func getHeadLine() string {
+	if common.Config.Nerdfont == true {
+		return icon.Terminal + " "
+	}
+	return ""
+}
+
 func GenerateModel(spfPromptHotkey string, shellPromptHotkey string, closeOnSuccess bool, maxHeight int, width int) Model {
 	m := Model{
-		headline:          icon.Terminal + " " + promptHeadlineText,
+		headline:          getHeadLine() + promptHeadlineText,
 		open:              false,
 		shellMode:         true,
 		textInput:         common.GeneratePromptTextInput(),
@@ -125,7 +132,6 @@ func (m *Model) Render() string {
 	r := ui.PromptRenderer(m.maxHeight, m.width)
 	r.SetBorderTitle(m.headline + " " + modeString(m.shellMode))
 	r.AddLines(" " + m.textInput.View())
-
 	if !m.shellMode {
 		// To make sure its added one time only per render call
 		hintSectionAdded := false


### PR DESCRIPTION
Add getHeadLine function that sets headline basesd on nerdfont setting.

fix bug related to issue #874
https://github.com/yorukot/superfile/issues/874

I can add tests if needed for when nerd font enabled and disabled but i need to get the testing suite setup in WSL or on a VM.