### PR TITLE
Normalize user-facing naming to superfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ go build -o bin/spf.exe
 
 Edit System Environment Variables and add superfile repo's `bin` directory to your PATH  
 
-## Start Superfile
+## Start superfile
 
 ```bash
 spf

--- a/src/internal/ui/prompt/consts.go
+++ b/src/internal/ui/prompt/consts.go
@@ -5,7 +5,7 @@ import "time"
 // These could as well be property of prompt Model vs being global consts
 // But its fine
 const (
-	promptHeadlineText = "Superfile Prompt"
+	promptHeadlineText = "superfile Prompt"
 
 	OpenCommand  = "open"
 	SplitCommand = "split"

--- a/src/internal/ui/prompt/model_test.go
+++ b/src/internal/ui/prompt/model_test.go
@@ -239,7 +239,7 @@ func TestModel_Render(t *testing.T) {
 		m.setShellMode(true)
 		res := ansi.Strip(m.Render())
 		exp := "" +
-			"╭─┤ " + icon.Terminal + " Superfile Prompt (Shell Mode) ├──╮\n" +
+			"╭─┤ " + icon.Terminal + " superfile Prompt (Shell Mode) ├──╮\n" +
 			// 23--------4------------56789012345678901234567890123456789
 			"│ :                                    │\n" +
 			// 23456789012345678901234567890123456789
@@ -250,7 +250,7 @@ func TestModel_Render(t *testing.T) {
 		m.setShellMode(false)
 		res = ansi.Strip(m.Render())
 		exp = "" +
-			"╭─┤ " + icon.Terminal + " Superfile Prompt (SPF Mode) ├────╮\n" +
+			"╭─┤ " + icon.Terminal + " superfile Prompt (SPF Mode) ├────╮\n" +
 			// 23--------4------------56789012345678901234567890123456789
 			"│ >                                    │\n" +
 			"├──────────────────────────────────────┤\n" +
@@ -292,7 +292,7 @@ func TestModel_Render(t *testing.T) {
 		m.HandleShellCommandResults(0, "")
 		res := ansi.Strip(m.Render())
 		exp := "" +
-			"╭─┤ " + icon.Terminal + " Superfile Prompt (Shell Mode) ├────────────╮\n" +
+			"╭─┤ " + icon.Terminal + " superfile Prompt (Shell Mode) ├────────────╮\n" +
 			// 23--------4------------567890123456789012345678901234567890123456789
 			"│ :                                              │\n" +
 			// 234567890123456789012345678901234567890123456789
@@ -305,7 +305,7 @@ func TestModel_Render(t *testing.T) {
 		m.HandleShellCommandResults(1, "")
 		res = ansi.Strip(m.Render())
 		exp = "" +
-			"╭─┤ " + icon.Terminal + " Superfile Prompt (Shell Mode) ├────────────╮\n" +
+			"╭─┤ " + icon.Terminal + " superfile Prompt (Shell Mode) ├────────────╮\n" +
 			// 23--------4------------567890123456789012345678901234567890123456789
 			"│ :                                              │\n" +
 			// 234567890123456789012345678901234567890123456789

--- a/testsuite/core/base_test.py
+++ b/testsuite/core/base_test.py
@@ -77,7 +77,7 @@ class GenericTestImpl(BaseTest):
     
     def start_spf(self) -> None:
         self.env.spf_mgr.start_spf(self.env.fs_mgr.abspath(self.start_dir))
-        assert self.env.spf_mgr.is_spf_running(), "Superfile is not running"
+        assert self.env.spf_mgr.is_spf_running(), "superfile is not running"
 
     def end_execution(self) -> None:
         self.env.spf_mgr.send_special_input(keys.KEY_ESC)    
@@ -112,9 +112,9 @@ class GenericTestImpl(BaseTest):
             self.env.spf_mgr.runtime_info(), self.env.fs_mgr.tree(self.test_root))
         try:
             if self.validate_spf_closed :
-                assert not self.env.spf_mgr.is_spf_running(), "Superfile is still running"
+                assert not self.env.spf_mgr.is_spf_running(), "superfile is still running"
             if self.validate_spf_running :
-                assert self.env.spf_mgr.is_spf_running(), "Superfile is not running"
+                assert self.env.spf_mgr.is_spf_running(), "superfile is not running"
 
             if self.validate_exists is not None:
                 for file_path in self.validate_exists:

--- a/testsuite/tests/chooser_file_test.py
+++ b/testsuite/tests/chooser_file_test.py
@@ -31,7 +31,7 @@ class ChooserFileTest(GenericTestImpl):
     def start_spf(self) -> None:
         self.env.spf_mgr.start_spf(self.env.fs_mgr.abspath(self.start_dir), 
             ["--chooser-file", str(self.env.fs_mgr.abspath(CHOOSER_FILE))])
-        assert self.env.spf_mgr.is_spf_running(), "Superfile is not running"
+        assert self.env.spf_mgr.is_spf_running(), "superfile is not running"
 
     # Override
     def end_execution(self) -> None:

--- a/website/src/content/docs/contribute/file-struct.md
+++ b/website/src/content/docs/contribute/file-struct.md
@@ -70,7 +70,7 @@ Contains the main business logic of the application, organized by functionality:
 - `style.go` - UI styling definitions
 - `style_function.go` - UI styling functions
 
-### `testsuite/` - Superfile's testsuite written in Python
+### `testsuite/` - superfile's testsuite written in Python
 
 - Automatically tests superfile's functionality.
 - See `testsuite/ReadMe.md` for more info


### PR DESCRIPTION
There was a previous issue (can't seem to find it now :/) where we discussed whether the project name should be Superfile or superfile. The agreed convention back then was to use superfile (lowercase).

This PR updates user-facing texts to consistently use superfile. Go naming conventions (e.g., exported identifiers) are left unchanged for now, since they don’t affect what users see.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated capitalization of "Superfile" to "superfile" across user-facing text, headers, prompts, documentation, and error messages for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->