### PR TITLE
fix: prevent pasting a directory into itself, avoiding infinite loop

### DIFF
--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -271,11 +271,11 @@ func verifyPreventedPasteResults(t *testing.T, m *model, originalPath string) {
 		verifyPathExists(t, originalPath, "Original file should still exist when paste is prevented")
 	}
 	// Clipboard should not be cleared when paste is prevented
-	assert.NotEqual(t, 0, len(m.copyItems.items), "Clipboard should not be cleared when paste is prevented")
+	assert.NotEmpty(t, m.copyItems.items, "Clipboard should not be cleared when paste is prevented")
 }
 
 // Helper function to verify successful paste results
-func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFiles []string, originalPath string, shouldOriginalExist bool, m *model) {
+func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFiles []string, originalPath string, shouldOriginalExist bool) {
 	t.Helper()
 	// Verify expected files were created in destination
 	verifyDestinationFiles(t, targetDir, expectedDestFiles)
@@ -397,7 +397,7 @@ func TestPasteItem(t *testing.T) {
 			if tt.shouldPreventPaste {
 				verifyPreventedPasteResults(t, m, originalPath)
 			} else {
-				verifySuccessfulPasteResults(t, tt.targetDir, tt.expectedDestFiles, originalPath, tt.shouldOriginalExist, m)
+				verifySuccessfulPasteResults(t, tt.targetDir, tt.expectedDestFiles, originalPath, tt.shouldOriginalExist)
 			}
 		})
 	}

--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,5 +164,318 @@ func TestCompressSelectedFiles(t *testing.T) {
 		entries, err := os.ReadDir(dir2)
 		require.NoError(t, err)
 		assert.Empty(t, entries)
+	})
+}
+
+func TestPasteItem(t *testing.T) {
+	curTestDir := t.TempDir()
+	sourceDir := filepath.Join(curTestDir, "source")
+	destDir := filepath.Join(curTestDir, "dest")
+	subDir := filepath.Join(sourceDir, "subdir")
+	file1 := filepath.Join(sourceDir, "file1.txt")
+	file2 := filepath.Join(sourceDir, "file2.txt")
+	dirFile1 := filepath.Join(subDir, "dirfile1.txt")
+
+	setupDirectories(t, curTestDir, sourceDir, destDir, subDir)
+	setupFiles(t, file1, file2, dirFile1)
+
+	testdata := []struct {
+		name                 string
+		startDir             string
+		targetDir            string
+		itemName             string
+		isCut                bool
+		selectMode           bool
+		selectedItems        []string
+		shouldClipboardClear bool
+		shouldOriginalExist  bool
+		expectedDestFiles    []string
+		shouldPreventPaste   bool
+		description          string
+	}{
+		{
+			name:                 "Copy Single File",
+			startDir:             sourceDir,
+			targetDir:            destDir,
+			itemName:             "file1.txt",
+			isCut:                false,
+			selectMode:           false,
+			selectedItems:        nil,
+			shouldClipboardClear: false,
+			shouldOriginalExist:  true,
+			expectedDestFiles:    []string{"file1.txt"},
+			shouldPreventPaste:   false,
+			description:          "Copy a single file from source to destination",
+		},
+		{
+			name:                 "Cut Single File",
+			startDir:             sourceDir,
+			targetDir:            destDir,
+			itemName:             "file2.txt",
+			isCut:                true,
+			selectMode:           false,
+			selectedItems:        nil,
+			shouldClipboardClear: true,
+			shouldOriginalExist:  false,
+			expectedDestFiles:    []string{"file2.txt"},
+			shouldPreventPaste:   false,
+			description:          "Cut a single file from source to destination",
+		},
+		{
+			name:                 "Cut Directory into Same Location",
+			startDir:             sourceDir,
+			targetDir:            sourceDir, // Same directory
+			itemName:             "subdir",
+			isCut:                true,
+			selectMode:           false,
+			selectedItems:        nil,
+			shouldClipboardClear: false,      // Should not clear because paste should be prevented
+			shouldOriginalExist:  true,       // Should still exist because paste prevented
+			expectedDestFiles:    []string{}, // No files should be created in dest
+			shouldPreventPaste:   true,
+			description:          "Cutting directory into same location should be prevented",
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			m := defaultTestModel(tt.startDir)
+			TeaUpdateWithErrCheck(t, &m, nil)
+
+			panel := m.getFocusedFilePanel()
+
+			if tt.selectMode {
+				// Switch to select mode and set selected items
+				m.changeFilePanelMode()
+				require.Equal(t, selectMode, panel.panelMode)
+				panel.selected = tt.selectedItems
+			} else {
+				// Find the item in browser mode
+				itemIndex := -1
+				for i, elem := range panel.element {
+					if elem.name == tt.itemName {
+						itemIndex = i
+						break
+					}
+				}
+				require.NotEqual(t, -1, itemIndex, "%s should be found in panel", tt.itemName)
+				panel.cursor = itemIndex
+			}
+
+			// Perform copy or cut operation
+			if tt.isCut {
+				TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.CutItems[0]))
+			} else {
+				TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.CopyItems[0]))
+			}
+
+			// Verify clipboard state after copy/cut
+			assert.Equal(t, tt.isCut, m.copyItems.cut, "Clipboard cut state should match operation")
+			if tt.selectMode {
+				assert.Len(t, m.copyItems.items, len(tt.selectedItems), "Clipboard should contain all selected items")
+			} else {
+				assert.Len(t, m.copyItems.items, 1, "Clipboard should contain one item")
+			}
+
+			// Navigate to target directory
+			if tt.targetDir != tt.startDir {
+				m.updateCurrentFilePanelDir(tt.targetDir)
+				TeaUpdateWithErrCheck(t, &m, nil)
+			}
+
+			// Get original file path for existence check
+			var originalPath string
+			if !tt.selectMode && tt.itemName != "" {
+				originalPath = filepath.Join(tt.startDir, tt.itemName)
+			}
+
+			// Perform paste operation
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.PasteItems[0]))
+
+			if tt.shouldPreventPaste {
+				// Verify that paste was prevented (original should still exist, clipboard not cleared)
+				if originalPath != "" {
+					if strings.Contains(originalPath, ".txt") {
+						assert.FileExists(t, originalPath, "Original file should still exist when paste is prevented")
+					} else {
+						assert.DirExists(t, originalPath, "Original directory should still exist when paste is prevented")
+					}
+				}
+				// Clipboard should not be cleared when paste is prevented
+				assert.NotEqual(t, 0, len(m.copyItems.items), "Clipboard should not be cleared when paste is prevented")
+			} else {
+				// Verify expected files were created in destination
+				for _, expectedFile := range tt.expectedDestFiles {
+					destPath := filepath.Join(tt.targetDir, expectedFile)
+					assert.Eventually(t, func() bool {
+						_, err := os.Stat(destPath)
+						return err == nil
+					}, time.Second, 10*time.Millisecond, "%s should exist in destination", expectedFile)
+				}
+
+				// Verify original file existence based on operation type
+				if originalPath != "" {
+					if tt.shouldOriginalExist {
+						if strings.Contains(originalPath, ".txt") {
+							assert.FileExists(t, originalPath, "Original file should exist after copy operation")
+						} else {
+							assert.DirExists(t, originalPath, "Original directory should exist after copy operation")
+						}
+					} else {
+						assert.Eventually(t, func() bool {
+							_, err := os.Stat(originalPath)
+							return os.IsNotExist(err)
+						}, time.Second, 10*time.Millisecond, "Original file should not exist after cut operation")
+					}
+				}
+			}
+		})
+	}
+
+	// Special test cases that don't fit the table-driven pattern
+	t.Run("Paste with Empty Clipboard", func(t *testing.T) {
+		emptyTestDir := filepath.Join(curTestDir, "empty_test")
+		setupDirectories(t, emptyTestDir)
+
+		m := defaultTestModel(emptyTestDir)
+		TeaUpdateWithErrCheck(t, &m, nil)
+
+		// Ensure clipboard is empty
+		m.copyItems.items = []string{}
+
+		// Get initial count
+		entriesBefore, err := os.ReadDir(emptyTestDir)
+		require.NoError(t, err)
+
+		// Attempt to paste (should do nothing)
+		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.PasteItems[0]))
+
+		// Should not crash and no new files should be created
+		entriesAfter, err := os.ReadDir(emptyTestDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, len(entriesBefore), len(entriesAfter), "No new files should be created when pasting with empty clipboard")
+	})
+
+	t.Run("Multiple Items Copy and Paste", func(t *testing.T) {
+		// Create fresh files for this test
+		multiFile1 := filepath.Join(sourceDir, "multi1.txt")
+		multiFile2 := filepath.Join(sourceDir, "multi2.txt")
+		setupFiles(t, multiFile1, multiFile2)
+
+		m := defaultTestModel(sourceDir)
+		TeaUpdateWithErrCheck(t, &m, nil)
+
+		// Switch to select mode
+		m.changeFilePanelMode()
+		require.Equal(t, selectMode, m.getFocusedFilePanel().panelMode)
+
+		// Select multiple files
+		panel := m.getFocusedFilePanel()
+		panel.selected = []string{multiFile1, multiFile2}
+
+		// Copy selected items
+		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.CopyItems[0]))
+
+		// Verify clipboard
+		assert.False(t, m.copyItems.cut, "Should be copy operation")
+		assert.Len(t, m.copyItems.items, 2, "Should have two items in clipboard")
+
+		// Navigate to destination
+		m.updateCurrentFilePanelDir(destDir)
+		TeaUpdateWithErrCheck(t, &m, nil)
+
+		// Paste items
+		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.PasteItems[0]))
+
+		// Verify both files were copied
+		destMulti1 := filepath.Join(destDir, "multi1.txt")
+		destMulti2 := filepath.Join(destDir, "multi2.txt")
+
+		assert.Eventually(t, func() bool {
+			_, err1 := os.Stat(destMulti1)
+			_, err2 := os.Stat(destMulti2)
+			return err1 == nil && err2 == nil
+		}, time.Second, 10*time.Millisecond, "Both files should be copied to destination")
+	})
+
+	t.Run("Cut into Subdirectory Prevention", func(t *testing.T) {
+		// Create a separate subdirectory for this test to avoid conflicts with table-driven tests
+		testSubDir := filepath.Join(sourceDir, "testsubdir")
+		testDirFile := filepath.Join(testSubDir, "testdirfile.txt")
+		setupDirectories(t, testSubDir)
+		setupFiles(t, testDirFile)
+
+		// Test the logic that prevents cutting a directory into its subdirectory
+		m := defaultTestModel(sourceDir)
+		TeaUpdateWithErrCheck(t, &m, nil)
+
+		// Find testsubdir and cut it
+		panel := m.getFocusedFilePanel()
+		subdirIndex := -1
+		for i, elem := range panel.element {
+			if elem.name == "testsubdir" {
+				subdirIndex = i
+				break
+			}
+		}
+		require.NotEqual(t, -1, subdirIndex, "testsubdir should be found in panel")
+		panel.cursor = subdirIndex
+
+		// Cut the directory
+		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.CutItems[0]))
+
+		// Navigate into the subdirectory and try to paste there (should be prevented)
+		m.updateCurrentFilePanelDir(testSubDir)
+		TeaUpdateWithErrCheck(t, &m, nil)
+		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.PasteItems[0]))
+
+		// Directory should still exist in original location after prevention
+		assert.DirExists(t, testSubDir, "Directory should still exist after failed paste into subdirectory")
+	})
+
+	t.Run("Duplicate File Handling", func(t *testing.T) {
+		// Create a file to copy
+		dupFile := filepath.Join(sourceDir, "duplicate.txt")
+		setupFiles(t, dupFile)
+
+		m := defaultTestModel(sourceDir)
+		TeaUpdateWithErrCheck(t, &m, nil)
+
+		// Find and copy the file
+		panel := m.getFocusedFilePanel()
+		dupIndex := -1
+		for i, elem := range panel.element {
+			if elem.name == "duplicate.txt" {
+				dupIndex = i
+				break
+			}
+		}
+		require.NotEqual(t, -1, dupIndex, "duplicate.txt should be found in panel")
+		panel.cursor = dupIndex
+
+		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.CopyItems[0]))
+
+		// Navigate to destination and paste
+		m.updateCurrentFilePanelDir(destDir)
+		TeaUpdateWithErrCheck(t, &m, nil)
+		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.PasteItems[0]))
+
+		// Verify first copy
+		destDup1 := filepath.Join(destDir, "duplicate.txt")
+		assert.Eventually(t, func() bool {
+			_, err := os.Stat(destDup1)
+			return err == nil
+		}, time.Second, 10*time.Millisecond, "First copy should succeed")
+
+		// Paste again to test duplicate handling
+		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.PasteItems[0]))
+
+		// Verify duplicate file with different name
+		destDup2 := filepath.Join(destDir, "duplicate(1).txt")
+		assert.Eventually(t, func() bool {
+			_, err := os.Stat(destDup2)
+			return err == nil
+		}, time.Second, 10*time.Millisecond, "Duplicate file should be created with (1) suffix")
 	})
 }

--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -165,149 +164,6 @@ func TestCompressSelectedFiles(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, entries)
 	})
-}
-
-// Helper function to find item index in panel by name
-func findItemIndexInPanel(panel *filePanel, itemName string) int {
-	for i, elem := range panel.element {
-		if elem.name == itemName {
-			return i
-		}
-	}
-	return -1
-}
-
-// Helper function to setup panel mode and selection
-func setupPanelModeAndSelection(t *testing.T, m *model, useSelectMode bool, itemName string, selectedItems []string) {
-	t.Helper()
-	panel := m.getFocusedFilePanel()
-
-	if useSelectMode {
-		// Switch to select mode and set selected items
-		m.changeFilePanelMode()
-		require.Equal(t, selectMode, panel.panelMode)
-		panel.selected = selectedItems
-	} else {
-		// Find the item in browser mode
-		itemIndex := findItemIndexInPanel(panel, itemName)
-		require.NotEqual(t, -1, itemIndex, "%s should be found in panel", itemName)
-		panel.cursor = itemIndex
-	}
-}
-
-// Helper function to perform copy or cut operation
-func performCopyOrCutOperation(t *testing.T, m *model, isCut bool) {
-	t.Helper()
-	if isCut {
-		TeaUpdateWithErrCheck(t, m, utils.TeaRuneKeyMsg(common.Hotkeys.CutItems[0]))
-	} else {
-		TeaUpdateWithErrCheck(t, m, utils.TeaRuneKeyMsg(common.Hotkeys.CopyItems[0]))
-	}
-}
-
-// Helper function to verify clipboard state after copy/cut
-func verifyClipboardState(t *testing.T, m *model, isCut bool, useSelectMode bool, selectedItemsCount int) {
-	t.Helper()
-	assert.Equal(t, isCut, m.copyItems.cut, "Clipboard cut state should match operation")
-	if useSelectMode {
-		assert.Len(t, m.copyItems.items, selectedItemsCount, "Clipboard should contain all selected items")
-	} else {
-		assert.Len(t, m.copyItems.items, 1, "Clipboard should contain one item")
-	}
-}
-
-// Helper function to navigate to target directory if different from start
-func navigateToTargetDir(t *testing.T, m *model, startDir, targetDir string) {
-	t.Helper()
-	if targetDir != startDir {
-		m.updateCurrentFilePanelDir(targetDir)
-		TeaUpdateWithErrCheck(t, m, nil)
-	}
-}
-
-// Helper function to get original path for existence check
-func getOriginalPath(useSelectMode bool, itemName, startDir string) string {
-	if !useSelectMode && itemName != "" {
-		return filepath.Join(startDir, itemName)
-	}
-	return ""
-}
-
-// Helper function to verify file or directory exists
-func verifyPathExists(t *testing.T, path, message string) {
-	t.Helper()
-	if strings.Contains(path, ".txt") {
-		assert.FileExists(t, path, message)
-	} else {
-		assert.DirExists(t, path, message)
-	}
-}
-
-// Helper function to verify file or directory doesn't exist after cut
-func verifyPathNotExistsEventually(t *testing.T, path, message string) {
-	t.Helper()
-	assert.Eventually(t, func() bool {
-		_, err := os.Stat(path)
-		return os.IsNotExist(err)
-	}, time.Second, 10*time.Millisecond, message)
-}
-
-// Helper function to verify expected destination files exist
-func verifyDestinationFiles(t *testing.T, targetDir string, expectedDestFiles []string) {
-	t.Helper()
-	for _, expectedFile := range expectedDestFiles {
-		destPath := filepath.Join(targetDir, expectedFile)
-		assert.Eventually(t, func() bool {
-			_, err := os.Stat(destPath)
-			return err == nil
-		}, time.Second, 10*time.Millisecond, "%s should exist in destination", expectedFile)
-	}
-}
-
-// Helper function to verify prevented paste results
-func verifyPreventedPasteResults(t *testing.T, m *model, originalPath string) {
-	t.Helper()
-	if originalPath != "" {
-		verifyPathExists(t, originalPath, "Original file should still exist when paste is prevented")
-	}
-	// Clipboard should not be cleared when paste is prevented
-	assert.NotEmpty(t, m.copyItems.items, "Clipboard should not be cleared when paste is prevented")
-}
-
-// Helper function to verify successful paste results
-func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFiles []string, originalPath string, shouldOriginalExist bool) {
-	t.Helper()
-	// Verify expected files were created in destination
-	verifyDestinationFiles(t, targetDir, expectedDestFiles)
-
-	// Verify original file existence based on operation type
-	if originalPath != "" {
-		if shouldOriginalExist {
-			verifyPathExists(t, originalPath, "Original file should exist after copy operation")
-		} else {
-			verifyPathNotExistsEventually(t, originalPath, "Original file should not exist after cut operation")
-		}
-	}
-
-	// TODO: Need to add a test to verify clipboard state.
-}
-
-// Helper function to setup model and perform copy/cut operation
-func setupModelAndPerformOperation(t *testing.T, startDir string, useSelectMode bool, itemName string, selectedItems []string, isCut bool) *model {
-	t.Helper()
-	m := defaultTestModel(startDir)
-	TeaUpdateWithErrCheck(t, &m, nil)
-
-	setupPanelModeAndSelection(t, &m, useSelectMode, itemName, selectedItems)
-	performCopyOrCutOperation(t, &m, isCut)
-
-	selectedItemsCount := len(selectedItems)
-	if !useSelectMode {
-		selectedItemsCount = 1
-	}
-	verifyClipboardState(t, &m, isCut, useSelectMode, selectedItemsCount)
-
-	return &m
 }
 
 func TestPasteItem(t *testing.T) {
@@ -485,4 +341,24 @@ func TestPasteItem(t *testing.T) {
 		// Verify duplicate file with different name
 		verifyDestinationFiles(t, destDir, []string{"duplicate(1).txt"})
 	})
+}
+
+// ------  Very specific utilities that are required for this test case file only
+
+// Helper function to setup model and perform copy/cut operation
+func setupModelAndPerformOperation(t *testing.T, startDir string, useSelectMode bool, itemName string, selectedItems []string, isCut bool) *model {
+	t.Helper()
+	m := defaultTestModel(startDir)
+	TeaUpdateWithErrCheck(t, &m, nil)
+
+	setupPanelModeAndSelection(t, &m, useSelectMode, itemName, selectedItems)
+	performCopyOrCutOperation(t, &m, isCut)
+
+	selectedItemsCount := len(selectedItems)
+	if !useSelectMode {
+		selectedItemsCount = 1
+	}
+	verifyClipboardState(t, &m, isCut, useSelectMode, selectedItemsCount)
+
+	return &m
 }

--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -275,7 +275,7 @@ func verifyPreventedPasteResults(t *testing.T, m *model, originalPath string) {
 }
 
 // Helper function to verify successful paste results
-func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFiles []string, originalPath string, shouldOriginalExist bool, shouldClipboardClear bool, m *model) {
+func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFiles []string, originalPath string, shouldOriginalExist bool, m *model) {
 	t.Helper()
 	// Verify expected files were created in destination
 	verifyDestinationFiles(t, targetDir, expectedDestFiles)
@@ -289,14 +289,7 @@ func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFi
 		}
 	}
 
-	// Verify clipboard state after paste
-	if shouldClipboardClear {
-		assert.Eventually(t, func() bool {
-			return len(m.copyItems.items) == 0
-		}, time.Second, 10*time.Millisecond, "Clipboard should be cleared after cut operation")
-	} else {
-		assert.NotEqual(t, 0, len(m.copyItems.items), "Clipboard should not be cleared after copy operation")
-	}
+	// TODO: Need to add a test to verify clipboard state.
 }
 
 // Helper function to setup model and perform copy/cut operation
@@ -404,7 +397,7 @@ func TestPasteItem(t *testing.T) {
 			if tt.shouldPreventPaste {
 				verifyPreventedPasteResults(t, m, originalPath)
 			} else {
-				verifySuccessfulPasteResults(t, tt.targetDir, tt.expectedDestFiles, originalPath, tt.shouldOriginalExist, tt.shouldClipboardClear, m)
+				verifySuccessfulPasteResults(t, tt.targetDir, tt.expectedDestFiles, originalPath, tt.shouldOriginalExist, m)
 			}
 		})
 	}

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -248,7 +248,7 @@ func (m *model) completelyDeleteSingleItem() {
 	prog := common.GenerateDefaultProgress()
 
 	newProcess := process{
-		name:     "󰆴 " + panel.element[panel.cursor].name,
+		name:     icon.Delete + icon.Space + panel.element[panel.cursor].name,
 		progress: prog,
 		state:    inOperation,
 		total:    1,

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -409,12 +409,11 @@ func (m *model) pasteItem() {
 				slog.Error("Cannot cut and paste a directory into itself or its subdirectory")
 				message := channelMessage{
 					messageID:   id,
-					messageType: sendWarnModal,
-					warnModal: warnModal{
-						open:     true,
-						title:    "Invalid paste location",
-						content:  "Cannot cut and paste a directory into itself or its subdirectory",
-						warnType: notificationWarn,
+					messageType: sendNotifyModal,
+					notifyModal: notifyModal{
+						open:    true,
+						title:   "Invalid paste location",
+						content: "Cannot cut and paste a directory into itself or its subdirectory",
 					},
 				}
 				channel <- message

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -444,6 +444,38 @@ func (m *model) pasteItem() {
 
 	// Check if trying to paste into source or subdirectory for both cut and copy operations
 	for _, srcPath := range m.copyItems.items {
+		// check if the srcPath and target path are the same
+		// Check if trying to paste into parent directory of source
+		if filepath.Dir(srcPath) == panel.location {
+			slog.Error("Cannot paste into parent directory of source", "src", srcPath, "dst", panel.location)
+			message := channelMessage{
+				messageID:   id,
+				messageType: sendNotifyModal,
+				notifyModal: notifyModal{
+					open:    true,
+					title:   "Invalid paste location",
+					content: "Cannot paste into parent directory of source",
+				},
+			}
+			channel <- message
+			return
+		}
+		slog.Debug("model.pasteItem", "srcPath", srcPath, "panel location", panel.location)
+		if m.copyItems.cut && srcPath == panel.location {
+			slog.Error("Cannot paste a directory into itself", "operation", "cut", "src", srcPath, "dst", panel.location)
+			message := channelMessage{
+				messageID:   id,
+				messageType: sendNotifyModal,
+				notifyModal: notifyModal{
+					open:    true,
+					title:   "Invalid paste location",
+					content: "Cannot paste a directory into itself",
+				},
+			}
+			channel <- message
+			return
+		}
+
 		if isAncestor(srcPath, panel.location) {
 			operation := "copy"
 			if m.copyItems.cut {
@@ -561,11 +593,6 @@ func (m *model) pasteItem() {
 	channel <- message
 
 	m.processBarModel.process[id] = p
-	// Reset after paste is done. Only in case of cut
-	// because current items in clipboard are deleted now
-	if m.copyItems.cut {
-		m.copyItems.reset(false)
-	}
 }
 
 // Extract compressed file

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -444,9 +444,9 @@ func (m *model) pasteItem() {
 
 	// Check if trying to paste into source or subdirectory for both cut and copy operations
 	for _, srcPath := range m.copyItems.items {
-		// check if the srcPath and target path are the same
-		// Check if trying to paste into parent directory of source
-		if filepath.Dir(srcPath) == panel.location {
+		// Check if trying to cut and paste into the same directory - this would be a no-op
+		// and could potentially cause issues, so we prevent it
+		if filepath.Dir(srcPath) == panel.location && m.copyItems.cut {
 			slog.Error("Cannot paste into parent directory of source", "src", srcPath, "dst", panel.location)
 			message := channelMessage{
 				messageID:   id,
@@ -460,7 +460,9 @@ func (m *model) pasteItem() {
 			channel <- message
 			return
 		}
+
 		slog.Debug("model.pasteItem", "srcPath", srcPath, "panel location", panel.location)
+
 		if m.copyItems.cut && srcPath == panel.location {
 			slog.Error("Cannot paste a directory into itself", "operation", "cut", "src", srcPath, "dst", panel.location)
 			message := channelMessage{
@@ -593,6 +595,7 @@ func (m *model) pasteItem() {
 	channel <- message
 
 	m.processBarModel.process[id] = p
+	m.copyItems.reset(false)
 }
 
 // Extract compressed file

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -404,8 +404,8 @@ func (m *model) pasteItem() {
 				return
 			}
 
-			// Check if destination is source or subdirectory of source
-			if strings.HasPrefix(dstAbs, srcAbs) {
+			// Use filepath.Rel to check if destination is inside source
+			if rel, err := filepath.Rel(srcAbs, dstAbs); err == nil && (rel == "." || !strings.HasPrefix(rel, "..")) {
 				slog.Error("Cannot cut and paste a directory into itself or its subdirectory")
 				message := channelMessage{
 					messageID:   id,
@@ -414,7 +414,7 @@ func (m *model) pasteItem() {
 						open:     true,
 						title:    "Invalid paste location",
 						content:  "Cannot cut and paste a directory into itself or its subdirectory",
-						warnType: confirmDeleteItem, // Reusing existing warn type since it's just for display
+						warnType: notificationWarn,
 					},
 				}
 				channel <- message

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -39,7 +39,7 @@ func isAncestor(src, dst string) bool {
 		dstResolved = dst
 	}
 
-	// Get absolute paths
+	// Get absolute paths. Abs() also Cleans paths to normalize separators and resolve . and ..
 	srcAbs, err := filepath.Abs(srcResolved)
 	if err != nil {
 		return false
@@ -49,10 +49,6 @@ func isAncestor(src, dst string) bool {
 	if err != nil {
 		return false
 	}
-
-	// Clean paths to normalize separators and resolve . and ..
-	srcAbs = filepath.Clean(srcAbs)
-	dstAbs = filepath.Clean(dstAbs)
 
 	// On Windows, perform case-insensitive comparison
 	if runtime.GOOS == "windows" {

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -595,7 +595,6 @@ func (m *model) pasteItem() {
 	channel <- message
 
 	m.processBarModel.process[id] = p
-	m.copyItems.reset(false)
 }
 
 // Extract compressed file

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -251,9 +251,14 @@ func (m *model) warnModalOpenKey(msg string) {
 			}
 		case confirmRenameItem:
 			m.confirmRename()
-		case notificationWarn:
-			m.cancelWarnModal()
 		}
+	}
+}
+
+func (m *model) notifyModalOpenKey(msg string) {
+	switch {
+	case slices.Contains(common.Hotkeys.Confirm, msg):
+		m.notifyModal.open = false
 	}
 }
 

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -256,6 +256,7 @@ func (m *model) warnModalOpenKey(msg string) {
 }
 
 func (m *model) notifyModalOpenKey(msg string) {
+	//nolint:gocritic // We use switch here because other key logic is also using switch, so it's more consistent.
 	switch {
 	case slices.Contains(common.Hotkeys.Confirm, msg):
 		m.notifyModal.open = false

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -251,6 +251,8 @@ func (m *model) warnModalOpenKey(msg string) {
 			}
 		case confirmRenameItem:
 			m.confirmRename()
+		case notificationWarn:
+			m.cancelWarnModal()
 		}
 	}
 }

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -115,6 +115,10 @@ func (m *model) handleChannelMessage(msg channelMessage) {
 			m.processBarModel.processList = append(m.processBarModel.processList, msg.messageID)
 		}
 		m.processBarModel.process[msg.messageID] = msg.processNewState
+		// Check if the process is cut and if the clipboard is empty
+		if (msg.processNewState.state == successful || msg.processNewState.state == failure) {
+			m.copyItems.reset(false)
+		}
 	default:
 		slog.Error("Unhandled channelMessageType in handleChannelMessage()",
 			"messageType", msg.messageType)

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -115,8 +115,8 @@ func (m *model) handleChannelMessage(msg channelMessage) {
 			m.processBarModel.processList = append(m.processBarModel.processList, msg.messageID)
 		}
 		m.processBarModel.process[msg.messageID] = msg.processNewState
-		// Check if the process is cut and if the clipboard is empty
-		if (msg.processNewState.state == successful || msg.processNewState.state == failure) {
+		// Check if the process is cut and if the process is successful or failure, both need to be reset
+		if (msg.processNewState.state == successful || msg.processNewState.state == failure) && m.copyItems.cut {
 			m.copyItems.reset(false)
 		}
 	default:

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -106,6 +106,8 @@ func (m *model) handleChannelMessage(msg channelMessage) {
 	switch msg.messageType {
 	case sendWarnModal:
 		m.warnModal = msg.warnModal
+	case sendNotifyModal:
+		m.notifyModal = msg.notifyModal
 	case sendMetadata:
 		m.fileMetaData.metaData = msg.metadata
 	case sendProcess:
@@ -237,6 +239,8 @@ func (m *model) handleKeyInput(msg tea.KeyMsg) tea.Cmd {
 	// Handles all warn models except the warn model for confirming to quit
 	case m.warnModal.open:
 		m.warnModalOpenKey(msg.String())
+	case m.notifyModal.open:
+		m.notifyModalOpenKey(msg.String())
 	// If renaming a object
 	case m.fileModel.renaming:
 		m.renamingKey(msg.String())
@@ -491,6 +495,13 @@ func (m model) View() string {
 		overlayX := m.fullWidth/2 - common.ModalWidth/2
 		overlayY := m.fullHeight/2 - common.ModalHeight/2
 		return stringfunction.PlaceOverlay(overlayX, overlayY, warnModal, finalRender)
+	}
+
+	if m.notifyModal.open {
+		notifyModal := m.notifyModalRender()
+		overlayX := m.fullWidth/2 - common.ModalWidth/2
+		overlayY := m.fullHeight/2 - common.ModalHeight/2
+		return stringfunction.PlaceOverlay(overlayX, overlayY, notifyModal, finalRender)
 	}
 
 	// This is also a render for warnmodal, but its being driven via a different flag

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -286,7 +286,7 @@ func (m *model) processBarRender() string {
 		if curProcess.total != 0 {
 			progressPercentage := float64(curProcess.done) / float64(curProcess.total)
 			slog.Debug("progress", "percentage", progressPercentage)
-			r.AddLines(cursor + curProcess.progress.ViewAs(progressPercentage), "")
+			r.AddLines(cursor+curProcess.progress.ViewAs(progressPercentage), "")
 		} else {
 			r.AddLines(cursor + curProcess.progress.ViewAs(1))
 		}

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -277,9 +277,19 @@ func (m *model) processBarRender() string {
 		case cancel:
 			symbol = common.ProcessCancelStyle.Render(icon.Error)
 		}
-
+		slog.Debug("process", "name", curProcess.name, "done", curProcess.done, "total", curProcess.total, "state", curProcess.state, "symbol", symbol)
 		r.AddLines(cursor + common.FooterStyle.Render(common.TruncateText(curProcess.name, utils.FooterWidth(m.fullWidth)-7, "...")+" ") + symbol)
-		r.AddLines(cursor+curProcess.progress.ViewAs(float64(curProcess.done)/float64(curProcess.total)), "")
+
+		// calculate progress percentage
+		// if the total is 0 mean the process only have directory
+		// so we can set the progress to 100%
+		if curProcess.total != 0 {
+			progressPercentage := float64(curProcess.done) / float64(curProcess.total)
+			slog.Debug("progress", "percentage", progressPercentage)
+			r.AddLines(cursor+curProcess.progress.ViewAs(progressPercentage), "")
+		} else {
+			r.AddLines(cursor+curProcess.progress.ViewAs(1))
+		}
 	}
 
 	return r.Render()

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -516,6 +516,14 @@ func (m *model) warnModalRender() string {
 	return common.ModalBorderStyle(common.ModalHeight, common.ModalWidth).Render(title + "\n\n" + content + "\n\n" + tip)
 }
 
+func (m *model) notifyModalRender() string {
+	title := m.notifyModal.title
+	content := m.notifyModal.content
+	okay := common.ModalConfirm.Render(" (" + common.Hotkeys.Confirm[0] + ") Okay ")
+	okay = common.MainStyle.AlignHorizontal(lipgloss.Center).AlignVertical(lipgloss.Center).Render(okay)
+	return common.ModalBorderStyle(common.ModalHeight, common.ModalWidth).Render(title + "\n\n" + content + "\n\n" + okay)
+}
+
 func (m *model) promptModalRender() string {
 	return m.promptModal.Render()
 }

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -286,9 +286,9 @@ func (m *model) processBarRender() string {
 		if curProcess.total != 0 {
 			progressPercentage := float64(curProcess.done) / float64(curProcess.total)
 			slog.Debug("progress", "percentage", progressPercentage)
-			r.AddLines(cursor+curProcess.progress.ViewAs(progressPercentage), "")
+			r.AddLines(cursor + curProcess.progress.ViewAs(progressPercentage), "")
 		} else {
-			r.AddLines(cursor+curProcess.progress.ViewAs(1))
+			r.AddLines(cursor + curProcess.progress.ViewAs(1))
 		}
 	}
 

--- a/src/internal/test_utils.go
+++ b/src/internal/test_utils.go
@@ -3,20 +3,18 @@ package internal
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/utils"
 )
 
 var SampleDataBytes = []byte("This is sample") //nolint: gochecknoglobals // Effectively const
-
-func defaultTestModel(dirs ...string) model {
-	m := defaultModelConfig(false, false, false, dirs)
-	_, _ = TeaUpdate(&m, tea.WindowSizeMsg{Width: 2 * common.MinimumWidth, Height: 2 * common.MinimumHeight})
-	return m
-}
 
 func setupDirectories(t *testing.T, dirs ...string) {
 	t.Helper()
@@ -37,6 +35,34 @@ func setupFilesWithData(t *testing.T, data []byte, files ...string) {
 func setupFiles(t *testing.T, files ...string) {
 	setupFilesWithData(t, SampleDataBytes, files...)
 }
+
+// -------------------- Model setup utils
+
+func defaultTestModel(dirs ...string) model {
+	m := defaultModelConfig(false, false, false, dirs)
+	_, _ = TeaUpdate(&m, tea.WindowSizeMsg{Width: 2 * common.MinimumWidth, Height: 2 * common.MinimumHeight})
+	return m
+}
+
+// Helper function to setup panel mode and selection
+func setupPanelModeAndSelection(t *testing.T, m *model, useSelectMode bool, itemName string, selectedItems []string) {
+	t.Helper()
+	panel := m.getFocusedFilePanel()
+
+	if useSelectMode {
+		// Switch to select mode and set selected items
+		m.changeFilePanelMode()
+		require.Equal(t, selectMode, panel.panelMode)
+		panel.selected = selectedItems
+	} else {
+		// Find the item in browser mode
+		itemIndex := findItemIndexInPanel(panel, itemName)
+		require.NotEqual(t, -1, itemIndex, "%s should be found in panel", itemName)
+		panel.cursor = itemIndex
+	}
+}
+
+// --------------------  Bubletea utilities
 
 // TeaUpdate : Utility to send update to model , majorly used in tests
 // Not using pointer receiver as this is more like a utility, than
@@ -79,4 +105,118 @@ func IsTeaQuit(cmd tea.Cmd) bool {
 	default:
 		return false
 	}
+}
+
+// Helper function to perform copy or cut operation
+func performCopyOrCutOperation(t *testing.T, m *model, isCut bool) {
+	t.Helper()
+	if isCut {
+		TeaUpdateWithErrCheck(t, m, utils.TeaRuneKeyMsg(common.Hotkeys.CutItems[0]))
+	} else {
+		TeaUpdateWithErrCheck(t, m, utils.TeaRuneKeyMsg(common.Hotkeys.CopyItems[0]))
+	}
+}
+
+// -------------- Validation Utilities
+
+// Helper function to verify clipboard state after copy/cut
+func verifyClipboardState(t *testing.T, m *model, isCut bool, useSelectMode bool, selectedItemsCount int) {
+	t.Helper()
+	assert.Equal(t, isCut, m.copyItems.cut, "Clipboard cut state should match operation")
+	if useSelectMode {
+		assert.Len(t, m.copyItems.items, selectedItemsCount, "Clipboard should contain all selected items")
+	} else {
+		assert.Len(t, m.copyItems.items, 1, "Clipboard should contain one item")
+	}
+}
+
+// Helper function to verify file or directory exists
+func verifyPathExists(t *testing.T, path, message string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err, message)
+	if info.IsDir() {
+		assert.DirExists(t, path, message)
+	} else {
+		assert.FileExists(t, path, message)
+	}
+}
+
+// Helper function to verify file or directory doesn't exist after cut
+func verifyPathNotExistsEventually(t *testing.T, path, message string) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		_, err := os.Stat(path)
+		return os.IsNotExist(err)
+	}, time.Second, 10*time.Millisecond, message)
+}
+
+// Helper function to verify expected destination files exist
+func verifyDestinationFiles(t *testing.T, targetDir string, expectedDestFiles []string) {
+	t.Helper()
+	for _, expectedFile := range expectedDestFiles {
+		destPath := filepath.Join(targetDir, expectedFile)
+		assert.Eventually(t, func() bool {
+			_, err := os.Stat(destPath)
+			return err == nil
+		}, time.Second, 10*time.Millisecond, "%s should exist in destination", expectedFile)
+	}
+}
+
+// Helper function to verify prevented paste results
+func verifyPreventedPasteResults(t *testing.T, m *model, originalPath string) {
+	t.Helper()
+	if originalPath != "" {
+		verifyPathExists(t, originalPath, "Original file should still exist when paste is prevented")
+	}
+	// Clipboard should not be cleared when paste is prevented
+	assert.NotEmpty(t, m.copyItems.items, "Clipboard should not be cleared when paste is prevented")
+}
+
+// Helper function to verify successful paste results
+func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFiles []string, originalPath string, shouldOriginalExist bool) {
+	t.Helper()
+	// Verify expected files were created in destination
+	verifyDestinationFiles(t, targetDir, expectedDestFiles)
+
+	// Verify original file existence based on operation type
+	if originalPath != "" {
+		if shouldOriginalExist {
+			verifyPathExists(t, originalPath, "Original file should exist after copy operation")
+		} else {
+			verifyPathNotExistsEventually(t, originalPath, "Original file should not exist after cut operation")
+		}
+	}
+
+	// TODO: Need to add a test to verify clipboard state.
+}
+
+// -------------- Other utilities
+
+// Helper function to find item index in panel by name
+func findItemIndexInPanel(panel *filePanel, itemName string) int {
+	for i, elem := range panel.element {
+		if elem.name == itemName {
+			return i
+		}
+	}
+	return -1
+}
+
+// Helper function to navigate to target directory if different from start
+func navigateToTargetDir(t *testing.T, m *model, startDir, targetDir string) {
+	t.Helper()
+	if targetDir != startDir {
+		err := m.updateCurrentFilePanelDir(targetDir)
+		require.NoError(t, err)
+		TeaUpdateWithErrCheck(t, m, nil)
+	}
+}
+
+// Helper function to get original path for existence check
+func getOriginalPath(useSelectMode bool, itemName, startDir string) string {
+	if !useSelectMode && itemName != "" {
+		return filepath.Join(startDir, itemName)
+	}
+	return ""
 }

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -40,7 +40,6 @@ const (
 const (
 	confirmDeleteItem warnType = iota
 	confirmRenameItem
-	notificationWarn
 )
 
 // Constants for panel with no focus
@@ -76,6 +75,7 @@ const (
 	sendWarnModal channelMessageType = iota
 	sendMetadata
 	sendProcess
+	sendNotifyModal
 )
 
 const (
@@ -91,11 +91,13 @@ const (
 // issues like race conditions and whatnot, which are hidden since we are creating
 // new model in each tea update.
 type model struct {
-	fileModel            fileModel
-	sidebarModel         sidebar.Model
-	processBarModel      processBarModel
-	focusPanel           focusPanelType
-	copyItems            copyItems
+	fileModel       fileModel
+	sidebarModel    sidebar.Model
+	processBarModel processBarModel
+	focusPanel      focusPanelType
+	copyItems       copyItems
+	// Modals
+	notifyModal          notifyModal
 	typingModal          typingModal
 	warnModal            warnModal
 	helpMenu             helpMenuModal
@@ -151,6 +153,12 @@ type typingModal struct {
 	open          bool
 	textInput     textinput.Model
 	errorMesssage string
+}
+
+type notifyModal struct {
+	open    bool
+	title   string
+	content string
 }
 
 // File metadata
@@ -256,6 +264,7 @@ type channelMessage struct {
 	messageType     channelMessageType
 	processNewState process
 	warnModal       warnModal
+	notifyModal     notifyModal
 	metadata        [][2]string
 }
 

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -91,17 +91,20 @@ const (
 // issues like race conditions and whatnot, which are hidden since we are creating
 // new model in each tea update.
 type model struct {
+	// Main Panels
 	fileModel       fileModel
 	sidebarModel    sidebar.Model
 	processBarModel processBarModel
 	focusPanel      focusPanelType
 	copyItems       copyItems
+
 	// Modals
 	notifyModal          notifyModal
 	typingModal          typingModal
 	warnModal            warnModal
 	helpMenu             helpMenuModal
 	promptModal          prompt.Model
+
 	fileMetaData         fileMetadata
 	imagePreviewer       *filepreview.ImagePreviewer
 	modelQuitState       modelQuitStateType

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -99,11 +99,11 @@ type model struct {
 	copyItems       copyItems
 
 	// Modals
-	notifyModal          notifyModal
-	typingModal          typingModal
-	warnModal            warnModal
-	helpMenu             helpMenuModal
-	promptModal          prompt.Model
+	notifyModal notifyModal
+	typingModal typingModal
+	warnModal   warnModal
+	helpMenu    helpMenuModal
+	promptModal prompt.Model
 
 	fileMetaData         fileMetadata
 	imagePreviewer       *filepreview.ImagePreviewer

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -40,6 +40,7 @@ const (
 const (
 	confirmDeleteItem warnType = iota
 	confirmRenameItem
+	notificationWarn
 )
 
 // Constants for panel with no focus


### PR DESCRIPTION
fix #570 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a notification modal displaying important messages with a title and content, featuring a single "Okay" button for acknowledgment.
  - Enhanced paste operations by preventing directories from being cut and pasted into themselves or their subdirectories, with clear user notifications for invalid actions.

- **User Interface**
  - Notification modals are now centered on the screen and styled consistently with other modal dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->