### PR TITLE
fix: Add clipboard clearing check in Paste test

### DIFF
--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -255,6 +255,12 @@ func TestPasteItem(t *testing.T) {
 			} else {
 				verifySuccessfulPasteResults(t, tt.targetDir, tt.expectedDestFiles, originalPath, tt.shouldOriginalExist)
 			}
+			// Checking separately, as this is something independent of tt.shouldPreventPaste
+			if tt.shouldClipboardClear {
+				assert.Empty(t, p.m.copyItems.items, "Clipboard should be cleared after successful cut-paste")
+			} else {
+				assert.NotEmpty(t, p.m.copyItems.items, "Clipboard should remain after copy-paste")
+			}
 		})
 	}
 

--- a/src/internal/test_utils.go
+++ b/src/internal/test_utils.go
@@ -200,8 +200,6 @@ func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFi
 			verifyPathNotExistsEventually(t, originalPath, "Original file should not exist after cut operation")
 		}
 	}
-
-	// TODO: Need to add a test to verify clipboard state.
 }
 
 // -------------- Other utilities


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded paste-operation tests with explicit clipboard state verification (cleared vs. retained) after each scenario, improving coverage and confidence in expected behavior.
* **Style**
  * Cleaned up test utilities by removing an obsolete comment and trailing whitespace.
* **Chores**
  * No user-facing changes. Functionality, performance, and public APIs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->