### PR TITLE
Fix: Cannot Build on Windows

### DIFF
--- a/src/pkg/file_preview/utils.go
+++ b/src/pkg/file_preview/utils.go
@@ -4,8 +4,6 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
-	"syscall"
-	"unsafe"
 )
 
 // Terminal cell to pixel conversion constants
@@ -102,59 +100,6 @@ func (tc *TerminalCapabilities) detectTerminalCellSize() TerminalCellSize {
 	// Fallback to default values
 	slog.Info("Using default terminal cell size", "os", runtime.GOOS)
 	return getDefaultCellSize()
-}
-
-// getTerminalCellSizeViaIoctl uses ioctl system call to get terminal size
-func getTerminalCellSizeViaIoctl() (TerminalCellSize, bool) {
-	// Try different file descriptors in order of preference
-	fds := []uintptr{
-		1, // stdout
-		0, // stdin
-		2, // stderr
-	}
-
-	for _, fd := range fds {
-		if cellSize, ok := getTerminalSizeFromFd(fd); ok {
-			return cellSize, true
-		}
-	}
-
-	return TerminalCellSize{}, false
-}
-
-// getTerminalSizeFromFd gets terminal size from a specific file descriptor
-func getTerminalSizeFromFd(fd uintptr) (TerminalCellSize, bool) {
-	var ws winsize
-
-	// TIOCGWINSZ ioctl call to get window size
-	// This is the same method used by most terminal libraries
-	_, _, errno := syscall.Syscall(
-		syscall.SYS_IOCTL,
-		fd,
-		syscall.TIOCGWINSZ,
-		uintptr(unsafe.Pointer(&ws)),
-	)
-
-	if errno != 0 {
-		return TerminalCellSize{}, false
-	}
-
-	// Check if we got valid pixel dimensions
-	if ws.Xpixel > 0 && ws.Ypixel > 0 && ws.Col > 0 && ws.Row > 0 {
-		pixelsPerColumn := int(ws.Xpixel) / int(ws.Col)
-		pixelsPerRow := int(ws.Ypixel) / int(ws.Row)
-
-		// Sanity check the values
-		if pixelsPerColumn > 0 && pixelsPerRow > 0 &&
-			pixelsPerColumn < 100 && pixelsPerRow < 100 {
-			return TerminalCellSize{
-				PixelsPerColumn: pixelsPerColumn,
-				PixelsPerRow:    pixelsPerRow,
-			}, true
-		}
-	}
-
-	return TerminalCellSize{}, false
 }
 
 // getDefaultCellSize returns default fallback terminal cell size

--- a/src/pkg/file_preview/utils_unix.go
+++ b/src/pkg/file_preview/utils_unix.go
@@ -1,0 +1,61 @@
+//go:build !windows
+// +build !windows
+
+package filepreview
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// getTerminalCellSizeViaIoctl uses ioctl system call to get terminal size
+func getTerminalCellSizeViaIoctl() (TerminalCellSize, bool) {
+	// Try different file descriptors in order of preference
+	fds := []uintptr{
+		1, // stdout
+		0, // stdin
+		2, // stderr
+	}
+
+	for _, fd := range fds {
+		if cellSize, ok := getTerminalSizeFromFd(fd); ok {
+			return cellSize, true
+		}
+	}
+
+	return TerminalCellSize{}, false
+}
+
+// getTerminalSizeFromFd gets terminal size from a specific file descriptor
+func getTerminalSizeFromFd(fd uintptr) (TerminalCellSize, bool) {
+	var ws winsize
+
+	// TIOCGWINSZ ioctl call to get window size
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd,
+		syscall.TIOCGWINSZ,
+		uintptr(unsafe.Pointer(&ws)),
+	)
+
+	if errno != 0 {
+		return TerminalCellSize{}, false
+	}
+
+	// Check if we got valid pixel dimensions
+	if ws.Xpixel > 0 && ws.Ypixel > 0 && ws.Col > 0 && ws.Row > 0 {
+		pixelsPerColumn := int(ws.Xpixel) / int(ws.Col)
+		pixelsPerRow := int(ws.Ypixel) / int(ws.Row)
+
+		// Sanity check the values
+		if pixelsPerColumn > 0 && pixelsPerRow > 0 &&
+			pixelsPerColumn < 100 && pixelsPerRow < 100 {
+			return TerminalCellSize{
+				PixelsPerColumn: pixelsPerColumn,
+				PixelsPerRow:    pixelsPerRow,
+			}, true
+		}
+	}
+
+	return TerminalCellSize{}, false
+}

--- a/src/pkg/file_preview/utils_windows.go
+++ b/src/pkg/file_preview/utils_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+package filepreview
+
+// getTerminalCellSizeViaIoctl is not supported on Windows, so always return false
+func getTerminalCellSizeViaIoctl() (TerminalCellSize, bool) {
+	return TerminalCellSize{}, false
+}
+
+// getTerminalSizeFromFd is not supported on Windows, so always return false
+func getTerminalSizeFromFd(fd uintptr) (TerminalCellSize, bool) {
+	return TerminalCellSize{}, false
+}


### PR DESCRIPTION
Related to issue #920 while this doesn't allow for pixel perfect detection on windows, it at least allows the project to build on windows.