### PR TITLE
feat: Add a new hotkey to handle cd-on-quit whenever needed

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -112,6 +112,8 @@ func (c *ConfigType) GetIgnoreMissingFields() bool {
 type HotkeysType struct {
 	Confirm []string `toml:"confirm" comment:"=================================================================================================\nGlobal hotkeys (cannot conflict with other hotkeys)"`
 	Quit    []string `toml:"quit"`
+	CdQuit  []string `toml:"cd_quit"`
+
 	// movement
 	ListUp   []string `toml:"list_up" comment:"movement"`
 	ListDown []string `toml:"list_down"`

--- a/src/internal/default_config.go
+++ b/src/internal/default_config.go
@@ -65,6 +65,11 @@ func getHelpMenuData() []helpMenuModalData { //nolint: funlen // This should be 
 			hotkeyWorkType: globalType,
 		},
 		{
+			hotkey:         common.Hotkeys.CdQuit,
+			description:    "Quit superfile and change directory to current folder",
+			hotkeyWorkType: globalType,
+		},
+		{
 			hotkey:         common.Hotkeys.ConfirmTyping,
 			description:    "Confirm typing",
 			hotkeyWorkType: globalType,

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -2,8 +2,7 @@
 # Global hotkeys (cannot conflict with other hotkeys)
 confirm = ['enter', 'right', 'l']
 quit = ['q', 'esc']
-cd_quit = ['Q']
-
+cd_quit = ['Q', '']
 # movement
 list_up = ['up', 'k']
 list_down = ['down', 'j']

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -2,6 +2,7 @@
 # Global hotkeys (cannot conflict with other hotkeys)
 confirm = ['enter', 'right', 'l']
 quit = ['q', 'esc']
+cd_quit = ['Q']
 
 # movement
 list_up = ['up', 'k']

--- a/src/superfile_config/vimHotkeys.toml
+++ b/src/superfile_config/vimHotkeys.toml
@@ -4,6 +4,7 @@
 # Global hotkeys (cannot conflict with other hotkeys)
 confirm = ['enter', '']
 quit = ['ctrl+c', ''] # also know as, theprimeagen troller
+cd_quit = ['Q', '']
 # movement
 list_up = ['k', '']
 list_down = ['j', '']

--- a/website/src/content/docs/list/hotkey-list.md
+++ b/website/src/content/docs/list/hotkey-list.md
@@ -12,14 +12,19 @@ These are the default hotkeys and you can [change](/configure/custom-hotkeys) th
 
 ## General
 
-| Function                        | Key              | Variable name    |
-| ------------------------------- | ---------------- | ---------------- |
-| Open superfile                  | `spf`            |                  |
-| Confirm your select or typing   | `enter`, `right` | `confirm_typing` |
-| Quit typing, modal or superfile | `esc`, `q`       | `quit`           |
-| Cancel typing                   | `ctrl+c`, `esc`  | `cancel_typing`  |
-| Open help menu(hotkeylist)      | `?`              | `open_help_menu` |
-| Toggle footer                   | `F`              | `toggle_footer`  |
+| Function                                | Key              | Variable name    |
+| --------------------------------------- | ---------------- | ---------------- |
+| Open superfile                          | `spf`            |                  |
+| Confirm your select or typing           | `enter`, `right` | `confirm_typing` |
+| Quit typing, modal or superfile         | `esc`, `q`       | `quit`           |
+| Quit superfile and cd to current folder | `Q`              | `cd_quit`        |
+| Cancel typing                           | `ctrl+c`, `esc`  | `cancel_typing`  |
+| Open help menu(hotkeylist)              | `?`              | `open_help_menu` |
+| Toggle footer                           | `F`              | `toggle_footer`  |
+
+:::note
+Quit superfile and cd to current folder "cd_quit" require the same scripts as ["cd_on_quit"](/configure/superfile-config/#cd_on_quit) setting
+:::
 
 ## Panel navigation
 


### PR DESCRIPTION
Resolves #923 
This PR introduces a new hotkey defaulted to "shift+q" (cd_quit = ['Q']) to change directory upon quitting superfile.   
I tried to add the new hotkey without affecting the cd-on-quit configuration, so it stays relevant for anyone that wants to always change directory when quitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global hotkey “Cd Quit” (Q) to quit and change directory to the current folder. Available in default and Vim keymaps and configurable in hotkeys settings.

* **Documentation**
  * Updated hotkey list with “Cd Quit,” including a note about required scripts.
  * Added “Cd Quit” entry to the in-app help menu.

* **Tests**
  * Added test ensuring “Cd Quit” writes the expected change-directory command on exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->