### PR TITLE
feat: Add Action to Publish to Winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -2,15 +2,12 @@ name: Publish to WinGet
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
-  winget:
+  publish:
     name: Publish WinGet package
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
+    runs-on: windows-latest
     steps:
       - name: Submit package to Windows Package Manager Community Repository
         uses: vedantmgoyal2009/winget-releaser@v2


### PR DESCRIPTION
Added workflow to publish package to winget upon newly published release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to publish new releases to the Windows Package Manager (WinGet) when a release is published on GitHub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->