### PR TITLE
feat(docs): Update arch install package docs

### DIFF
--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -79,10 +79,10 @@ scoop install superfile
 sudo pacman -S superfile
 ```
 
-###### Fetches prebuilt binaries from GitHub
+###### Builds most recent version from GitHub
 
 ```bash
-yay -S superfile-bin
+yay -S superfile-git
 ```
 
 ### Homebrew


### PR DESCRIPTION
The main superfile package got moved from the AUR to the extras repo so can be installed with pacman instead of an AUR manager.

`superfile-bin` got removed or deleted at some point.

Also added `superfile-git` for installing from latest commit as the main package is for the most recent released version https://aur.archlinux.org/packages/superfile-git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Arch Linux installation instructions to reflect new package names and commands.
  * Clarified descriptions for package options and their installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->