### PR TITLE
fix: Improve command tokenization to handle quotes and escapes

### DIFF
--- a/src/internal/model_prompt_test.go
+++ b/src/internal/model_prompt_test.go
@@ -246,80 +246,121 @@ func TestModel_Update_Prompt(t *testing.T) {
 
 		setupDirectories(t, dirWithSpaces, dirWithQuotes, dirWithDoubleQuotes, dirWithMixed)
 
-		m := defaultTestModel(dir1)
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
+		t.Run("cd with double quotes", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
 
-		// Test cd with spaces using quotes
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` "`+dirWithSpaces+`"`))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "cd with double quotes should work")
-		assert.Equal(t, dirWithSpaces, m.getFocusedFilePanel().location)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` "`+dirWithSpaces+`"`))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "cd with double quotes should work")
+			assert.Equal(t, dirWithSpaces, m.getFocusedFilePanel().location)
+		})
 
-		// Test cd with spaces using single quotes
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` '`+dirWithSpaces+`'`))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "cd with single quotes should work")
-		assert.Equal(t, dirWithSpaces, m.getFocusedFilePanel().location)
+		t.Run("cd with single quotes", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
 
-		// Test cd with single quotes in path using double quotes
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` "`+dirWithQuotes+`"`))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "cd with single quotes in path should work")
-		assert.Equal(t, dirWithQuotes, m.getFocusedFilePanel().location)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` '`+dirWithSpaces+`'`))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "cd with single quotes should work")
+			assert.Equal(t, dirWithSpaces, m.getFocusedFilePanel().location)
+		})
 
-		// Test cd with double quotes in path using single quotes
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` '`+dirWithDoubleQuotes+`'`))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "cd with double quotes in path should work")
-		assert.Equal(t, dirWithDoubleQuotes, m.getFocusedFilePanel().location)
+		t.Run("cd with single quotes in path using double quotes", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
 
-		// Test cd with escaped quotes
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` `+strings.ReplaceAll(dirWithSpaces, " ", `\ `)))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "cd with escaped spaces should work")
-		assert.Equal(t, dirWithSpaces, m.getFocusedFilePanel().location)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` "`+dirWithQuotes+`"`))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "cd with single quotes in path should work")
+			assert.Equal(t, dirWithQuotes, m.getFocusedFilePanel().location)
+		})
 
-		// Test open with spaces and quotes
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.OpenCommand+` "`+dirWithSpaces+`"`))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "open with double quotes should work")
-		assert.Equal(t, dirWithSpaces, m.getFocusedFilePanel().location)
+		t.Run("cd with double quotes in path using single quotes", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
 
-		m.closeFilePanel()
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` '`+dirWithDoubleQuotes+`'`))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "cd with double quotes in path should work")
+			assert.Equal(t, dirWithDoubleQuotes, m.getFocusedFilePanel().location)
+		})
 
-		// Test shell substitution with quotes
-		userHomeEnv := "HOME"
-		if runtime.GOOS == utils.OsWindows {
-			userHomeEnv = "USERPROFILE"
-		}
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` "${`+userHomeEnv+`}"`))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "cd with quoted env var should work")
-		assert.Equal(t, xdg.Home, m.getFocusedFilePanel().location)
+		t.Run("cd with escaped spaces", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
 
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` '${`+userHomeEnv+`}'`))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "cd with single quoted env var works in superfile (unlike bash)")
-		assert.Equal(t, xdg.Home, m.getFocusedFilePanel().location)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` `+strings.ReplaceAll(dirWithSpaces, " ", `\ `)))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "cd with escaped spaces should work")
+			assert.Equal(t, dirWithSpaces, m.getFocusedFilePanel().location)
+		})
+
+		t.Run("open with double quotes", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
+
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.OpenCommand+` "`+dirWithSpaces+`"`))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "open with double quotes should work")
+			assert.Equal(t, dirWithSpaces, m.getFocusedFilePanel().location)
+
+			m.closeFilePanel()
+		})
+
+		t.Run("cd with quoted environment variable", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
+
+			userHomeEnv := "HOME"
+			if runtime.GOOS == utils.OsWindows {
+				userHomeEnv = "USERPROFILE"
+			}
+
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` "${`+userHomeEnv+`}"`))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "cd with quoted env var should work")
+			assert.Equal(t, xdg.Home, m.getFocusedFilePanel().location)
+		})
+
+		t.Run("cd with single quoted environment variable", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenSPFPrompt[0]))
+
+			userHomeEnv := "HOME"
+			if runtime.GOOS == utils.OsWindows {
+				userHomeEnv = "USERPROFILE"
+			}
+
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(prompt.CdCommand+` '${`+userHomeEnv+`}'`))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "cd with single quoted env var works in superfile (unlike bash)")
+			assert.Equal(t, xdg.Home, m.getFocusedFilePanel().location)
+		})
 	})
 
 	t.Run("Shell command with quotes", func(t *testing.T) {
 		dirWithSpaces := filepath.Join(curTestDir, "test dir with spaces")
 		setupDirectories(t, dirWithSpaces)
 
-		m := defaultTestModel(dir1)
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenCommandLine[0]))
+		t.Run("shell command with double quotes", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenCommandLine[0]))
 
-		// Test shell command with quoted directory
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(`mkdir "`+filepath.Join(dir1, "new dir with spaces")+`"`))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "shell command with quotes should work")
-		assert.DirExists(t, filepath.Join(dir1, "new dir with spaces"))
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(`mkdir "`+filepath.Join(dir1, "new dir with spaces")+`"`))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "shell command with quotes should work")
+			assert.DirExists(t, filepath.Join(dir1, "new dir with spaces"))
+		})
 
-		// Test shell command with single quotes
-		TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(`mkdir '`+filepath.Join(dir1, "another dir with spaces")+`'`))
-		TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
-		assert.True(t, m.promptModal.LastActionSucceeded(), "shell command with single quotes should work")
-		assert.DirExists(t, filepath.Join(dir1, "another dir with spaces"))
+		t.Run("shell command with single quotes", func(t *testing.T) {
+			m := defaultTestModel(dir1)
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenCommandLine[0]))
+
+			TeaUpdateWithErrCheck(t, &m, utils.TeaRuneKeyMsg(`mkdir '`+filepath.Join(dir1, "another dir with spaces")+`'`))
+			TeaUpdateWithErrCheck(t, &m, tea.KeyMsg{Type: tea.KeyEnter})
+			assert.True(t, m.promptModal.LastActionSucceeded(), "shell command with single quotes should work")
+			assert.DirExists(t, filepath.Join(dir1, "another dir with spaces"))
+		})
 	})
 }

--- a/src/internal/model_prompt_test.go
+++ b/src/internal/model_prompt_test.go
@@ -74,7 +74,6 @@ func TestModel_Update_Prompt(t *testing.T) {
 
 // testBasicPromptFunctionality tests opening, closing and basic command execution
 func testBasicPromptFunctionality(t *testing.T, dir1 string) {
-
 	t.Run("Basic Prompt Opening", func(t *testing.T) {
 		m := defaultTestModel(dir1)
 		assert.False(t, m.promptModal.IsOpen())

--- a/src/internal/ui/prompt/tokenize.go
+++ b/src/internal/ui/prompt/tokenize.go
@@ -133,7 +133,16 @@ func tokenizeWithQuotes(command string) ([]string, error) {
 	for _, r := range command {
 		switch {
 		case escaped:
-			buffer.WriteRune(r)
+			// Only allow escaping of specific characters that have special meaning
+			switch r {
+			case '"', '\'', '\\', ' ':
+				// These are valid escape sequences
+				buffer.WriteRune(r)
+			default:
+				// Invalid escape sequence - treat backslash as literal
+				buffer.WriteRune('\\')
+				buffer.WriteRune(r)
+			}
 			escaped = false
 		case r == '\\':
 			escaped = true

--- a/src/internal/ui/prompt/tokenize.go
+++ b/src/internal/ui/prompt/tokenize.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/yorukot/superfile/src/internal/utils"
 )
@@ -17,7 +18,7 @@ func tokenizePromptCommand(command string, cwdLocation string) ([]string, error)
 	if err != nil {
 		return nil, err
 	}
-	return strings.Fields(command), nil
+	return tokenizeWithQuotes(command)
 }
 
 // Replace ${} and $() with values
@@ -109,4 +110,57 @@ func findEndingBracket(r []rune, openIdx int, openParan rune, closeParan rune) i
 		}
 	}
 	return i
+}
+
+// splits command into tokens while respecting quotes and escapes
+func tokenizeWithQuotes(command string) ([]string, error) {
+	var (
+		tokens    []string
+		buffer    strings.Builder
+		quoteOpen rune // 0:none, '\'' or '"'
+		escaped   bool
+	)
+
+	// Initialize tokens as empty slice instead of nil
+	tokens = []string{}
+
+	// Helper function to flush the current buffer into tokens
+	flush := func() {
+		tokens = append(tokens, buffer.String())
+		buffer.Reset()
+	}
+
+	for _, r := range command {
+		switch {
+		case escaped:
+			buffer.WriteRune(r)
+			escaped = false
+		case r == '\\':
+			escaped = true
+		case quoteOpen == 0 && (r == '"' || r == '\''):
+			quoteOpen = r
+		case quoteOpen == r:
+			// End of quoted section - always flush (even if empty)
+			flush()
+			quoteOpen = 0
+		case unicode.IsSpace(r) && quoteOpen == 0:
+			// Only flush if we have content
+			if buffer.Len() > 0 {
+				flush()
+			}
+		default:
+			buffer.WriteRune(r)
+		}
+	}
+
+	if escaped || quoteOpen != 0 {
+		return nil, errors.New("unmatched quotes or escape characters in command")
+	}
+
+	// Flush any remaining content
+	if buffer.Len() > 0 {
+		flush()
+	}
+
+	return tokens, nil
 }


### PR DESCRIPTION
fix #834 

* Removed the simple tokenization using `strings.Fields(command)` and switched to the new **`tokenizeWithQuotes`** function.

  * Parses single (`'`) and double (`"`) quotes as well as back-slash escapes, allowing paths with spaces to be split safely.
  * Detects unterminated quotes or lone back-slashes and returns an `error`.

* Updated the call site in `getPromptAction()` to use `tokenizeWithQuotes`.

* Implemented entirely with the standard library—no additional dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command input handling to correctly process quoted substrings and escape characters, ensuring more accurate tokenization of user commands. Unmatched quotes or escape characters now result in clear error messages.
* **Tests**
  * Added extensive tests covering command tokenization with quotes, escapes, and error cases.
  * Enhanced prompt command tests to verify handling of directory names and shell commands with spaces and quotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->