### PR TITLE
fix: windows test ci

### DIFF
--- a/.github/workflows/superfile-build-test.yml
+++ b/.github/workflows/superfile-build-test.yml
@@ -13,8 +13,6 @@ jobs:
   build:
     name: Build and Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    env:
-      GOMODCACHE: ${{ runner.temp }}/gomodcache
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -33,19 +31,25 @@ jobs:
         with:
           path: |
             ~/.cache/go-build
-            ${{ env.GOMODCACHE }}
+            ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 
       - name: Install dependencies
         run: go mod download
+        env:
+          GOMODCACHE: ${{ runner.temp }}/gomodcache
 
       - name: Build
         run: go build ./...
+        env:
+          GOMODCACHE: ${{ runner.temp }}/gomodcache
 
       - name: Test
         run: go test -v ./...
+        env:
+          GOMODCACHE: ${{ runner.temp }}/gomodcache
 
       - name: Check gofmt (skip on Windows)
         if: runner.os != 'Windows'

--- a/.github/workflows/superfile-build-test.yml
+++ b/.github/workflows/superfile-build-test.yml
@@ -2,9 +2,9 @@ name: Go CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
-    branches: ["**"]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/superfile-build-test.yml
+++ b/.github/workflows/superfile-build-test.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     name: Build and Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      GOMODCACHE: ${{ runner.temp }}/gomodcache
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -31,7 +33,7 @@ jobs:
         with:
           path: |
             ~/.cache/go-build
-            ~/go/pkg/mod
+            ${{ env.GOMODCACHE }}
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-

--- a/.github/workflows/superfile-build-test.yml
+++ b/.github/workflows/superfile-build-test.yml
@@ -2,9 +2,9 @@ name: Go CI
 
 on:
   push:
-    branches: [main]
+    branches: ["**"]
   pull_request:
-    branches: [main]
+    branches: ["**"]
 
 permissions:
   contents: read

--- a/.github/workflows/superfile-build-test.yml
+++ b/.github/workflows/superfile-build-test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: |
             ~/.cache/go-build
-            ~/go/pkg/mod
+            ${{ runner.temp }}/gomodcache
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -42,7 +42,7 @@ jobs:
           GOMODCACHE: ${{ runner.temp }}/gomodcache
 
       - name: Build
-        run: go build ./...
+        run: go build -v ./...
         env:
           GOMODCACHE: ${{ runner.temp }}/gomodcache
 

--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -125,26 +125,23 @@ func TestCompressSelectedFiles(t *testing.T) {
 				return err == nil
 			}, time.Second, 10*time.Millisecond)
 
-			// Assert zip file exists right after compression
-			require.FileExists(t, zipFile, "Expected zip file does not exist after compression")
-
 			// No-op update to get the filepanel updated
 			// TODO - This should not be needed. Only operation finish SPF should refresh
 			// on its own
 			TeaUpdateWithErrCheck(t, &m, nil)
 
 			require.Greater(t, len(m.getFocusedFilePanel().element), tt.cursorIndexForZip)
-			panelLocation := m.getFocusedFilePanel().element[tt.cursorIndexForZip].location
+			selectedItemLocation := m.getFocusedFilePanel().element[tt.cursorIndexForZip].location
 			// Debug output for panel element
-			t.Logf("Panel element at cursorIndexForZip: %s", panelLocation)
-			assert.Equal(t, zipFile, panelLocation,
+			t.Logf("Panel element at cursorIndexForZip: %s", selectedItemLocation)
+			assert.Equal(t, zipFile, selectedItemLocation,
 				"%s does not exists at index %d among %v", zipFile, tt.cursorIndexForZip,
 				m.getFocusedFilePanel().element)
 
 			// Ensure we are extracting the zip file, not a directory
-			fileInfo, err := os.Stat(panelLocation)
+			fileInfo, err := os.Stat(selectedItemLocation)
 			require.NoError(t, err, "Failed to stat panel location before extraction")
-			require.False(t, fileInfo.IsDir(), "Panel location for extraction is a directory, expected a zip file: %s", panelLocation)
+			require.False(t, fileInfo.IsDir(), "Panel location for extraction is a directory, expected a zip file: %s", selectedItemLocation)
 
 			m.getFocusedFilePanel().cursor = tt.cursorIndexForZip
 

--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -125,6 +125,9 @@ func TestCompressSelectedFiles(t *testing.T) {
 				return err == nil
 			}, time.Second, 10*time.Millisecond)
 
+			// Assert zip file exists right after compression
+			require.FileExists(t, zipFile, "Expected zip file does not exist after compression")
+
 			// No-op update to get the filepanel updated
 			// TODO - This should not be needed. Only operation finish SPF should refresh
 			// on its own

--- a/src/internal/test_utils.go
+++ b/src/internal/test_utils.go
@@ -27,7 +27,10 @@ func setupDirectories(t *testing.T, dirs ...string) {
 func setupFilesWithData(t *testing.T, data []byte, files ...string) {
 	t.Helper()
 	for _, file := range files {
-		err := os.WriteFile(file, data, 0644)
+		dir := filepath.Dir(file)
+		err := os.MkdirAll(dir, 0755)
+		require.NoError(t, err)
+		err = os.WriteFile(file, data, 0644)
 		require.NoError(t, err)
 	}
 }

--- a/src/internal/test_utils.go
+++ b/src/internal/test_utils.go
@@ -18,9 +18,8 @@ var SampleDataBytes = []byte("This is sample") //nolint: gochecknoglobals // Eff
 
 func setupDirectories(t *testing.T, dirs ...string) {
 	t.Helper()
-	for i, dir := range dirs {
+	for _, dir := range dirs {
 		if dir == "" {
-			dirs[i] = t.TempDir()
 			continue
 		}
 		err := os.MkdirAll(dir, 0755)
@@ -31,20 +30,7 @@ func setupDirectories(t *testing.T, dirs ...string) {
 func setupFilesWithData(t *testing.T, data []byte, files ...string) {
 	t.Helper()
 	for _, file := range files {
-		dir := filepath.Dir(file)
-		if dir == "" {
-			dir = t.TempDir()
-			file = filepath.Join(dir, filepath.Base(file))
-		}
-		err := os.MkdirAll(dir, 0755)
-		require.NoError(t, err)
-		base := filepath.Base(file)
-		tempFile, err := os.CreateTemp(dir, base+"-*")
-		require.NoError(t, err)
-		_, err = tempFile.Write(data)
-		require.NoError(t, err)
-		require.NoError(t, tempFile.Close())
-		err = os.Rename(tempFile.Name(), file)
+		err := os.WriteFile(file, data, 0644)
 		require.NoError(t, err)
 	}
 }

--- a/src/internal/test_utils.go
+++ b/src/internal/test_utils.go
@@ -18,7 +18,11 @@ var SampleDataBytes = []byte("This is sample") //nolint: gochecknoglobals // Eff
 
 func setupDirectories(t *testing.T, dirs ...string) {
 	t.Helper()
-	for _, dir := range dirs {
+	for i, dir := range dirs {
+		if dir == "" {
+			dirs[i] = t.TempDir()
+			continue
+		}
 		err := os.MkdirAll(dir, 0755)
 		require.NoError(t, err)
 	}
@@ -28,9 +32,19 @@ func setupFilesWithData(t *testing.T, data []byte, files ...string) {
 	t.Helper()
 	for _, file := range files {
 		dir := filepath.Dir(file)
+		if dir == "" {
+			dir = t.TempDir()
+			file = filepath.Join(dir, filepath.Base(file))
+		}
 		err := os.MkdirAll(dir, 0755)
 		require.NoError(t, err)
-		err = os.WriteFile(file, data, 0644)
+		base := filepath.Base(file)
+		tempFile, err := os.CreateTemp(dir, base+"-*")
+		require.NoError(t, err)
+		_, err = tempFile.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, tempFile.Close())
+		err = os.Rename(tempFile.Name(), file)
 		require.NoError(t, err)
 	}
 }

--- a/src/internal/ui/prompt/tokenize_test.go
+++ b/src/internal/ui/prompt/tokenize_test.go
@@ -128,7 +128,7 @@ func Test_resolveShellSubstitution(t *testing.T) {
 		},
 		{
 			name:            "Ill formed command 2",
-			command:         "abc $(abc) syt ${ sdfc ( {)}",
+			command:         "abc $(echo abc) syt ${ sdfc ( {)}",
 			expectedResult:  "",
 			isErrorExpected: true,
 			errorToMatch:    curlyBracketMatchError(),


### PR DESCRIPTION
I've fixed the windows build test CI mentioned in issue #938, I adjusted the workflow to run on my branch to make sure it works, all tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Tests**
  * Improved file compression and extraction tests with additional assertions and logging for better validation and debugging.
  * Enhanced test setup to skip empty directory paths, preventing unnecessary directory creation.
  * Refined shell substitution test to use a valid inner command while maintaining expected error handling.
* **Chores**
  * Updated build and test workflow to use a runner-specific temporary directory for Go module caching, improving environment isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->