### PR TITLE
chore: add winget install instruction to readme and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you want to inspect the script, see : [install.ps1](./website/public/install.
 
 #### [Winget](https://winget.run/)
 ```powershell
-winget install yorukot.superfile
+winget install --id yorukot.superfile
 ```
 
 #### [Scoop](https://scoop.sh/)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ powershell -ExecutionPolicy Bypass -Command "Invoke-Expression ((New-Object Syst
 ```
 If you want to inspect the script, see : [install.ps1](./website/public/install.ps1)
 
+#### [Winget](https://winget.run/)
+```powershell
+winget install superfile
+```
+
 #### [Scoop](https://scoop.sh/)
 ```
 scoop install superfile

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you want to inspect the script, see : [install.ps1](./website/public/install.
 
 #### [Winget](https://winget.run/)
 ```powershell
-winget install superfile
+winget install yorukot.superfile
 ```
 
 #### [Scoop](https://scoop.sh/)

--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -62,7 +62,7 @@ powershell -ExecutionPolicy Bypass -Command "$env:SPF_INSTALL_VERSION=1.2.1; Inv
 With [Winget](https://winget.run/):
 
 ```powershell
-winget install yorukot.superfile
+winget install --id yorukot.superfile
 ``````
 
 With [Scoop](https://scoop.sh/):

--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -59,6 +59,12 @@ Use `SPF_INSTALL_VERSION` to specify a version :
 powershell -ExecutionPolicy Bypass -Command "$env:SPF_INSTALL_VERSION=1.2.1; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.netlify.app/install.ps1'))"
 ```
 
+With [Winget](https://winget.run/):
+
+```powershell
+winget install superfile
+``````
+
 With [Scoop](https://scoop.sh/):
 
 ```bash

--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -62,7 +62,7 @@ powershell -ExecutionPolicy Bypass -Command "$env:SPF_INSTALL_VERSION=1.2.1; Inv
 With [Winget](https://winget.run/):
 
 ```powershell
-winget install superfile
+winget install yorukot.superfile
 ``````
 
 With [Scoop](https://scoop.sh/):


### PR DESCRIPTION
Added winget install instructions to readme and website

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section in the installation instructions for Windows users, detailing how to install Superfile using Winget as an alternative package manager. Includes a sample command for quick setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->