### PR TITLE
feat(readme): add a repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 [![Release](https://img.shields.io/github/v/release/yorukot/superfile.svg?style=flat-square)](https://github.com/yorukot/superfile/releases/latest)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/yorukot/superfile?utm_source=oss&utm_medium=github&utm_campaign=yorukot%2Fsuperfile&labelColor=171717&color=FF570A&&label=CodeRabbit+Reviews)](https://www.coderabbit.ai/)
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/superfile.svg)](https://repology.org/project/superfile/versions)
 ![](/asset/demo.png)
 
 </div>


### PR DESCRIPTION
helps people identify what repos don't or don't have the latest stable version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Packaging status" badge to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->