### PR TITLE
fix: fixing `config.toml`

### DIFF
--- a/src/internal/utils/file_utils.go
+++ b/src/internal/utils/file_utils.go
@@ -155,7 +155,7 @@ func LoadTomlFile(filePath string, defaultData string, target interface{}, fixFl
 		resultErr.UpdateMessageAndError("failed to marshal config to TOML", err)
 		return resultErr
 	}
-	_, err = origFile.Write(tomlData)
+	_, err = origFile.WriteAt(tomlData, 0)
 
 	if err != nil {
 		resultErr.UpdateMessageAndError("failed to write TOML data to original file", err)

--- a/src/internal/utils/file_utils_test.go
+++ b/src/internal/utils/file_utils_test.go
@@ -313,6 +313,10 @@ func TestLoadTomlFileIgnorer(t *testing.T) {
 
 			assert.Equal(t, testContent, backupContent)
 
+			// Validate that if you Load Original File again, it loads without any errors
+			err = LoadTomlFile(orgFile, defaultData, &tomlVal, true)
+			require.NoError(t, err)
+
 			err = os.WriteFile(orgFile, backupContent, 0644)
 			require.NoError(t, err)
 		}


### PR DESCRIPTION
Before the write, a copy is performed using `io.Copy` and that results in the write offset being moved to the EOF and the writing to start from there, effectively resulting in appending to the file instead of overwriting and that leads to toml decoding errors such as every key being set twice etc... This fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving TOML files to ensure updates fully overwrite the original content.
  * Enhanced validation to confirm that fixed TOML configuration files load correctly without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->