### PR TITLE
fix: make PageUp and PageDown context-aware for file panels

### DIFF
--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -42,10 +42,14 @@ func (m *model) mainKey(msg string) tea.Cmd {
 		}
 
 	case slices.Contains(common.Hotkeys.PageUp, msg):
-		m.fileModel.filePanels[m.filePanelFocusIndex].pgUp(m.mainPanelHeight)
+		if m.focusPanel == nonePanelFocus {
+			m.fileModel.filePanels[m.filePanelFocusIndex].pgUp(m.mainPanelHeight)
+		}
 
 	case slices.Contains(common.Hotkeys.PageDown, msg):
-		m.fileModel.filePanels[m.filePanelFocusIndex].pgDown(m.mainPanelHeight)
+		if m.focusPanel == nonePanelFocus {
+			m.fileModel.filePanels[m.filePanelFocusIndex].pgDown(m.mainPanelHeight)
+		}
 
 	case slices.Contains(common.Hotkeys.ChangePanelMode, msg):
 		m.getFocusedFilePanel().changeFilePanelMode()


### PR DESCRIPTION
fix #966

since page up/down are only supported by file panels, make it work only when focus is on file panels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PageUp and PageDown keys so that they only scroll the file panel when no other panel is focused. This prevents unintended scrolling when other panels are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->