### PR TITLE
chore(lint): migrate golangci-yaml config format to v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,10 +14,18 @@
 # (1) govet shadow analyzer is set to "strict : false" settings.
 # strict : true causes too much noise
 
+## Migrated to v2 config format with `golangci-lint migrate` using v2.4.0
+#
+# - Details about the migration: 
+#     https://golangci-lint.run/docs/product/migration-guide/
+# - After automatic migration, comments from the v1 config were manually
+#   reintroduced, and most unprecedented settings were removed or commented out.
+# - Exceptions are linters.exceptions.generated and linters.exceptions.presets,
+#   which were not present in the v1 config, but are useful in the v2 config.
+version: "2"
+
 run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
-  timeout: 3m
+  # The configuration `run.timeout` is ignored. By default, in v2, the timeout is disabled.
 
   # The mode used to evaluate relative paths.
   # It's used by exclusions, Go plugins, and some linters.
@@ -29,238 +37,21 @@ run:
   # Default: wd
   relative-path-mode: gomod
 
-
 # This file contains only configs which differ from defaults.
-# All possible options can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
-linters-settings:
-  cyclop:
-    # The maximal code complexity to report.
-    # Default: 10
-    max-complexity: 30
-    # The maximal average package complexity.
-    # If it's higher than 0.0 (float) the check is enabled
-    # Default: 0.0
-    package-average: 10.0
-
-  depguard:
-    # Rules to apply.
-    #
-    # Variables:
-    # - File Variables
-    #   Use an exclamation mark `!` to negate a variable.
-    #   Example: `!$test` matches any file that is not a go test file.
-    #
-    #   `$all` - matches all go files
-    #   `$test` - matches all go test files
-    #
-    # - Package Variables
-    #
-    #   `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
-    #
-    # Default (applies if no custom rules are defined): Only allow $gostd in all files.
-    rules:
-      # Name of a rule.
-      legacy:
-        # List of packages that are not allowed.
-        # Entries can be a variable (starting with $), a string prefix, or an exact match (if ending with $).
-        # Default: []
-        deny:
-          - pkg: "math/rand$"
-            desc: "Use math/rand/v2 instead, see https://go.dev/blog/randv2"
-          - pkg: "github.com/golang/protobuf"
-            desc: "Use google.golang.org/protobuf instead, see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules"
-          - pkg: "github.com/satori/go.uuid"
-            desc: "Use github.com/google/uuid instead, satori's package is not maintained"
-          - pkg: "github.com/gofrs/uuid$"
-            desc: "Use github.com/gofrs/uuid/v5 or later, it was not a go module before v5"
-
-  errcheck:
-    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-type-assertions: true
-
-  exhaustive:
-    # Program elements to check for exhaustiveness.
-    # Default: [ switch ]
-    check:
-      - switch
-      - map
-
-  exhaustruct:
-    # List of regular expressions to exclude struct packages and their names from checks.
-    # Regular expressions must match complete canonical struct package/name/structname.
-    # Default: []
-    exclude:
-      # std libs
-      - "^net/http.Client$"
-      - "^net/http.Cookie$"
-      - "^net/http.Request$"
-      - "^net/http.Response$"
-      - "^net/http.Server$"
-      - "^net/http.Transport$"
-      - "^net/url.URL$"
-      - "^os/exec.Cmd$"
-      - "^reflect.StructField$"
-      # public libs
-      - "^github.com/Shopify/sarama.Config$"
-      - "^github.com/Shopify/sarama.ProducerMessage$"
-      - "^github.com/mitchellh/mapstructure.DecoderConfig$"
-      - "^github.com/prometheus/client_golang/.+Opts$"
-      - "^github.com/spf13/cobra.Command$"
-      - "^github.com/spf13/cobra.CompletionOptions$"
-      - "^github.com/stretchr/testify/mock.Mock$"
-      - "^github.com/testcontainers/testcontainers-go.+Request$"
-      - "^github.com/testcontainers/testcontainers-go.FromDockerfile$"
-      - "^golang.org/x/tools/go/analysis.Analyzer$"
-      - "^google.golang.org/protobuf/.+Options$"
-      - "^gopkg.in/yaml.v3.Node$"
-
-  funlen:
-    # Checks the number of lines in a function.
-    # If lower than 0, disable the check.
-    # Default: 60
-    lines: 100
-    # Checks the number of statements in a function.
-    # If lower than 0, disable the check.
-    # Default: 40
-    statements: 50
-    # Ignore comments when counting lines.
-    # Default false
-    ignore-comments: true
-  gochecksumtype:
-    # Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.
-    # Default: true
-    default-signifies-exhaustive: false
-
-  gocognit:
-    # Minimal code complexity to report.
-    # Default: 30 (but we recommend 10-20)
-    min-complexity: 20
-
-  gocritic:
-    # Settings passed to gocritic.
-    # The settings key is the name of a supported gocritic checker.
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
-    settings:
-      captLocal:
-        # Whether to restrict checker to params only.
-        # Default: true
-        paramsOnly: false
-      underef:
-        # Whether to skip (*x).method() calls where x is a pointer receiver.
-        # Default: true
-        skipRecvDeref: false
-
-  govet:
-    # Enable all analyzers.
-    # Default: false
-    enable-all: true
-    # Disable analyzers by name.
-    # Run `go tool vet help` to see all analyzers.
-    # Default: []
-    disable:
-      - fieldalignment # too strict
-    # Settings per analyzer.
-    settings:
-      shadow:
-        # Whether to be strict about shadowing; can be noisy.
-        # Default: false
-        strict: false
-
-  inamedparam:
-    # Skips check for interface methods with only a single parameter.
-    # Default: false
-    skip-single-param: true
-
-  mnd:
-    # List of function patterns to exclude from analysis.
-    # Values always ignored: `time.Date`,
-    # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
-    # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
-    # Default: []
-    ignored-functions:
-      - args.Error
-      - flag.Arg
-      - flag.Duration.*
-      - flag.Float.*
-      - flag.Int.*
-      - flag.Uint.*
-      - os.Chmod
-      - os.Mkdir.*
-      - os.OpenFile
-      - os.WriteFile
-      - prometheus.ExponentialBuckets.*
-      - prometheus.LinearBuckets
-
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 0
-
-  nolintlint:
-    # Exclude following linters from requiring an explanation.
-    # Default: []
-    allow-no-explanation: [ funlen, gocognit, lll ]
-    # Enable to require an explanation of nonzero length after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific linter being suppressed.
-    # Default: false
-    require-specific: true
-
-  perfsprint:
-    # Optimizes into strings concatenation.
-    # Default: true
-    strconcat: false
-
-  reassign:
-    # Patterns for global variable names that are checked for reassignment.
-    # See https://github.com/curioswitch/go-reassign#usage
-    # Default: ["EOF", "Err.*"]
-    patterns:
-      - ".*"
-
-  rowserrcheck:
-    # database/sql is always checked
-    # Default: []
-    packages:
-      - github.com/jmoiron/sqlx
-
-  sloglint:
-    # Enforce not using global loggers.
-    # Values:
-    # - "": disabled
-    # - "all": report all global loggers
-    # - "default": report only the default slog logger
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
-    # Default: ""
-    no-global: "all"
-    # Enforce using methods that accept a context.
-    # Values:
-    # - "": disabled
-    # - "all": report all contextless calls
-    # - "scope": report only if a context exists in the scope of the outermost function
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
-    # Default: ""
-    context: "scope"
-
-  usetesting:
-    # Enable/disable `os.TempDir()` detections.
-    # Default: false
-    os-temp-dir: true
-
-
+# All possible options can be found here:
+#   https://golangci-lint.run/docs/linters/
+# You can also refer to the default config:
+#   golangci-lint config --no-config show
+# Or view a list of all linters with descriptions:
+#   golangci-lint help linters
 linters:
-  disable-all: true
+  default: none
   enable:
     ## enabled by default
     - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
-    - gosimple # specializes in simplifying a code
     - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # detects when assignments to existing variables are not used
     - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
     - unused # checks for unused constants, variables, functions and types
     ## disabled by default
     - asasalint # checks for pass []any as any in variadic func(...any)
@@ -289,7 +80,7 @@ linters:
     - gocritic # provides diagnostics that check for bugs, performance and style issues
     - gocyclo # computes and checks the cyclomatic complexity of functions
     #- godot # checks if comments end in a period # Too much for us right now
-    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
+    #- goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
     - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - goprintffuncname # checks that printf-like functions are named with f at the end
     # TODO enable - ignore for a few int overflow, and fix file permissions
@@ -326,7 +117,6 @@ linters:
     # - sloglint # ensure consistent code style when using log/slog
     - spancheck # checks for mistakes with OpenTelemetry/Census spans
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
-    - stylecheck # is a replacement for golint
     - testableexamples # checks if examples are testable (have an expected output)
     - testifylint # checks usage of github.com/stretchr/testify
     # - testpackage # makes you use a separate _test package # Not needed - Makes it harder to test unexported package functions.
@@ -390,7 +180,248 @@ linters:
     # - tenv # [deprecated, replaced by usetesting] detects using os.Setenv instead of t.Setenv since Go1.17
     #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
     # - wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
+
+    ## Deprecated or removed from v2
+    #- typecheck # like the front-end of a Go compiler, parses and type-checks Go code
+    #- gosimple # specializes in simplifying a code
+    #- stylecheck # is a replacement for golint
+
+  settings:
+    cyclop:
+      # The maximal code complexity to report.
+      # Default: 10
+      max-complexity: 30
+      # The maximal average package complexity.
+      # If it's higher than 0.0 (float) the check is enabled
+      # Default: 0.0
+      package-average: 10.0
+
+    depguard:
+      # Rules to apply.
+      # Variables:
+      # - File Variables
+      #   Use an exclamation mark `!` to negate a variable.
+      #   Example: `!$test` matches any file that is not a go test file.
+      #   `$all` - matches all go files
+      #   `$test` - matches all go test files
+      # - Package Variables
+      #   `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
+      # Default (applies if no custom rules are defined): Only allow $gostd in all files.
+      rules:
+        # Name of a rule.
+        legacy:
+          # List of packages that are not allowed.
+          # Entries can be a variable (starting with $), a string prefix, or an exact match (if ending with $).
+          # Default: []
+          deny:
+            - pkg: math/rand$
+              desc: Use math/rand/v2 instead, see https://go.dev/blog/randv2
+            - pkg: github.com/golang/protobuf
+              desc: Use google.golang.org/protobuf instead, see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
+            - pkg: github.com/satori/go.uuid
+              desc: Use github.com/google/uuid instead, satori's package is not maintained
+            - pkg: github.com/gofrs/uuid$
+              desc: Use github.com/gofrs/uuid/v5 or later, it was not a go module before v5
+
+    errcheck:
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-type-assertions: true
+
+    exhaustive:
+      # Program elements to check for exhaustiveness.
+      # Default: [ switch ]
+      check:
+        - switch
+        - map
+
+    exhaustruct:
+      # List of regular expressions to exclude struct packages and their names from checks.
+      # Regular expressions must match complete canonical struct package/name/structname.
+      # Default: []
+      exclude:
+        # std libs
+        - ^net/http.Client$
+        - ^net/http.Cookie$
+        - ^net/http.Request$
+        - ^net/http.Response$
+        - ^net/http.Server$
+        - ^net/http.Transport$
+        - ^net/url.URL$
+        - ^os/exec.Cmd$
+        - ^reflect.StructField$
+        # public libs
+        - ^github.com/Shopify/sarama.Config$
+        - ^github.com/Shopify/sarama.ProducerMessage$
+        - ^github.com/mitchellh/mapstructure.DecoderConfig$
+        - ^github.com/prometheus/client_golang/.+Opts$
+        - ^github.com/spf13/cobra.Command$
+        - ^github.com/spf13/cobra.CompletionOptions$
+        - ^github.com/stretchr/testify/mock.Mock$
+        - ^github.com/testcontainers/testcontainers-go.+Request$
+        - ^github.com/testcontainers/testcontainers-go.FromDockerfile$
+        - ^golang.org/x/tools/go/analysis.Analyzer$
+        - ^google.golang.org/protobuf/.+Options$
+        - ^gopkg.in/yaml.v3.Node$
+
+    funlen:
+      # Checks the number of lines in a function.
+      # If lower than 0, disable the check.
+      # Default: 60
+      lines: 100
+      # Checks the number of statements in a function.
+      # If lower than 0, disable the check.
+      # Default: 40
+      statements: 50
+      # Ignore comments when counting lines.
+      # Default false
+      ignore-comments: true
+
+    gocognit:
+      # Minimal code complexity to report.
+      # Default: 30 (but we recommend 10-20)
+      min-complexity: 20
+
+    gochecksumtype:
+      # Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.
+      # Default: true
+      default-signifies-exhaustive: false
+
+    gocritic:
+      # Settings passed to gocritic.
+      # The settings key is the name of a supported gocritic checker.
+      # The list of supported checkers can be find in https://go-critic.github.io/overview.
+      settings:
+        captLocal:
+          # Whether to restrict checker to params only.
+          # Default: true
+          paramsOnly: false
+        underef:
+          # Whether to skip (*x).method() calls where x is a pointer receiver.
+          # Default: true
+          skipRecvDeref: false
+
+    govet:
+      # Enable all analyzers.
+      # Default: false
+      enable-all: true
+      # Disable analyzers by name.
+      # Run `go tool vet help` to see all analyzers.
+      # Default: []
+      disable:
+        - fieldalignment # too strict
+      # Settings per analyzer.
+      settings:
+        shadow:
+          # Whether to be strict about shadowing; can be noisy.
+          # Default: false
+          strict: false
+
+    inamedparam:
+      # Skips check for interface methods with only a single parameter.
+      # Default: false
+      skip-single-param: true
+
+    mnd:
+      # List of function patterns to exclude from analysis.
+      # Values always ignored: `time.Date`,
+      # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+      # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
+      # Default: []
+      ignored-functions:
+        - args.Error
+        - flag.Arg
+        - flag.Duration.*
+        - flag.Float.*
+        - flag.Int.*
+        - flag.Uint.*
+        - os.Chmod
+        - os.Mkdir.*
+        - os.OpenFile
+        - os.WriteFile
+        - prometheus.ExponentialBuckets.*
+        - prometheus.LinearBuckets
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      # Default: 30
+      max-func-lines: 0
+
+    nolintlint:
+      # Exclude following linters from requiring an explanation.
+      # Default: []
+      allow-no-explanation: [ funlen, gocognit, lll ]
+      # Enable to require an explanation of nonzero length after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      # Default: false
+      require-specific: true
+
+    perfsprint:
+      # Optimizes into strings concatenation.
+      # Default: true
+      strconcat: false
+
+    reassign:
+      # Patterns for global variable names that are checked for reassignment.
+      # See https://github.com/curioswitch/go-reassign#usage
+      # Default: ["EOF", "Err.*"]
+      patterns:
+        - ".*"
+
+    rowserrcheck:
+      # database/sql is always checked
+      # Default: []
+      packages:
+        - github.com/jmoiron/sqlx
+
+    sloglint:
+      # Enforce not using global loggers.
+      # Values:
+      # - "": disabled
+      # - "all": report all global loggers
+      # - "default": report only the default slog logger
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
+      # Default: ""
+      no-global: "all"
+      # Enforce using methods that accept a context.
+      # Values:
+      # - "": disabled
+      # - "all": report all contextless calls
+      # - "scope": report only if a context exists in the scope of the outermost function
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
+      # Default: ""
+      context: "scope"
+
+    usetesting:
+      # Enable/disable `os.TempDir()` detections.
+      # Default: false
+      os-temp-dir: true
+
   exclusions:
+    # Mode of the generated files analysis.
+    # - `strict`: sources are excluded by strictly following the Go generated file convention.
+    #    Source files that have lines matching only the following regular expression will be excluded: 
+    #      `^// Code generated .* DO NOT EDIT\.$`
+    #    This line must appear before the first non-comment, non-blank text in the file.
+    #    https://go.dev/s/generatedcode
+    # - `lax`: sources are excluded if they contain lines like:
+    #      `autogenerated file`, `code generated`, `do not edit`, etc.
+    # - `disable`: disable the generated files exclusion.
+    # Default: strict
+    generated: lax
+
+    # Predefined exclusion rules.
+    # Default: []
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+
+    # Excluding configuration per-path, per-linter, per-text and per-source.
     rules:
       # Stores globally accessible icon strings
       - path: 'src/config/icon/icon.go'
@@ -417,7 +448,29 @@ linters:
       - path: 'src/internal/common/config_type.go'
         linters:
           - lll    
-          
+      - path: _test\.go
+        linters:
+          - bodyclose
+          - dupl
+          - errcheck
+          - funlen
+          - goconst
+          - gosec
+          - noctx
+          - wrapcheck
+      - source: (noinspection|TODO)
+        linters:
+          - godot
+      - source: //noinspection
+        linters:
+          - gocritic
+
+    # Paths to exclude from analysis.
+    # Default: []
+    paths:
+#      - third_party$
+#      - builtin$
+#      - examples$
 
 issues:
   # Maximum count of issues with the same text.
@@ -425,18 +478,21 @@ issues:
   # Default: 3
   max-same-issues: 50
 
-  exclude-rules:
-    - source: "(noinspection|TODO)"
-      linters: [ godot ]
-    - source: "//noinspection"
-      linters: [ gocritic ]
-    - path: "_test\\.go"
-      linters:
-        - bodyclose
-        - dupl
-        - errcheck
-        - funlen
-        - goconst
-        - gosec
-        - noctx
-        - wrapcheck
+formatters:
+  # Enable specific formatter.
+  # Default: [] (uses standard Go formatting)
+  enable:
+    #- gci
+    #- gofmt
+    #- gofumpt
+    - goimports
+    #- golines
+    #- swaggo
+  exclusions:
+    # See linters.exclusions.generated for options and descriptions.
+    # Default: lax
+    generated: lax
+    paths:
+#      - third_party$
+#      - builtin$
+#      - examples$


### PR DESCRIPTION
# Summary

The [golangci-lint](https://github.com/golangci/golangci-lint) project migrated to [version 2](https://github.com/golangci/golangci-lint/releases/tag/v2.0.0) some time ago.

 - [`superfile/.golangci.yaml (v1.3.3, main)`](https://github.com/yorukot/superfile/blob/v1.3.3/.golangci.yaml) depends on [`golangci-lint (v1.64.5)`](https://github.com/golangci/golangci-lint/releases/tag/v1.64.5)
 - This PR migrated the config file format using [`golangci-lint (v2.4.0, latest)`](https://github.com/golangci/golangci-lint/releases/tag/v2.4.0)

# Reason

Users trying to lint the project with a current version of `golangci-lint` will encounter messages like the following:

```sh
$ make lint
Error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
Failed executing command with error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
make: *** [Makefile:20: lint] Error 3
```

This is because `golangci-lint` requires a [`version`](https://golangci-lint.run/docs/configuration/file/#version-configuration) key in the v2 config, which is entirely absent from the v1 config.

## Changes

Settings for handling generated files via `go generate` have been added in version 2 and are included in this PR at YAML paths: 
 - `linters.exceptions.generated = lax` (default `strict`), and 
 - `formatters.exceptions.generated = lax` (default `lax`).

Version 2 also adds support for a handful of ["preset" exclusion rules](https://golangci-lint.run/docs/linters/false-positives/#exclusion-presets) to automatically omit many pedantic and false-positive reports. There are 4 presets provided at this time, and all 4 have been included with this PR at YAML path `linters.exceptions.presets`.


 - This significantly helps #738 (see below)

<details><summary><h3>With this PR, <code>golangci-lint</code> v2 is reporting 16 issues across the project</h3></summary>

```
src/internal/ui/prompt/tokenize_test.go:442:41: string literal contains rune in Han script (gosmopolitan)
                        command:         `"こんにちは" '世界'`,
                                                             ^
src/internal/ui/prompt/tokenize_test.go:443:50: string literal contains rune in Han script (gosmopolitan)
                        expectedRes:     []string{"こんにちは", "世界"},
                                                                      ^
src/internal/config_function.go:93:28: os/exec.Command must not be called. use os/exec.CommandContext (noctx)
                        out, err := exec.Command("zoxide", "query", firstFilePanelDirs[i]).Output()
                                                ^
src/internal/handle_file_operations.go:458:19: os/exec.Command must not be called. use os/exec.CommandContext (noctx)
        c := exec.Command(cmd, args...)
                         ^
src/internal/handle_file_operations.go:495:19: os/exec.Command must not be called. use os/exec.CommandContext (noctx)
        c := exec.Command(cmd, args...)
                         ^
src/internal/handle_panel_movement.go:88:22: os/exec.Command must not be called. use os/exec.CommandContext (noctx)
                cmd := exec.Command(dllpath, dllfile, panel.element[panel.cursor].location)
                                   ^
src/internal/handle_panel_movement.go:97:21: os/exec.Command must not be called. use os/exec.CommandContext (noctx)
        cmd := exec.Command(openCommand, panel.element[panel.cursor].location)
                           ^
src/internal/common/icon_utils.go:1:9: var-naming: avoid meaningless package names (revive)
package common
        ^
src/internal/utils/shell_utils.go:1:9: var-naming: avoid meaningless package names (revive)
package utils
        ^
src/internal/ui/prompt/tokenize.go:100:3: QF1003: could use tagged switch on r[i] (staticcheck)
                if r[i] == openParan {
                ^
src/internal/file_operation_compress_test.go:108:2: len: use require.Len (testifylint)
        require.Equal(t, len(expectedFiles), len(zipReader.File), "ZIP should contain expected number of files")
        ^
src/internal/handle_file_operation_test.go:285:3: len: use assert.Len (testifylint)
                assert.Equal(t, len(entriesBefore), len(entriesAfter),
                ^
src/internal/model_file_operations_test.go:95:3: empty: use assert.Empty (testifylint)
                assert.Equal(t, "", m.typingModal.errorMesssage)
                ^
src/internal/model_file_operations_test.go:102:4: empty: use assert.NotEmpty (testifylint)
                        assert.NotEqual(t, "", m.typingModal.errorMesssage, "expected an error for input: %q", tt.fileName)
                        ^
src/internal/ui/prompt/model_test.go:76:4: empty: use assert.Empty (testifylint)
                        assert.Equal(t, "", m.resultMsg)
                        ^
src/internal/ui/rendering/content_renderer_test.go:45:3: empty: use assert.Empty (testifylint)
                assert.Equal(t, "", r.Render())
                ^
16 issues:
* gosmopolitan: 2
* noctx: 5
* revive: 2
* staticcheck: 1
* testifylint: 6
```

</details>

## Notes

- [`golangci-lint` Migration Guide](https://golangci-lint.run/docs/product/migration-guide/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated linting configuration to v2 for improved consistency and maintainability.
  * Standardized code formatting using goimports.
  * Curated enabled linters and refined exclusions to reduce false positives and noise.
  * Introduced presets and per-path rules for more targeted checks.
  * Limited duplicate issue reports to keep CI output concise.
  * No user-facing changes; this enhances developer workflow and build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->