### PR TITLE
feat: When on Linux, when pressing enter on a code file, opens up the…

### DIFF
--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -188,6 +188,57 @@ func IsTextFile(filename string) (bool, error) {
 	return IsBufferPrintable(buffer[:cnt]), nil
 }
 
+func IsCodeFile(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+
+	// Common code file extensions
+	codeExtensions := map[string]bool{
+		".c":      true,
+		".h":      true,
+		".cpp":    true,
+		".cc":     true,
+		".cxx":    true,
+		".hpp":    true,
+		".hh":     true,
+		".hxx":    true,
+		".go":     true,
+		".zig":    true,
+		".rs":     true,
+		".py":     true,
+		".sh":     true,
+		".bash":   true,
+		".zsh":    true,
+		".fish":   true,
+		".lua":    true,
+		".rb":     true,
+		".php":    true,
+		".java":   true,
+		".js":     true,
+		".ts":     true,
+		".jsx":    true,
+		".tsx":    true,
+		".vue":    true,
+		".svelte": true,
+		".astro":  true,
+		".md":     true,
+		".txt":    true,
+		".log":    true,
+		".json":   true,
+		".toml":   true,
+		".yaml":   true,
+		".yml":    true,
+		".xml":    true,
+		".html":   true,
+		".css":    true,
+		".scss":   true,
+		".sass":   true,
+		".less":   true,
+	}
+
+	return codeExtensions[ext]
+}
+
+
 // Although some characters like `\x0b`(vertical tab) are printable,
 // previewing them breaks the layout.
 // So, among the "non-graphic" printable characters, we only need \n and \t

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -155,9 +155,9 @@ func (m *model) normalAndBrowserModeKey(msg string) tea.Cmd {
 		case slices.Contains(common.Hotkeys.PermanentlyDeleteItems, msg):
 			return m.getDeleteTriggerCmd(true)
 		case slices.Contains(common.Hotkeys.CopyItems, msg):
-			m.copyMultipleItem(false)
+			m.copySingleItem(false)
 		case slices.Contains(common.Hotkeys.CutItems, msg):
-			m.copyMultipleItem(true)
+			m.copySingleItem(true)
 		case slices.Contains(common.Hotkeys.FilePanelSelectAllItem, msg):
 			m.selectAllItem()
 		}
@@ -166,7 +166,7 @@ func (m *model) normalAndBrowserModeKey(msg string) tea.Cmd {
 
 	switch {
 	case slices.Contains(common.Hotkeys.Confirm, msg):
-		m.enterPanel()
+		return m.enterPanel()
 	case slices.Contains(common.Hotkeys.ParentDirectory, msg):
 		m.parentDirectory()
 	case slices.Contains(common.Hotkeys.DeleteItems, msg):


### PR DESCRIPTION
… file in nano. Defined the file extensions in string_functions.go with a new functions called IsCodeFile. And some small return statements in [key_functions.go](https://github.com/EmbeddingBits/superfile/blob/main/src/internal/key_function.go).

I found this thing where when you press enter when over a file, it opened code files in libreoffice using the `xdg-open`. So, I worked on it for Linux, and for some of the extensions defined in ![string_functions.go](https://github.com/embeddingbits/superfile/blob/main/src/internal/common/string_function.go). I've only worked for Linux as im not aware of the behaviour in Windows or Mac. :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - On Linux, pressing Enter on a code file opens it directly in a terminal editor.
  - Platform-aware file opening across Windows, macOS, and Linux for a smoother experience.

- Bug Fixes
  - Enter action now reliably triggers the intended operation when opening items.
  - In select mode, Copy and Cut now act on the highlighted item for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->