### PR TITLE
fix(filePanel): allow focusType to be set correctly

### DIFF
--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -39,12 +39,18 @@ func (m *model) validateLayout() error {
 func filePanelSlice(dir []string) []filePanel {
 	res := make([]filePanel, len(dir))
 	for i := range dir {
-		res[i] = defaultFilePanel(dir[i])
+		// Making the first panel as the default focus panel
+		// while others remain secondFocus
+		focusType := secondFocus
+		if i == 0 {
+			focusType = focus
+		}
+		res[i] = defaultFilePanel(dir[i], focusType)
 	}
 	return res
 }
 
-func defaultFilePanel(dir string) filePanel {
+func defaultFilePanel(dir string, currentFocusType filePanelFocusType) filePanel {
 	return filePanel{
 		render:   0,
 		cursor:   0,
@@ -55,14 +61,16 @@ func defaultFilePanel(dir string) filePanel {
 			open:   false,
 			cursor: common.Config.DefaultSortType,
 			data: sortOptionsModelData{
-				options: []string{string(sortingName), string(sortingSize),
-					string(sortingDateModified), string(sortingFileType)},
+				options: []string{
+					string(sortingName), string(sortingSize),
+					string(sortingDateModified), string(sortingFileType),
+				},
 				selected: common.Config.DefaultSortType,
 				reversed: common.Config.SortOrderReversed,
 			},
 		},
 		panelMode:        browserMode,
-		focusType:        focus,
+		focusType:        currentFocusType,
 		directoryRecords: make(map[string]directoryRecord),
 		searchBar:        common.GenerateSearchBar(),
 	}


### PR DESCRIPTION
The defaultFilePanel function previously hardcoded focusType to 'focus', causing multiple panels to appear focused simultaneously.

Now, defaultFilePanel accepts a focusType parameter, allowing callers to initialize panels with the correct focus state. This ensures only one panel is focused at initialization, and others are set to 'noneFocus' or 'secondFocus' as needed.

Fixes the inconsistent panel focus issue introduced in PR #759.