### PR TITLE
refactor(filepanel): replace filePanelFocusType with isFocused boolean

### DIFF
--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -55,11 +55,11 @@ func isExternalDiskPath(path string) bool {
 		strings.HasPrefix(path, "/Volumes")
 }
 
-func returnFocusType(focusPanel focusPanelType) filePanelFocusType {
+func returnFocusType(focusPanel focusPanelType) bool {
 	if focusPanel == nonePanelFocus {
-		return focus
+		return true
 	}
-	return secondFocus
+	return false
 }
 
 // TODO : Take common.Config.CaseSensitiveSort as a function parameter
@@ -86,7 +86,8 @@ func returnDirElement(location string, displayDotFile bool, sortOptions sortOpti
 }
 
 func returnDirElementBySearchString(location string, displayDotFile bool, searchString string,
-	sortOptions sortOptionsModelData) []element {
+	sortOptions sortOptionsModelData,
+) []element {
 	items, err := os.ReadDir(location)
 	if err != nil {
 		slog.Error("Error while return folder element function", "error", err)
@@ -355,7 +356,8 @@ func processCmdToTeaCmd(cmd processbar.Cmd) tea.Cmd {
 	}
 	return func() tea.Msg {
 		updateMsg := cmd()
-		return ProcessBarUpdateMsg{pMsg: updateMsg,
+		return ProcessBarUpdateMsg{
+			pMsg: updateMsg,
 			BaseMessage: BaseMessage{
 				reqID: updateMsg.GetReqID(),
 			},

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -56,10 +56,7 @@ func isExternalDiskPath(path string) bool {
 }
 
 func returnFocusType(focusPanel focusPanelType) bool {
-	if focusPanel == nonePanelFocus {
-		return true
-	}
-	return false
+	return focusPanel == nonePanelFocus
 }
 
 // TODO : Take common.Config.CaseSensitiveSort as a function parameter

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -118,7 +118,7 @@ func (m *model) sidebarSelectDirectory() {
 	if err != nil {
 		slog.Error("Error switching to sidebar directory", "error", err)
 	}
-	panel.focusType = focus
+	panel.isFocused = true
 }
 
 // Select all item in the file panel (only work on select mode)

--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -41,11 +41,10 @@ func (m *model) createNewFilePanel(location string) error {
 	}
 
 	m.fileModel.filePanels = append(m.fileModel.filePanels, filePanel{
-
 		location:         location,
 		sortOptions:      m.fileModel.filePanels[m.filePanelFocusIndex].sortOptions,
 		panelMode:        browserMode,
-		focusType:        secondFocus,
+		isFocused:        false,
 		directoryRecords: make(map[string]directoryRecord),
 		searchBar:        common.GenerateSearchBar(),
 	})
@@ -60,8 +59,8 @@ func (m *model) createNewFilePanel(location string) error {
 		}
 	}
 
-	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = noneFocus
-	m.fileModel.filePanels[m.filePanelFocusIndex+1].focusType = returnFocusType(m.focusPanel)
+	m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = false
+	m.fileModel.filePanels[m.filePanelFocusIndex+1].isFocused = returnFocusType(m.focusPanel)
 	m.fileModel.width = (m.fullWidth - common.Config.SidebarWidth - m.fileModel.filePreview.GetWidth() -
 		(4 + (len(m.fileModel.filePanels)-1)*2)) / len(m.fileModel.filePanels)
 	m.filePanelFocusIndex++
@@ -99,7 +98,7 @@ func (m *model) closeFilePanel() {
 
 	m.fileModel.width = (m.fullWidth - common.Config.SidebarWidth - m.fileModel.filePreview.GetWidth() -
 		(4 + (len(m.fileModel.filePanels)-1)*2)) / len(m.fileModel.filePanels)
-	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = returnFocusType(m.focusPanel)
+	m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = returnFocusType(m.focusPanel)
 
 	m.fileModel.maxFilePanel = (m.fullWidth - common.Config.SidebarWidth - m.fileModel.filePreview.GetWidth()) / 20
 
@@ -134,26 +133,26 @@ func (m *model) toggleFilePreviewPanel() {
 
 // Focus on next file panel
 func (m *model) nextFilePanel() {
-	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = noneFocus
+	m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = false
 	if m.filePanelFocusIndex == (len(m.fileModel.filePanels) - 1) {
 		m.filePanelFocusIndex = 0
 	} else {
 		m.filePanelFocusIndex++
 	}
 
-	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = returnFocusType(m.focusPanel)
+	m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = returnFocusType(m.focusPanel)
 }
 
 // Focus on previous file panel
 func (m *model) previousFilePanel() {
-	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = noneFocus
+	m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = false
 	if m.filePanelFocusIndex == 0 {
 		m.filePanelFocusIndex = (len(m.fileModel.filePanels) - 1)
 	} else {
 		m.filePanelFocusIndex--
 	}
 
-	m.fileModel.filePanels[m.filePanelFocusIndex].focusType = returnFocusType(m.focusPanel)
+	m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = returnFocusType(m.focusPanel)
 }
 
 // Focus on sidebar
@@ -163,10 +162,10 @@ func (m *model) focusOnSideBar() {
 	}
 	if m.focusPanel == sidebarFocus {
 		m.focusPanel = nonePanelFocus
-		m.fileModel.filePanels[m.filePanelFocusIndex].focusType = focus
+		m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = true
 	} else {
 		m.focusPanel = sidebarFocus
-		m.fileModel.filePanels[m.filePanelFocusIndex].focusType = secondFocus
+		m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = true
 	}
 }
 
@@ -178,10 +177,10 @@ func (m *model) focusOnProcessBar() {
 
 	if m.focusPanel == processBarFocus {
 		m.focusPanel = nonePanelFocus
-		m.fileModel.filePanels[m.filePanelFocusIndex].focusType = focus
+		m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = true
 	} else {
 		m.focusPanel = processBarFocus
-		m.fileModel.filePanels[m.filePanelFocusIndex].focusType = secondFocus
+		m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = false
 	}
 }
 
@@ -193,9 +192,9 @@ func (m *model) focusOnMetadata() {
 
 	if m.focusPanel == metadataFocus {
 		m.focusPanel = nonePanelFocus
-		m.fileModel.filePanels[m.filePanelFocusIndex].focusType = focus
+		m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = true
 	} else {
 		m.focusPanel = metadataFocus
-		m.fileModel.filePanels[m.filePanelFocusIndex].focusType = secondFocus
+		m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = false
 	}
 }

--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -165,7 +165,7 @@ func (m *model) focusOnSideBar() {
 		m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = true
 	} else {
 		m.focusPanel = sidebarFocus
-		m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = true
+		m.fileModel.filePanels[m.filePanelFocusIndex].isFocused = false
 	}
 }
 

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -129,7 +129,7 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen //
 
 func (m *model) normalAndBrowserModeKey(msg string) tea.Cmd {
 	// if not focus on the filepanel return
-	if m.getFocusedFilePanel().isFocused != true {
+	if !m.getFocusedFilePanel().isFocused {
 		if m.focusPanel == sidebarFocus && slices.Contains(common.Hotkeys.Confirm, msg) {
 			m.sidebarSelectDirectory()
 		}

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -129,7 +129,7 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen //
 
 func (m *model) normalAndBrowserModeKey(msg string) tea.Cmd {
 	// if not focus on the filepanel return
-	if m.getFocusedFilePanel().focusType != focus {
+	if m.getFocusedFilePanel().isFocused != true {
 		if m.focusPanel == sidebarFocus && slices.Contains(common.Hotkeys.Confirm, msg) {
 			m.sidebarSelectDirectory()
 		}

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -644,7 +644,7 @@ func (m *model) getFilePanelItems() {
 		var fileElement []element
 		nowTime := time.Now()
 		// Check last time each element was updated, if less then 3 seconds ignore
-		if filePanel.isFocused == false && nowTime.Sub(filePanel.lastTimeGetElement) < 3*time.Second {
+		if !filePanel.isFocused && nowTime.Sub(filePanel.lastTimeGetElement) < 3*time.Second {
 			// TODO : revisit this. This feels like a duct tape solution of an actual
 			// deep rooted problem. This feels very hacky.
 			if !m.updatedToggleDotFile {
@@ -664,7 +664,7 @@ func (m *model) getFilePanelItems() {
 
 		reRenderTime := int(float64(len(filePanel.element)) / 100)
 
-		if filePanel.isFocused != false && !focusPanelReRender &&
+		if filePanel.isFocused && !focusPanelReRender &&
 			nowTime.Sub(filePanel.lastTimeGetElement) < time.Duration(reRenderTime)*time.Second {
 			continue
 		}

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -55,7 +55,7 @@ func (m *model) filePanelRender() string {
 			filePanelWidth = m.fileModel.width
 		}
 
-		f[i] = filePanel.Render(m.mainPanelHeight, filePanelWidth, filePanel.focusType != noneFocus)
+		f[i] = filePanel.Render(m.mainPanelHeight, filePanelWidth, filePanel.isFocused != false)
 	}
 	return lipgloss.JoinHorizontal(lipgloss.Top, f...)
 }

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -55,7 +55,7 @@ func (m *model) filePanelRender() string {
 			filePanelWidth = m.fileModel.width
 		}
 
-		f[i] = filePanel.Render(m.mainPanelHeight, filePanelWidth, filePanel.isFocused != false)
+		f[i] = filePanel.Render(m.mainPanelHeight, filePanelWidth, filePanel.isFocused)
 	}
 	return lipgloss.JoinHorizontal(lipgloss.Top, f...)
 }

--- a/src/internal/test_utils.go
+++ b/src/internal/test_utils.go
@@ -14,8 +14,10 @@ import (
 	"github.com/yorukot/superfile/src/internal/utils"
 )
 
-const DefaultTestTick = 10 * time.Millisecond
-const DefaultTestTimeout = time.Second
+const (
+	DefaultTestTick    = 10 * time.Millisecond
+	DefaultTestTimeout = time.Second
+)
 
 // -------------------- Model setup utils
 
@@ -162,7 +164,8 @@ func verifyPreventedPasteResults(t *testing.T, m *model, originalPath string) {
 
 // Helper function to verify successful paste results
 func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFiles []string,
-	originalPath string, shouldOriginalExist bool) {
+	originalPath string, shouldOriginalExist bool,
+) {
 	t.Helper()
 	// Verify expected files were created in destination
 	verifyDestinationFiles(t, targetDir, expectedDestFiles)

--- a/src/internal/test_utils.go
+++ b/src/internal/test_utils.go
@@ -14,10 +14,8 @@ import (
 	"github.com/yorukot/superfile/src/internal/utils"
 )
 
-const (
-	DefaultTestTick    = 10 * time.Millisecond
-	DefaultTestTimeout = time.Second
-)
+const DefaultTestTick = 10 * time.Millisecond
+const DefaultTestTimeout = time.Second
 
 // -------------------- Model setup utils
 
@@ -164,8 +162,7 @@ func verifyPreventedPasteResults(t *testing.T, m *model, originalPath string) {
 
 // Helper function to verify successful paste results
 func verifySuccessfulPasteResults(t *testing.T, targetDir string, expectedDestFiles []string,
-	originalPath string, shouldOriginalExist bool,
-) {
+	originalPath string, shouldOriginalExist bool) {
 	t.Helper()
 	// Verify expected files were created in destination
 	verifyDestinationFiles(t, targetDir, expectedDestFiles)

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -17,13 +17,16 @@ import (
 // Type representing the mode of the panel
 type panelMode uint
 
+// [Depreciated]
+// Replaced By a simple bool variable isFocused , which is a part of the FilePanel struct itself
 // Type representing the focus type of the file panel
-type filePanelFocusType uint
+// type filePanelFocusType uint
 
 // Type representing the type of focused panel
-type focusPanelType int
-
-type hotkeyType int
+type (
+	focusPanelType int
+	hotkeyType     int
+)
 
 type modelQuitStateType int
 
@@ -44,12 +47,17 @@ const (
 	metadataFocus
 )
 
+//[Depreciating] The below typed constants used to determine which
+//panel is currently being focued , is being replaced with simpler
+//isFocused bool value , This tells wheather the focus is currently on the panel =>TRUE
+//else for other oher case ,where the panel is not under foucs,the value is =>FALSE
+
 // Constants for file panel with no focus
-const (
-	noneFocus filePanelFocusType = iota
-	secondFocus
-	focus
-)
+//const (
+//noneFocus filePanelFocusType = iota
+//secondFocus
+//focus
+//)
 
 // Constants for select mode or browser mode
 const (
@@ -158,7 +166,7 @@ type fileModel struct {
 type filePanel struct {
 	cursor             int
 	render             int
-	focusType          filePanelFocusType
+	isFocused          bool
 	location           string
 	sortOptions        sortOptionsModel
 	panelMode          panelMode

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -18,10 +18,9 @@ import (
 type panelMode uint
 
 // Type representing the type of focused panel
-type (
-	focusPanelType int
-	hotkeyType     int
-)
+type focusPanelType int
+
+type hotkeyType int
 
 type modelQuitStateType int
 

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -145,7 +145,6 @@ type fileModel struct {
 	filePreview  preview.Model
 }
 
-// filePanel.filePanelFocusType 's implementation  is being replaced with a isFocused bool variable .
 // Panel representing a file
 type filePanel struct {
 	cursor             int

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -17,10 +17,22 @@ import (
 // Type representing the mode of the panel
 type panelMode uint
 
-// [Depreciated]
-// Replaced By a simple bool variable isFocused , which is a part of the FilePanel struct itself
+// [Depreciated] - filePanel.filePanelFocusType 's implementation  is being replaced with a isFocused bool variable .
+
+// The below typed constants used to determine which
+// panel is currently being focused , is being replaced with simpler
+// isFocused bool value , This tells wheather the focus is currently on the panel =>TRUE
+// else for other oher case ,where the panel is not under ,the value is =>FALSE
+
 // Type representing the focus type of the file panel
 // type filePanelFocusType uint
+
+// Earlier implementation
+// const (
+// noneFocus filePanelFocusType = iota
+// secondFocus
+// focus
+// )
 
 // Type representing the type of focused panel
 type (
@@ -46,18 +58,6 @@ const (
 	sidebarFocus
 	metadataFocus
 )
-
-//[Depreciating] The below typed constants used to determine which
-//panel is currently being focued , is being replaced with simpler
-//isFocused bool value , This tells wheather the focus is currently on the panel =>TRUE
-//else for other oher case ,where the panel is not under foucs,the value is =>FALSE
-
-// Constants for file panel with no focus
-//const (
-//noneFocus filePanelFocusType = iota
-//secondFocus
-//focus
-//)
 
 // Constants for select mode or browser mode
 const (
@@ -162,6 +162,7 @@ type fileModel struct {
 	filePreview  preview.Model
 }
 
+// filePanel.filePanelFocusType 's implementation  is being replaced with a isFocused bool variable .
 // Panel representing a file
 type filePanel struct {
 	cursor             int

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -17,23 +17,6 @@ import (
 // Type representing the mode of the panel
 type panelMode uint
 
-// [Depreciated] - filePanel.filePanelFocusType 's implementation  is being replaced with a isFocused bool variable .
-
-// The below typed constants used to determine which
-// panel is currently being focused , is being replaced with simpler
-// isFocused bool value , This tells wheather the focus is currently on the panel =>TRUE
-// else for other oher case ,where the panel is not under ,the value is =>FALSE
-
-// Type representing the focus type of the file panel
-// type filePanelFocusType uint
-
-// Earlier implementation
-// const (
-// noneFocus filePanelFocusType = iota
-// secondFocus
-// focus
-// )
-
 // Type representing the type of focused panel
 type (
 	focusPanelType int

--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -39,12 +39,8 @@ func (m *model) validateLayout() error {
 func filePanelSlice(dir []string) []filePanel {
 	res := make([]filePanel, len(dir))
 	for i := range dir {
-		// Making the first panel as the default focus panel
-		// while others remain secondFocus
-		isFocus := false
-		if i == 0 {
-			isFocus = true
-		}
+		// Making the first panel as the focussed
+		isFocus := i == 0
 		res[i] = defaultFilePanel(dir[i], isFocus)
 	}
 	return res

--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -93,18 +93,19 @@ func (f focusPanelType) String() string {
 	}
 }
 
-//func (f filePanelFocusType) String() string {
-//switch f {
-//case noneFocus:
-//return "noneFocus"
-//case secondFocus:
-//return "secondFocus"
-//case focus:
-//return "focus"
-//default:
-//return invalidTypeString
-//}
-//}
+// [Depreciated] - filePanel.filePanelFocusType 's implementation  is being replaced with a isFocused bool variable .
+// func (f filePanelFocusType) String() string {
+// switch f {
+// case noneFocus:
+// return "noneFocus"
+// case secondFocus:
+// return "secondFocus"
+// case focus:
+// return "focus"
+// default:
+// return invalidTypeString
+// }
+// }
 
 func (p panelMode) String() string {
 	switch p {

--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -41,16 +41,16 @@ func filePanelSlice(dir []string) []filePanel {
 	for i := range dir {
 		// Making the first panel as the default focus panel
 		// while others remain secondFocus
-		focusType := secondFocus
+		isFocus := false
 		if i == 0 {
-			focusType = focus
+			isFocus = true
 		}
-		res[i] = defaultFilePanel(dir[i], focusType)
+		res[i] = defaultFilePanel(dir[i], isFocus)
 	}
 	return res
 }
 
-func defaultFilePanel(dir string, currentFocusType filePanelFocusType) filePanel {
+func defaultFilePanel(dir string, focused bool) filePanel {
 	return filePanel{
 		render:   0,
 		cursor:   0,
@@ -70,7 +70,7 @@ func defaultFilePanel(dir string, currentFocusType filePanelFocusType) filePanel
 			},
 		},
 		panelMode:        browserMode,
-		focusType:        currentFocusType,
+		isFocused:        focused,
 		directoryRecords: make(map[string]directoryRecord),
 		searchBar:        common.GenerateSearchBar(),
 	}
@@ -93,18 +93,18 @@ func (f focusPanelType) String() string {
 	}
 }
 
-func (f filePanelFocusType) String() string {
-	switch f {
-	case noneFocus:
-		return "noneFocus"
-	case secondFocus:
-		return "secondFocus"
-	case focus:
-		return "focus"
-	default:
-		return invalidTypeString
-	}
-}
+//func (f filePanelFocusType) String() string {
+//switch f {
+//case noneFocus:
+//return "noneFocus"
+//case secondFocus:
+//return "secondFocus"
+//case focus:
+//return "focus"
+//default:
+//return invalidTypeString
+//}
+//}
 
 func (p panelMode) String() string {
 	switch p {

--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -93,20 +93,6 @@ func (f focusPanelType) String() string {
 	}
 }
 
-// [Depreciated] - filePanel.filePanelFocusType 's implementation  is being replaced with a isFocused bool variable .
-// func (f filePanelFocusType) String() string {
-// switch f {
-// case noneFocus:
-// return "noneFocus"
-// case secondFocus:
-// return "secondFocus"
-// case focus:
-// return "focus"
-// default:
-// return invalidTypeString
-// }
-// }
-
 func (p panelMode) String() string {
 	switch p {
 	case selectMode:


### PR DESCRIPTION
The filePanelFocusType typed constant with multiple states (noneFocus, secondFocus, focus) added unnecessary complexity for managing panel focus. It also made the code harder to read and maintain.
Solution

Replaced filePanelFocusType with a simple isFocused boolean field in filePanel.
isFocused = true → panel is focused
isFocused = false → panel is not focused

This change removes unused constants and simplifies focus handling.




Refs #1033 
Refs #1030 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified panel focus handling to a single, consistent indicator across navigation, rendering, and key interactions, improving reliability and consistency in focus behavior.
- Style
  - Minor formatting cleanups for readability without changing behavior.
- Chores
  - Consolidated internal variable declarations and adjusted logging to reflect the updated focus indicator.

No user-facing features changed; interactions should feel more consistent and stable, especially when switching panels and using the sidebar or process bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->