### PR TITLE
refactor(ansi): Migrate from github.com/charmbracelet/x/exp/term/ansi to github.com/charmbracelet/x/ansi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/term v0.18.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
@@ -61,7 +62,6 @@ require (
 	github.com/BourgeoisBear/rasterm v1.1.1
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/x/exp/term v0.0.0-20240814160751-e2dc8b53b604
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/disintegration/imaging v1.6.2
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/charmbracelet/x/ansi v0.9.3 h1:BXt5DHS/MKF+LjuK4huWrC6NCvHtexww7dMayh
 github.com/charmbracelet/x/ansi v0.9.3/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd h1:vy0GVL4jeHEwG5YOXDmi86oYw2yuYUGqz6a8sLwg0X8=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
-github.com/charmbracelet/x/exp/term v0.0.0-20240814160751-e2dc8b53b604 h1:Dd3IMfj+uWPNYXGOiqP698ssKfJcKZGjAW1T5H7Btqc=
-github.com/charmbracelet/x/exp/term v0.0.0-20240814160751-e2dc8b53b604/go.mod h1:3yyfTUvntvRMtnNv2YRxn5q0HzBiShrse/DjoGHtM18=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"runtime"
 
-	"github.com/charmbracelet/x/exp/term/ansi"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/pelletier/go-toml/v2"
 
 	"github.com/yorukot/superfile/src/config/icon"
@@ -103,7 +103,6 @@ func ValidateConfig(c *ConfigType) error {
 // with the default values and modify the hotkeys if the FixHotkeys flag is on.
 func LoadHotkeysFile() {
 	err := utils.LoadTomlFile(variable.HotkeysFile, HotkeysTomlString, &Hotkeys, variable.FixHotkeys)
-
 	if err != nil {
 		userMsg := fmt.Sprintf("%s%s", LipglossError, err.Error())
 
@@ -194,12 +193,12 @@ func LoadAllDefaultConfig(content embed.FS) {
 	}
 
 	// Prevent failure for first time app run by making sure parent directories exists
-	if err = os.MkdirAll(filepath.Dir(variable.ThemeFileVersion), 0755); err != nil {
+	if err = os.MkdirAll(filepath.Dir(variable.ThemeFileVersion), 0o755); err != nil {
 		slog.Error("Error creating theme file parent directory", "error", err)
 		return
 	}
 
-	err = os.WriteFile(variable.ThemeFileVersion, []byte(variable.CurrentVersion), 0644)
+	err = os.WriteFile(variable.ThemeFileVersion, []byte(variable.CurrentVersion), 0o644)
 	if err != nil {
 		slog.Error("Error writing theme file version", "error", err)
 	}
@@ -230,7 +229,7 @@ func WriteThemeFiles(content embed.FS) error {
 	_, err := os.Stat(variable.ThemeFolder)
 
 	if os.IsNotExist(err) {
-		if err = os.MkdirAll(variable.ThemeFolder, 0755); err != nil {
+		if err = os.MkdirAll(variable.ThemeFolder, 0o755); err != nil {
 			slog.Error("Error creating theme directory", "error", err)
 			return err
 		}

--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -13,7 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/x/exp/term/ansi"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TruncateText(text string, maxChars int, tails string) string {

--- a/src/internal/model_render_test.go
+++ b/src/internal/model_render_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/x/exp/term/ansi"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -138,7 +138,7 @@ func TestFilePreviewRenderWithDimensions(t *testing.T) {
 			curDir := filepath.Join(curTestDir, "dir"+strconv.Itoa(i))
 			utils.SetupDirectories(t, curDir)
 			filePath := filepath.Join(curDir, tt.fileName)
-			err := os.WriteFile(filePath, []byte(tt.fileContent), 0644)
+			err := os.WriteFile(filePath, []byte(tt.fileContent), 0o644)
 			require.NoError(t, err)
 
 			m := defaultTestModel(curDir)

--- a/src/internal/model_test.go
+++ b/src/internal/model_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 	// Create testDir
 	testDir = filepath.Join(os.TempDir(), "spf_testdir")
 	cleanupTestDir()
-	if err := os.Mkdir(testDir, 0755); err != nil {
+	if err := os.Mkdir(testDir, 0o755); err != nil {
 		fmt.Printf("error while creating test directory, err : %v", err)
 		os.Exit(1)
 	}
@@ -225,7 +225,7 @@ func TestChooserFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := defaultTestModel(dir1)
 			if tt.expectedQuit {
-				err := os.WriteFile(tt.chooserFile, []byte{}, 0644)
+				err := os.WriteFile(tt.chooserFile, []byte{}, 0o644)
 				require.NoError(t, err)
 			}
 			variable.SetChooserFile(tt.chooserFile)

--- a/src/internal/ui/prompt/model_test.go
+++ b/src/internal/ui/prompt/model_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/x/exp/term/ansi"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/src/internal/ui/rendering/border.go
+++ b/src/internal/ui/rendering/border.go
@@ -3,7 +3,7 @@ package rendering
 import (
 	"strings"
 
-	"github.com/charmbracelet/x/exp/term/ansi"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/src/internal/ui/rendering/renderer_core.go
+++ b/src/internal/ui/rendering/renderer_core.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/x/exp/term/ansi"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Add lines as much as the remaining capacity allows

--- a/src/internal/ui/rendering/truncate.go
+++ b/src/internal/ui/rendering/truncate.go
@@ -3,7 +3,7 @@ package rendering
 import (
 	"log/slog"
 
-	"github.com/charmbracelet/x/exp/term/ansi"
+	"github.com/charmbracelet/x/ansi"
 )
 
 type TruncateStyle int

--- a/src/internal/ui/rendering/truncate_test.go
+++ b/src/internal/ui/rendering/truncate_test.go
@@ -75,7 +75,7 @@ func TestTruncate(t *testing.T) {
 		},
 		{
 			name:     "Ansi color sequence",
-			line:     testStyle.Render("1234"),
+			line:     testStyle.Render("12345"),
 			maxWidth: 4,
 			style:    TailsTruncateRight,
 			expected: testStyle.Render("1..."),

--- a/src/internal/ui/rendering/truncate_test.go
+++ b/src/internal/ui/rendering/truncate_test.go
@@ -80,6 +80,13 @@ func TestTruncate(t *testing.T) {
 			style:    TailsTruncateRight,
 			expected: testStyle.Render("1..."),
 		},
+		{
+			name:     "Ansi color sequence with just enough widht",
+			line:     testStyle.Render("1234"),
+			maxWidth: 4,
+			style:    TailsTruncateRight,
+			expected: testStyle.Render("1234"),
+		},
 	}
 	for _, tt := range testdata {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/internal/utils/file_utils.go
+++ b/src/internal/utils/file_utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -13,9 +14,7 @@ import (
 	"github.com/adrg/xdg"
 	"github.com/pelletier/go-toml/v2"
 
-	"bufio"
-
-	"github.com/charmbracelet/x/exp/term/ansi"
+	"github.com/charmbracelet/x/ansi"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -28,7 +27,7 @@ func WriteTomlData(filePath string, data interface{}) error {
 		// return a wrapped error
 		return fmt.Errorf("error encoding data : %w", err)
 	}
-	err = os.WriteFile(filePath, tomlData, 0644)
+	err = os.WriteFile(filePath, tomlData, 0o644)
 	if err != nil {
 		return fmt.Errorf("error writing file : %w", err)
 	}
@@ -147,7 +146,7 @@ func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) 
 	}()
 	// Copy the original file to the backup
 	// Open it in read write mode
-	origFile, err := os.OpenFile(filePath, os.O_RDWR, 0644)
+	origFile, err := os.OpenFile(filePath, os.O_RDWR, 0o644)
 	if err != nil {
 		resultErr.UpdateMessageAndError("failed to open original file for backup", err)
 		return resultErr
@@ -166,7 +165,6 @@ func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) 
 		return resultErr
 	}
 	_, err = origFile.WriteAt(tomlData, 0)
-
 	if err != nil {
 		resultErr.UpdateMessageAndError("failed to write TOML data to original file", err)
 		return resultErr
@@ -230,7 +228,7 @@ func CreateDirectories(dirs ...string) error {
 		if dir == "" {
 			continue
 		}
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", dir, err)
 		}
 	}
@@ -241,7 +239,7 @@ func CreateDirectories(dirs ...string) error {
 func CreateFiles(files ...string) error {
 	for _, file := range files {
 		if _, err := os.Stat(file); os.IsNotExist(err) {
-			if err = os.WriteFile(file, nil, 0644); err != nil {
+			if err = os.WriteFile(file, nil, 0o644); err != nil {
 				return fmt.Errorf("failed to create file %s: %w", file, err)
 			}
 		}


### PR DESCRIPTION
This PR replaces all usages of the experimental ANSI package with the stable version.

Changes include:
- Updated all imports of github.com/charmbracelet/x/exp/term/ansi to github.com/charmbracelet/x/ansi.
- Modified the ReadFileContent function in utils/file_utils.go to use the stable ansi package.
- Ran `go mod tidy` to remove the old dependency and update go.mod and go.sum accordingly.

No other experimental ANSI references remain in the codebase. This ensures the project relies on the maintained stable package and improves reliability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing features added.

- Refactor
  - Updated terminal text-handling imports and standardized file-permission literal notation across the codebase.

- Tests
  - Adjusted tests to reflect import and permission-notation changes and refined ANSI truncation test cases.

- Chores
  - Updated indirect third-party dependency version.

- Impact
  - No user-visible behavioral or performance changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->