### PR TITLE
docs: fix incorrect zoxide plugin config name

### DIFF
--- a/website/src/content/docs/configure/enable-plugin.md
+++ b/website/src/content/docs/configure/enable-plugin.md
@@ -55,7 +55,7 @@ Find the plugin section in your config and change its value from `false` to `tru
 
 ```toml
 metadata = false
-zoxide = false
+zoxide_support = false
 ```
 
 Set any plugin to `true` to enable it, or `false` to disable it.

--- a/website/src/content/docs/list/plugin-list.md
+++ b/website/src/content/docs/list/plugin-list.md
@@ -22,6 +22,6 @@ Superfile supports various plugins to extend its functionality. Below is a compl
 
 - **Requirements:** [`zoxide`](https://github.com/ajeetdsouza/zoxide)
 
-- **Config name:** `zoxide`
+- **Config name:** `zoxide_support`
 
 - **Usage:** Press `z` to open the zoxide navigation modal. Start typing to search directories, use arrow keys to navigate results, and press Enter to jump to a directory.


### PR DESCRIPTION
This PR fixes incorrect references to the Zoxide plugin configuration name in the documentation. The docs previously showed zoxide as the config key, but the actual implementation uses zoxide_support.

Problem

Users following the docs to enable the Zoxide plugin would set zoxide, which does not exist, causing the plugin to fail. The correct key is zoxide_support.

Changes Made

website/src/content/docs/list/plugin-list.md – Updated zoxide → zoxide_support (line 25)

website/src/content/docs/configure/enable-plugin.md – Updated config example zoxide = false → zoxide_support = false (line 58)

Verification

The correct key zoxide_support is confirmed in the source code:

src/superfile_config/config.toml (line 92): zoxide_support = false

src/internal/common/config_type.go (line 104): ZoxideSupport bool toml:"zoxide_support"

src/internal/config_function.go (line 76): if common.Config.ZoxideSupport

Before & After

Before:

# In documentation
zoxide = false


Config name: zoxide

After:

# In documentation
zoxide_support = false