### PR TITLE
fix(nix): resolve build failures in the nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745875161,
-        "narHash": "sha256-0YkWCS13jpoo3+sX/3kcgdxBNt1VZTmvF+FhZb4rFKI=",
+        "lastModified": 1756047880,
+        "narHash": "sha256-JeuGh9kA1SPL70fnvpLxkIkCWpTjtoPaus3jzvdna0k=",
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "2cbd7fdd6eeab65c494cc426e18f4e4d2a5e35c0",
+        "rev": "47d628dc3b506bd28632e47280c6b89d3496909d",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,14 @@
             version = "1.3.3";
             src = ./.;
             modules = ./gomod2nix.toml;
-            nativeCheckInputs = [ pkgs.writableTmpDirAsHomeHook ];
+
+            nativeCheckInputs = with pkgs; [
+              zoxide
+              exiftool
+              writableTmpDirAsHomeHook
+            ];
           };
+
           default = superfile;
         };
 


### PR DESCRIPTION
This pr resolves two build failures when using the nix flake.

### flake inputs

Some pkgs where outdated, thus causing a build failure.
Fixed by updating the `flake.lock` file.

### Check phase

After building the pkg, the tests are ran in the check phase. This phase failed because it required some pkgs that the flake was not providing: `zoxide` and `exiftool`.
Fixed by adding those pkgs to the `nativeCheckInputs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated build/check dependencies for the superfile package, adding additional tools to the validation environment. This affects development and CI only and does not alter runtime behavior or the user experience.

- Tests
  - Expanded the check environment with supplementary tools used during package checks. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->