### PR TITLE
fix(issue-1066): Fixed issue where enter was not searchable

### DIFF
--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -250,7 +250,8 @@ func fuzzySearch(query string, data []helpMenuModalData) []helpMenuModalData {
 		if item.subTitle != "" {
 			continue
 		}
-		haystack = append(haystack, item.description)
+		searchText := strings.Join(item.hotkey," ") + " " + item.description
+		haystack = append(haystack, searchText)
 		idxMap = append(idxMap, i)
 	}
 

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -250,7 +250,7 @@ func fuzzySearch(query string, data []helpMenuModalData) []helpMenuModalData {
 		if item.subTitle != "" {
 			continue
 		}
-		searchText := strings.Join(item.hotkey," ") + " " + item.description
+		searchText := strings.Join(item.hotkey, " ") + " " + item.description
 		haystack = append(haystack, searchText)
 		idxMap = append(idxMap, i)
 	}


### PR DESCRIPTION
Now when you enter helpmenu and search for "enter". Commands where the Return key is involved will show up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fuzzy search now matches hotkey terms in addition to descriptions, letting you find commands by typing shortcut keys (e.g., “Ctrl K”). Improves discoverability and speeds navigation across all non-subtitle items. Search results and ranking remain consistent. No configuration or UI changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->