### PR TITLE
fix: fix child process spawning attached

### DIFF
--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -98,7 +98,7 @@ func (m *model) executeOpenCommand() {
 	}
 
 	cmd := exec.Command(openCommand, panel.element[panel.cursor].location)
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != utils.OsWindows {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 		// Optionally, redirect stdio to avoid terminal hangups
 		cmd.Stdin = nil

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -98,13 +97,7 @@ func (m *model) executeOpenCommand() {
 	}
 
 	cmd := exec.Command(openCommand, panel.element[panel.cursor].location)
-	if runtime.GOOS != utils.OsWindows {
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-		// Optionally, redirect stdio to avoid terminal hangups
-		cmd.Stdin = nil
-		cmd.Stdout = nil
-		cmd.Stderr = nil
-	}
+	utils.DetachFromTerminal(cmd)
 	err := cmd.Start()
 	if err != nil {
 		slog.Error("Error while open file with", "error", err)

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -97,6 +98,13 @@ func (m *model) executeOpenCommand() {
 	}
 
 	cmd := exec.Command(openCommand, panel.element[panel.cursor].location)
+	if runtime.GOOS != "windows" {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		// Optionally, redirect stdio to avoid terminal hangups
+		cmd.Stdin = nil
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+	}
 	err := cmd.Start()
 	if err != nil {
 		slog.Error("Error while open file with", "error", err)

--- a/src/internal/utils/detach_unix.go
+++ b/src/internal/utils/detach_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package utils
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func DetachFromTerminal(cmd *exec.Cmd) {
+	// Start new session so child isn't tied to the TTY (prevents SIGHUP on terminal close).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// Optionally, redirect stdio to avoid terminal hangups
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+}

--- a/src/internal/utils/detach_windows.go
+++ b/src/internal/utils/detach_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package utils
+
+import "os/exec"
+
+func DetachFromTerminal(cmd *exec.Cmd) {
+	// No-op: current Windows path uses rundll32 and returns immediately.
+	// If needed later, set CreationFlags/HideWindow via syscall.SysProcAttr.
+}


### PR DESCRIPTION
Fixes #1083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process launching on Linux and other non-Windows platforms: external commands now start in their own session and detach from the terminal. This prevents the app from hanging, suppresses unintended console output, and keeps the app responsive after opening files, links, or external tools. Windows and macOS behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->