### PR TITLE
refactor: common operation on pinned directory file using PinnedManager

### DIFF
--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -6,8 +6,6 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/yorukot/superfile/src/internal/ui/sidebar"
-
 	"github.com/yorukot/superfile/src/internal/common"
 
 	variable "github.com/yorukot/superfile/src/config"
@@ -16,7 +14,7 @@ import (
 // Pinned directory
 func (m *model) pinnedDirectory() {
 	panel := &m.fileModel.filePanels[m.filePanelFocusIndex]
-	err := sidebar.TogglePinnedDirectory(panel.location)
+	err := m.sidebarModel.TogglePinnedDirectory(panel.location)
 	if err != nil {
 		slog.Error("Error while toggling pinned directory", "error", err)
 	}

--- a/src/internal/ui/sidebar/directory_utils.go
+++ b/src/internal/ui/sidebar/directory_utils.go
@@ -1,109 +1,14 @@
 package sidebar
 
 import (
-	"encoding/json"
-	"fmt"
-	"log/slog"
 	"os"
-	"path/filepath"
 	"slices"
 
 	"github.com/adrg/xdg"
 
-	variable "github.com/yorukot/superfile/src/config"
 	"github.com/yorukot/superfile/src/config/icon"
 	"github.com/yorukot/superfile/src/internal/utils"
 )
-
-// Return all sidebar directories
-func getDirectories() []directory {
-	return formDirctorySlice(getWellKnownDirectories(), getPinnedDirectories(), getExternalMediaFolders())
-}
-
-func formDirctorySlice(homeDirectories []directory, pinnedDirectories []directory,
-	diskDirectories []directory) []directory {
-	// Preallocation for efficiency
-	totalCapacity := len(homeDirectories) + len(pinnedDirectories) + len(diskDirectories) + 2
-	directories := make([]directory, 0, totalCapacity)
-
-	directories = append(directories, homeDirectories...)
-	directories = append(directories, pinnedDividerDir)
-	directories = append(directories, pinnedDirectories...)
-	directories = append(directories, diskDividerDir)
-	directories = append(directories, diskDirectories...)
-	return directories
-}
-
-// Return system default directory e.g. Home, Downloads, etc
-func getWellKnownDirectories() []directory {
-	wellKnownDirectories := []directory{
-		{Location: xdg.Home, Name: icon.Home + icon.Space + "Home"},
-		{Location: xdg.UserDirs.Download, Name: icon.Download + icon.Space + "Downloads"},
-		{Location: xdg.UserDirs.Documents, Name: icon.Documents + icon.Space + "Documents"},
-		{Location: xdg.UserDirs.Pictures, Name: icon.Pictures + icon.Space + "Pictures"},
-		{Location: xdg.UserDirs.Videos, Name: icon.Videos + icon.Space + "Videos"},
-		{Location: xdg.UserDirs.Music, Name: icon.Music + icon.Space + "Music"},
-		{Location: xdg.UserDirs.Templates, Name: icon.Templates + icon.Space + "Templates"},
-		{Location: xdg.UserDirs.PublicShare, Name: icon.PublicShare + icon.Space + "PublicShare"},
-	}
-
-	return slices.DeleteFunc(wellKnownDirectories, func(d directory) bool {
-		_, err := os.Stat(d.Location)
-		return err != nil
-	})
-}
-
-// Get user pinned directories
-func getPinnedDirectories() []directory {
-	directories := []directory{}
-	var paths []string
-
-	jsonData, err := os.ReadFile(variable.PinnedFile)
-	if err != nil {
-		slog.Error("Error while read superfile data", "error", err)
-		return directories
-	}
-
-	// Check if the data is in the old format
-	// TODO: Remove this after a release 1.2.4
-	if err := json.Unmarshal(jsonData, &paths); err == nil {
-		for _, path := range paths {
-			directoryName := filepath.Base(path)
-			directories = append(directories, directory{Location: path, Name: directoryName})
-		}
-	} else {
-		// Check if the data is in the new format
-		if err := json.Unmarshal(jsonData, &directories); err != nil {
-			// If the data is in neither format, log the error
-			slog.Error("Error parsing pinned data", "error", err)
-		}
-	}
-
-	clean := removeNotExistingDirectories(directories)
-
-	return clean
-}
-
-// removeNotExistingDirectories removes directories that do not exist from the pinned directories list
-func removeNotExistingDirectories(dirs []directory) []directory {
-	cleanedDirs := make([]directory, 0, len(dirs))
-	for _, dir := range dirs {
-		if _, err := os.Stat(dir.Location); err == nil {
-			cleanedDirs = append(cleanedDirs, dir)
-		} else if !os.IsNotExist(err) {
-			slog.Warn("Error while checking pinned directory", "directory", dir.Location, "error", err)
-		}
-	}
-
-	// if any directory is removed, update the pinned file
-	if len(cleanedDirs) != len(dirs) {
-		if err := savePinnedDirectories(dirs); err != nil {
-			slog.Error("error saving pinned directories", "error", err)
-		}
-	}
-
-	return cleanedDirs
-}
 
 // Fuzzy search function for a list of directories.
 func fuzzySearch(query string, dirs []directory) []directory {
@@ -131,52 +36,49 @@ func fuzzySearch(query string, dirs []directory) []directory {
 	return filteredDirs
 }
 
+// Return all sidebar directories
+func getDirectories(pinnedMgr *PinnedManager) []directory {
+	return formDirctorySlice(getWellKnownDirectories(), pinnedMgr.Load(), getExternalMediaFolders())
+}
+
+// Return system default directory e.g. Home, Downloads, etc
+func getWellKnownDirectories() []directory {
+	wellKnownDirectories := []directory{
+		{Location: xdg.Home, Name: icon.Home + icon.Space + "Home"},
+		{Location: xdg.UserDirs.Download, Name: icon.Download + icon.Space + "Downloads"},
+		{Location: xdg.UserDirs.Documents, Name: icon.Documents + icon.Space + "Documents"},
+		{Location: xdg.UserDirs.Pictures, Name: icon.Pictures + icon.Space + "Pictures"},
+		{Location: xdg.UserDirs.Videos, Name: icon.Videos + icon.Space + "Videos"},
+		{Location: xdg.UserDirs.Music, Name: icon.Music + icon.Space + "Music"},
+		{Location: xdg.UserDirs.Templates, Name: icon.Templates + icon.Space + "Templates"},
+		{Location: xdg.UserDirs.PublicShare, Name: icon.PublicShare + icon.Space + "PublicShare"},
+	}
+
+	return slices.DeleteFunc(wellKnownDirectories, func(d directory) bool {
+		_, err := os.Stat(d.Location)
+		return err != nil
+	})
+}
+
 // Get filtered directories using fuzzy search logic with three haystacks.
-func getFilteredDirectories(query string) []directory {
+func getFilteredDirectories(query string, pinnedMgr *PinnedManager) []directory {
 	return formDirctorySlice(
 		fuzzySearch(query, getWellKnownDirectories()),
-		fuzzySearch(query, getPinnedDirectories()),
+		fuzzySearch(query, pinnedMgr.Load()),
 		fuzzySearch(query, getExternalMediaFolders()),
 	)
 }
 
-// TogglePinnedDirectory adds or removes a directory from the pinned directories list
-func TogglePinnedDirectory(dir string) error {
-	dirs := getPinnedDirectories()
-	unPinned := false
+func formDirctorySlice(homeDirectories []directory, pinnedDirectories []directory,
+	diskDirectories []directory) []directory {
+	// Preallocation for efficiency
+	totalCapacity := len(homeDirectories) + len(pinnedDirectories) + len(diskDirectories) + 2
+	directories := make([]directory, 0, totalCapacity)
 
-	for i, other := range dirs {
-		if other.Location == dir {
-			dirs = append(dirs[:i], dirs[i+1:]...)
-			unPinned = true
-			break
-		}
-	}
-
-	if !unPinned {
-		dirs = append(dirs, directory{
-			Location: dir,
-			Name:     filepath.Base(dir),
-		})
-	}
-
-	if err := savePinnedDirectories(dirs); err != nil {
-		return fmt.Errorf("error saving pinned directories: %w", err)
-	}
-
-	return nil
-}
-
-// savePinnedDirectories marshals and writes the pinned directories to file.
-func savePinnedDirectories(dirs []directory) error {
-	data, err := json.Marshal(dirs)
-	if err != nil {
-		return fmt.Errorf("error marshaling pinned directories: %w", err)
-	}
-
-	if err := os.WriteFile(variable.PinnedFile, data, 0644); err != nil {
-		return fmt.Errorf("error writing pinned directories file: %w", err)
-	}
-
-	return nil
+	directories = append(directories, homeDirectories...)
+	directories = append(directories, pinnedDividerDir)
+	directories = append(directories, pinnedDirectories...)
+	directories = append(directories, diskDividerDir)
+	directories = append(directories, diskDirectories...)
+	return directories
 }

--- a/src/internal/ui/sidebar/pinned.go
+++ b/src/internal/ui/sidebar/pinned.go
@@ -1,0 +1,102 @@
+package sidebar
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+type PinnedManager struct {
+	filePath string
+}
+
+func NewPinnedFileManager(filePath string) PinnedManager {
+	return PinnedManager{
+		filePath: filePath,
+	}
+}
+
+// Load reads the pinned directories from file and cleans non-existing ones
+func (mgr *PinnedManager) Load() []directory {
+	directories := []directory{}
+
+	jsonData, err := os.ReadFile(mgr.filePath)
+	if err != nil {
+		slog.Error("Error reading pinned directories file", "error", err)
+		return directories
+	}
+
+	// Check for the old format has been dropped in this manager
+	if err := json.Unmarshal(jsonData, &directories); err != nil {
+		slog.Error("Error parsing pinned directories data", "error", err)
+		return directories
+	}
+
+	// Clean non-existing directories
+	cleanedDirs := mgr.Clean(directories)
+
+	return cleanedDirs
+}
+
+// Save marshals and writes the pinned directories to file.
+func (mgr *PinnedManager) Save(dirs []directory) error {
+	data, err := json.Marshal(dirs)
+	if err != nil {
+		return fmt.Errorf("error marshaling pinned directories: %w", err)
+	}
+
+	if err := os.WriteFile(mgr.filePath, data, 0644); err != nil {
+		return fmt.Errorf("error writing pinned directories file: %w", err)
+	}
+
+	return nil
+}
+
+// Toggle adds or removes a directory from the pinned directories list
+func (mgr *PinnedManager) Toggle(dir string) error {
+	dirs := mgr.Load()
+	unPinned := false
+
+	for i, other := range dirs {
+		if other.Location == dir {
+			dirs = append(dirs[:i], dirs[i+1:]...)
+			unPinned = true
+			break
+		}
+	}
+
+	if !unPinned {
+		dirs = append(dirs, directory{
+			Location: dir,
+			Name:     filepath.Base(dir),
+		})
+	}
+
+	if err := mgr.Save(dirs); err != nil {
+		return fmt.Errorf("error saving pinned directories: %w", err)
+	}
+
+	return nil
+}
+
+// Clean removes non-existing directories and optionally saves the updated list
+func (mgr *PinnedManager) Clean(dirs []directory) []directory {
+	cleanedDirs := make([]directory, 0, len(dirs))
+	for _, dir := range dirs {
+		if _, err := os.Stat(dir.Location); err == nil {
+			cleanedDirs = append(cleanedDirs, dir)
+		} else if !os.IsNotExist(err) {
+			slog.Warn("error while checking pinned directory", "directory", dir.Location, "error", err)
+		}
+	}
+
+	if len(cleanedDirs) != len(dirs) {
+		if err := mgr.Save(cleanedDirs); err != nil {
+			slog.Error("error saving pinned directories", "error", err)
+		}
+	}
+
+	return cleanedDirs
+}

--- a/src/internal/ui/sidebar/pinned.go
+++ b/src/internal/ui/sidebar/pinned.go
@@ -92,10 +92,12 @@ func (mgr *PinnedManager) Clean(dirs []directory) []directory {
 		}
 	}
 
-	if len(cleanedDirs) != len(dirs) {
-		if err := mgr.Save(cleanedDirs); err != nil {
-			slog.Error("error saving pinned directories", "error", err)
-		}
+	if len(cleanedDirs) == len(dirs) {
+		return cleanedDirs
+	}
+
+	if err := mgr.Save(cleanedDirs); err != nil {
+		slog.Error("error saving pinned directories", "error", err)
 	}
 
 	return cleanedDirs

--- a/src/internal/ui/sidebar/sidebar.go
+++ b/src/internal/ui/sidebar/sidebar.go
@@ -1,14 +1,11 @@
 package sidebar
 
 import (
-	"encoding/json"
 	"log/slog"
-	"os"
 	"slices"
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	variable "github.com/yorukot/superfile/src/config"
 	"github.com/yorukot/superfile/src/internal/common"
 )
 
@@ -53,14 +50,8 @@ func (s *Model) ConfirmSidebarRename() {
 		}
 	}
 
-	jsonData, err := json.Marshal(pinnedDirs)
-	if err != nil {
-		slog.Error("Error marshaling pinned directories data", "error", err)
-	}
-
-	err = os.WriteFile(variable.PinnedFile, jsonData, 0644)
-	if err != nil {
-		slog.Error("Error updating pinned directories data", "error", err)
+	if err := savePinnedDirectories(pinnedDirs); err != nil {
+		slog.Error("error saving pinned directories", "error", err)
 	}
 }
 

--- a/src/internal/ui/sidebar/type.go
+++ b/src/internal/ui/sidebar/type.go
@@ -14,4 +14,5 @@ type Model struct {
 	rename      textinput.Model
 	renaming    bool
 	searchBar   textinput.Model
+	pinnedMgr   *PinnedManager
 }


### PR DESCRIPTION
Fixes #1082 

Refactors pinned directories logic by introducing a ```PinnedManager``` struct at ```src/internal/ui/sidebar/pinned.go```.

Changes:
  
    Common operations like Load, Save, Clean, Toggle are available.
    Following functions have been ported (signatures are the same) :
    
    getPinnedDirectories -> pinnedMgr.Load
    removeNotExistingDirectories -> pinnedMgr.Clean
    TogglePinnedDirectory -> pinnedMgr.Toggle
    savePinnedDirectories -> pinnedMgr.Save

A ```PinnedManager``` instance is added to ```sidebar.Model``` by reference.


Tested pin/unpin operations across builds, nothing broke.

Note:
This PR is for suggested approach 2, see branch ```refactor/remove-duplicate-save-pinned-file``` for approach 1. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * More reliable pin/unpin of folders in the sidebar with automatic cleanup of missing locations.
  * Sidebar now consistently combines well-known, pinned, and external media folders.
  * Smoother updates and filtering of directories for better responsiveness.

* **Bug Fixes**
  * Removed stale entries when folders are renamed or deleted.
  * Improved persistence to prevent occasional failures when saving pinned folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->