### PR TITLE
chore: migrate from superfile.netlify.app to superfile.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 ### MacOS and Linux
 
 ```bash
-bash -c "$(curl -sLo- https://superfile.netlify.app/install.sh)"
+bash -c "$(curl -sLo- https://superfile.dev/install.sh)"
 ```
 If you want to inspect the script, see : [install.sh](./website/public/install.sh)
 
@@ -74,7 +74,7 @@ If you want to inspect the script, see : [install.sh](./website/public/install.s
 
 #### Powershell
 ```powershell
-powershell -ExecutionPolicy Bypass -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.netlify.app/install.ps1'))"
+powershell -ExecutionPolicy Bypass -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.dev/install.ps1'))"
 ```
 If you want to inspect the script, see : [install.ps1](./website/public/install.ps1)
 
@@ -89,7 +89,7 @@ scoop install superfile
 ```
 
 ### More installation methods
-[Click me to check on how to install](https://superfile.netlify.app/getting-started/installation/)
+[Click me to check on how to install](https://superfile.dev/getting-started/installation/)
 
 ## Build
 
@@ -148,32 +148,32 @@ spf
 
 ## Tutorial
 
-After you install superfile, you can go [here](https://superfile.netlify.app/getting-started/tutorial/) to briefly understand how to use superfile!
+After you install superfile, you can go [here](https://superfile.dev/getting-started/tutorial/) to briefly understand how to use superfile!
 
 ## Plugins
 
-[Click me to the plugins wiki](https://superfile.netlify.app/list/plugin-list/)
+[Click me to the plugins wiki](https://superfile.dev/list/plugin-list/)
 
 ## Themes
 
-[Click me to the theme wiki](https://superfile.netlify.app/configure/custom-theme/)
+[Click me to the theme wiki](https://superfile.dev/configure/custom-theme/)
 
 ## Hotkeys
 
 > [!WARNING]
 > If you are vim/nvim user please change your default hotkeys config to vim version!
 
-[**Click me to see the hotkey wiki**](https://superfile.netlify.app/configure/custom-hotkeys/)
+[**Click me to see the hotkey wiki**](https://superfile.dev/configure/custom-hotkeys/)
 
 ## Notes
 
 We have an auto update functionality, that fetches superfile's latest released version from github (if last timestamp of last version check was less than 24 hours) and prints a prompt to user, if there is a newer version available.
 
-You can turn this off, by setting `auto_check_update` to false in superfile config. [**Click me to see the config wiki**](https://superfile.netlify.app/configure/superfile-config/) 
+You can turn this off, by setting `auto_check_update` to false in superfile config. [**Click me to see the config wiki**](https://superfile.dev/configure/superfile-config/) 
 
 ## Troubleshooting
 
-[**Click me to see common problem fix**](https://superfile.netlify.app/troubleshooting/)
+[**Click me to see common problem fix**](https://superfile.dev/troubleshooting/)
 
 ## Uninstalling
 
@@ -199,14 +199,14 @@ If you don't rember, just try removing both.
 To uninstall superfile on Windows, use this powershell script.
 
 ```powershell
-powershell -ExecutionPolicy Bypass -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.netlify.app/uninstall.ps1'))"
+powershell -ExecutionPolicy Bypass -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.dev/uninstall.ps1'))"
 ```
 
 ## Contributing
 
 If you want to contribute please follow the [contribution guide](./CONTRIBUTING.md)
 
-[**Click me to see changelog**](https://superfile.netlify.app/changelog)
+[**Click me to see changelog**](https://superfile.dev/changelog)
 
 ## Thanks
 

--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -63,12 +63,12 @@ type ThemeType struct {
 
 // Configuration settings
 type ConfigType struct {
-	Theme string `toml:"theme" comment:"More details are at https://superfile.netlify.app/configure/superfile-config/\nchange your theme"`
+	Theme string `toml:"theme" comment:"More details are at https://superfile.dev/configure/superfile-config/\nchange your theme"`
 
 	Editor                 string `toml:"editor" comment:"\nThe editor files will be opened with. (Leave blank to use the EDITOR environment variable)."`
 	DirEditor              string `toml:"dir_editor" comment:"\nThe editor directories will be opened with. (Leave blank to use the default editors)."`
 	AutoCheckUpdate        bool   `toml:"auto_check_update" comment:"\nAuto check for update"`
-	CdOnQuit               bool   `toml:"cd_on_quit" comment:"\nCd on quit (For more details, please check out https://superfile.netlify.app/configure/superfile-config/#cd_on_quit)"`
+	CdOnQuit               bool   `toml:"cd_on_quit" comment:"\nCd on quit (For more details, please check out https://superfile.dev/configure/superfile-config/#cd_on_quit)"`
 	DefaultOpenFilePreview bool   `toml:"default_open_file_preview" comment:"\nWhether to open file preview automatically every time superfile is opened."`
 	ShowImagePreview       bool   `toml:"show_image_preview" comment:"\nWhether to show image preview."`
 	ShowPanelFooterInfo    bool   `toml:"show_panel_footer_info" comment:"\nWhether to show additional footer info for file panel."`

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -318,16 +318,16 @@ func (m *model) introduceModalRender() string {
 	title := common.SidebarTitleStyle.Render(" Thanks for using superfile!!") +
 		common.ModalStyle.Render("\n You can read the following information before starting to use it!")
 	vimUserWarn := common.ProcessErrorStyle.Render("  ** Very importantly ** If you are a Vim/Nvim user, go to:\n" +
-		"  https://superfile.netlify.app/configure/custom-hotkeys/ to change your hotkey settings!")
+		"  https://superfile.dev/configure/custom-hotkeys/ to change your hotkey settings!")
 	subOne := common.SidebarTitleStyle.Render("  (1)") +
 		common.ModalStyle.Render(" If this is your first time, make sure you read:\n"+
-			"      https://superfile.netlify.app/getting-started/tutorial/")
+			"      https://superfile.dev/getting-started/tutorial/")
 	subTwo := common.SidebarTitleStyle.Render("  (2)") +
 		common.ModalStyle.Render(" If you forget the relevant keys during use,\n"+
 			"      you can press \"?\" (shift+/) at any time to query the keys!")
 	subThree := common.SidebarTitleStyle.Render("  (3)") +
 		common.ModalStyle.Render(" For more customization you can refer to:\n"+
-			"      https://superfile.netlify.app/")
+			"      https://superfile.dev/")
 	subFour := common.SidebarTitleStyle.Render("  (4)") +
 		common.ModalStyle.Render(" Thank you again for using superfile.\n"+
 			"      If you have any questions, please feel free to ask at:\n"+

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -1,4 +1,4 @@
-# More details are at https://superfile.netlify.app/configure/superfile-config/
+# More details are at https://superfile.dev/configure/superfile-config/
 #
 # change your theme
 theme = 'catppuccin'
@@ -12,7 +12,7 @@ dir_editor = ""
 # Auto check for update
 auto_check_update = true
 # 
-# Cd on quit (For more details, please check out https://superfile.netlify.app/configure/superfile-config/#cd_on_quit)
+# Cd on quit (For more details, please check out https://superfile.dev/configure/superfile-config/#cd_on_quit)
 cd_on_quit = false
 #
 # Whether to open file preview automatically every time superfile is opened.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -5,7 +5,7 @@ import starlightGiscus from 'starlight-giscus';
 import sitemap from '@astrojs/sitemap';
 
 
-const site = 'https://superfile.netlify.app/';
+const site = 'https://superfile.dev/';
 
 // https://astro.build/config
 export default defineConfig({
@@ -44,6 +44,7 @@ export default defineConfig({
       ],
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/yorukot/superfile' },
+        { icon: 'discord', label: 'Discord', href: 'https://discord.gg/YYtJ23Du7B' },
       ],
       head: [
         {
@@ -86,6 +87,14 @@ export default defineConfig({
             trackingId: 'G-WFLBCRZ7MC',
             autoTrack: true,
           };`,
+        },
+        {
+          tag: 'script',
+          attrs: {
+            defer: true,
+            src: 'https://umami.yorukot.me/script.js',
+            'data-website-id': '9286f04f-4bcd-43f3-8ab7-b479c249f2a7',
+          },
         },
       ],
       editLink: {

--- a/website/public/install.ps1
+++ b/website/public/install.ps1
@@ -149,5 +149,5 @@ Done!
 Restart you terminal, and for the love of Get-Command
 Take a look at tutorial :)
 
-https://superfile.netlify.app/getting-started/tutorial/
+https://superfile.dev/getting-started/tutorial/
 '@

--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -25,18 +25,18 @@ Copy and paste the following one-line command into your machine's terminal.
 With `curl`:
 
 ```bash
-bash -c "$(curl -sLo- https://superfile.netlify.app/install.sh)"
+bash -c "$(curl -sLo- https://superfile.dev/install.sh)"
 ```
 
 Or with `wget`:
 ```bash
-bash -c "$(wget -qO- https://superfile.netlify.app/install.sh)"
+bash -c "$(wget -qO- https://superfile.dev/install.sh)"
 ```
 
 Use `SPF_INSTALL_VERSION` to specify a version :
 
 ```bash
-SPF_INSTALL_VERSION=1.2.1 bash -c "$(curl -sLo- https://superfile.netlify.app/install.sh)"
+SPF_INSTALL_VERSION=1.2.1 bash -c "$(curl -sLo- https://superfile.dev/install.sh)"
 ```
 
 ### Windows
@@ -44,19 +44,19 @@ SPF_INSTALL_VERSION=1.2.1 bash -c "$(curl -sLo- https://superfile.netlify.app/in
 With `powershell`:
 
 ```bash
-powershell -ExecutionPolicy Bypass -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.netlify.app/install.ps1'))"
+powershell -ExecutionPolicy Bypass -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.dev/install.ps1'))"
 ```
 
 :::note
 To uninstall, run the above `powershell` command with the modified URL:
 
-`https://superfile.netlify.app/uninstall.ps1`
+`https://superfile.dev/uninstall.ps1`
 :::
 
 Use `SPF_INSTALL_VERSION` to specify a version :
 
 ```bash
-powershell -ExecutionPolicy Bypass -Command "$env:SPF_INSTALL_VERSION=1.2.1; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.netlify.app/install.ps1'))"
+powershell -ExecutionPolicy Bypass -Command "$env:SPF_INSTALL_VERSION=1.2.1; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://superfile.dev/install.ps1'))"
 ```
 
 With [Winget](https://winget.run/):


### PR DESCRIPTION
Update all references from the old Netlify domain to the new custom domain across documentation, configuration files, and install scripts. Also add discord button at the website header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated all docs, install/uninstall commands, and config references to use superfile.dev.
  - In-app help, tutorial, and hotkey links now point to superfile.dev.
  - PowerShell install script text updated to the new tutorial URL.

- New Features
  - Added Discord social link on the website.

- Chores
  - Switched website base URL to superfile.dev.
  - Integrated Umami analytics alongside existing tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->