### PR TITLE
fix: always clear images when showing a FullScreenStyle

### DIFF
--- a/src/internal/common/style_function.go
+++ b/src/internal/common/style_function.go
@@ -9,7 +9,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/yorukot/superfile/src/config/icon"
-	filepreview "github.com/yorukot/superfile/src/pkg/file_preview"
 )
 
 // Generate border style for file panel
@@ -178,7 +177,7 @@ func FullScreenStyle(height int, width int) lipgloss.Style {
 		Width(width).
 		Align(lipgloss.Center, lipgloss.Center).
 		Background(FullScreenBGColor).
-		Foreground(FullScreenFGColor).SetString(filepreview.ClearKittyImages())
+		Foreground(FullScreenFGColor)
 }
 
 // Generate file panel divider style

--- a/src/internal/common/style_function.go
+++ b/src/internal/common/style_function.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/yorukot/superfile/src/config/icon"
+	filepreview "github.com/yorukot/superfile/src/pkg/file_preview"
 )
 
 // Generate border style for file panel
@@ -177,7 +178,7 @@ func FullScreenStyle(height int, width int) lipgloss.Style {
 		Width(width).
 		Align(lipgloss.Center, lipgloss.Center).
 		Background(FullScreenBGColor).
-		Foreground(FullScreenFGColor)
+		Foreground(FullScreenFGColor).SetString(filepreview.ClearKittyImages())
 }
 
 // Generate file panel divider style

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/yorukot/superfile/src/internal/ui"
 	"github.com/yorukot/superfile/src/internal/ui/rendering"
+	filepreview "github.com/yorukot/superfile/src/pkg/file_preview"
 
 	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/utils"
@@ -257,12 +258,12 @@ func (m *model) terminalSizeWarnRender() string {
 	fullWidthString = common.TerminalCorrectSize.Render(fullWidthString)
 
 	heightString := common.MainStyle.Render(" Height = ")
-	return common.FullScreenStyle(m.fullHeight, m.fullWidth).Render(`Terminal size too small:` + "\n" +
-		"Width = " + fullWidthString +
-		heightString + fullHeightString + "\n\n" +
-		"Needed for current config:" + "\n" +
-		"Width = " + common.TerminalCorrectSize.Render(minimumWidthString) +
-		heightString + common.TerminalCorrectSize.Render(minimumHeightString))
+	return common.FullScreenStyle(m.fullHeight, m.fullWidth).Render(`Terminal size too small:`+"\n"+
+		"Width = "+fullWidthString+
+		heightString+fullHeightString+"\n\n"+
+		"Needed for current config:"+"\n"+
+		"Width = "+common.TerminalCorrectSize.Render(minimumWidthString)+
+		heightString+common.TerminalCorrectSize.Render(minimumHeightString)) + filepreview.ClearKittyImages()
 }
 
 func (m *model) terminalSizeWarnAfterFirstRender() string {
@@ -282,12 +283,12 @@ func (m *model) terminalSizeWarnAfterFirstRender() string {
 	fullWidthString = common.TerminalCorrectSize.Render(fullWidthString)
 
 	heightString := common.MainStyle.Render(" Height = ")
-	return common.FullScreenStyle(m.fullHeight, m.fullWidth).Render(`You change your terminal size too small:` + "\n" +
-		"Width = " + fullWidthString +
-		heightString + fullHeightString + "\n\n" +
-		"Needed for current config:" + "\n" +
-		"Width = " + common.TerminalCorrectSize.Render(minimumWidthString) +
-		heightString + common.TerminalCorrectSize.Render(minimumHeightString))
+	return common.FullScreenStyle(m.fullHeight, m.fullWidth).Render(`You change your terminal size too small:`+"\n"+
+		"Width = "+fullWidthString+
+		heightString+fullHeightString+"\n\n"+
+		"Needed for current config:"+"\n"+
+		"Width = "+common.TerminalCorrectSize.Render(minimumWidthString)+
+		heightString+common.TerminalCorrectSize.Render(minimumHeightString)) + filepreview.ClearKittyImages()
 }
 
 func (m *model) typineModalRender() string {


### PR DESCRIPTION
Clear Kitty terminal images when creating a `FullScreenStyle`.

Fixes #1072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Terminal size warnings now clear previously displayed inline images in compatible terminals (e.g., Kitty) to prevent visual artifacts.
  - Improved warning message formatting for clearer display during size-related prompts.

- Chores
  - Internal rendering logic adjusted with no changes to public APIs or user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->