### PR TITLE
fix: check and fix file panel scroll position on height changes

### DIFF
--- a/src/internal/file_panel.go
+++ b/src/internal/file_panel.go
@@ -92,3 +92,17 @@ func (panel *filePanel) updateCurrentFilePanelDir(path string) error {
 func (panel *filePanel) parentDirectory() error {
 	return panel.updateCurrentFilePanelDir("..")
 }
+
+func (panel *filePanel) handleResize(height int) {
+	// Min render cursor that keeps the cursor in view
+	minVisibleRenderCursor := panel.cursor - panelElementHeight(height) + 1
+	// Max render cursor. This ensures all elements are rendered if there is space
+	maxRenderCursor := max(len(panel.element)-panelElementHeight(height), 0)
+
+	if panel.render > maxRenderCursor {
+		panel.render = maxRenderCursor
+	}
+	if panel.render < minVisibleRenderCursor {
+		panel.render = minVisibleRenderCursor
+	}
+}

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -276,11 +276,8 @@ func (m *model) setHeightValues(height int) {
 	// Main panel height = Total terminal height- 2(file panel border) - footer height
 	m.mainPanelHeight = height - 2 - utils.FullFooterHeight(m.footerHeight, m.toggleFooter)
 
-	for index, filePanel := range m.fileModel.filePanels {
-		if filePanel.render < filePanel.cursor-panelElementHeight(m.mainPanelHeight)+1 {
-			filePanel.render = filePanel.cursor - panelElementHeight(m.mainPanelHeight) + 1
-			m.fileModel.filePanels[index] = filePanel
-		}
+	for index := range m.fileModel.filePanels {
+		m.fileModel.filePanels[index].handleResize(m.mainPanelHeight)
 	}
 }
 

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -275,6 +275,13 @@ func (m *model) setHeightValues(height int) {
 
 	// Main panel height = Total terminal height- 2(file panel border) - footer height
 	m.mainPanelHeight = height - 2 - utils.FullFooterHeight(m.footerHeight, m.toggleFooter)
+
+	for index, filePanel := range m.fileModel.filePanels {
+		if filePanel.render < filePanel.cursor-panelElementHeight(m.mainPanelHeight)+1 {
+			filePanel.render = filePanel.cursor - panelElementHeight(m.mainPanelHeight) + 1
+			m.fileModel.filePanels[index] = filePanel
+		}
+	}
 }
 
 // Set help menu size


### PR DESCRIPTION
I would like some comments on this fix. Not sure if it's complete.
For example if the fix placement looks fine or should I look elsewhere.

The idea is that whenever the heights are changed, we check if the cursor is always made visible.
After that the navigation functions can manage the `filePanel.render`

Something that is missing, from the current PR, is to reduce the `filePanel.render`, if the last item is already visible.

Fixes #820 (This also fixes the cursors when the window is resized)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Keeps the selected item in file panels visible when the window or panel height changes.
  - Ensures all file panels correctly adjust their rendering bounds during resize, preventing sudden jumps or hidden selections.
  - Delivers smoother, more consistent navigation after resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->