### PR TITLE
refactor: simplify renameIfDuplicate function and add comprehensive …

### DIFF
--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -28,6 +28,8 @@ const (
 	sortingFileType     sortingKind = "Type"
 )
 
+var suffixRegexp = regexp.MustCompile(`^(.*)\((\d+)\)$`)
+
 // Check if the directory is external disk path
 // TODO : This function should be give two directories, and it should return
 // if the two share a different disk partition.
@@ -265,8 +267,6 @@ func checkFileNameValidity(name string) error {
 		return nil
 	}
 }
-
-var suffixRegexp = regexp.MustCompile(`^(.*)\((\d+)\)$`)
 
 func renameIfDuplicate(destination string) (string, error) {
 	if _, err := os.Stat(destination); os.IsNotExist(err) {

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -266,61 +266,39 @@ func checkFileNameValidity(name string) error {
 	}
 }
 
-// This functions has very high code duplication. Need to refactor the logic into
-func renameIfDuplicate(destination string) (string, error) { //nolint: gocognit // see above todo
-	info, err := os.Stat(destination)
-	if os.IsNotExist(err) {
+var suffixRegexp = regexp.MustCompile(`^(.*)\((\d+)\)$`)
+
+func renameIfDuplicate(destination string) (string, error) {
+	if _, err := os.Stat(destination); os.IsNotExist(err) {
 		return destination, nil
 	} else if err != nil {
 		return "", err
 	}
 
-	if info.IsDir() {
-		match := regexp.MustCompile(`\((\d+)\)$`).FindStringSubmatch(info.Name())
-		if len(match) > 1 {
-			number, _ := strconv.Atoi(match[1])
-			for {
-				number++
-				newDirName := fmt.Sprintf("%s(%d)", info.Name()[:len(info.Name())-len(match[0])], number)
-				newPath := filepath.Join(filepath.Dir(destination), newDirName)
-				if _, err := os.Stat(newPath); os.IsNotExist(err) {
-					return newPath, nil
-				}
-			}
-		} else {
-			for i := 1; ; i++ {
-				newDirName := fmt.Sprintf("%s(%d)", info.Name(), i)
-				newPath := filepath.Join(filepath.Dir(destination), newDirName)
-				if _, err := os.Stat(newPath); os.IsNotExist(err) {
-					return newPath, nil
-				}
-			}
-		}
-	} else {
-		baseName := filepath.Base(destination)
-		ext := filepath.Ext(baseName)
-		fileName := baseName[:len(baseName)-len(ext)]
-		match := regexp.MustCompile(`\((\d+)\)$`).FindStringSubmatch(fileName)
-		if len(match) > 1 {
-			number, _ := strconv.Atoi(match[1])
-			for {
-				number++
-				newFileName := fmt.Sprintf("%s(%d)%s", fileName[:len(fileName)-len(match[0])], number, ext)
-				newPath := filepath.Join(filepath.Dir(destination), newFileName)
-				if _, err := os.Stat(newPath); os.IsNotExist(err) {
-					return newPath, nil
-				}
-			}
-		} else {
-			for i := 1; ; i++ {
-				newFileName := fmt.Sprintf("%s(%d)%s", fileName, i, ext)
-				newPath := filepath.Join(filepath.Dir(destination), newFileName)
-				if _, err := os.Stat(newPath); os.IsNotExist(err) {
-					return newPath, nil
-				}
-			}
+	dir := filepath.Dir(destination)
+	base := filepath.Base(destination)
+	ext := filepath.Ext(base)
+	name := base[:len(base)-len(ext)]
+
+	// Extract base name without existing suffix
+	counter := 1
+	if match := suffixRegexp.FindStringSubmatch(name); len(match) == 3 {
+		name = match[1] // base name without (N)
+		if num, err := strconv.Atoi(match[2]); err == nil {
+			counter = num + 1 // start from next number
 		}
 	}
+
+	// Find first available name
+	for i := counter; i < 10_000; i++ {
+		newName := fmt.Sprintf("%s(%d)%s", name, i, ext)
+		newPath := filepath.Join(dir, newName)
+		if _, err := os.Stat(newPath); os.IsNotExist(err) {
+			return newPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find free name for %s after many attempts", destination)
 }
 
 // TODO : Replace all usage of "m.fileModel.filePanels[m.filePanelFocusIndex]" with this

--- a/src/internal/function_test.go
+++ b/src/internal/function_test.go
@@ -343,7 +343,7 @@ func Benchmark_renameIfDuplicate(b *testing.B) {
 	require.NoError(b, err)
 
 	b.Run("file_exists", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_, err := renameIfDuplicate(existingFile)
 			if err != nil {
 				b.Fatal(err)
@@ -352,7 +352,7 @@ func Benchmark_renameIfDuplicate(b *testing.B) {
 	})
 
 	b.Run("dir_exists", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_, err := renameIfDuplicate(existingDir)
 			if err != nil {
 				b.Fatal(err)
@@ -362,7 +362,7 @@ func Benchmark_renameIfDuplicate(b *testing.B) {
 
 	b.Run("file_not_exists", func(b *testing.B) {
 		nonExistent := filepath.Join(dir, "nofile.txt")
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_, err := renameIfDuplicate(nonExistent)
 			if err != nil {
 				b.Fatal(err)

--- a/src/internal/function_test.go
+++ b/src/internal/function_test.go
@@ -284,7 +284,8 @@ func Test_renameIfDuplicate(t *testing.T) {
 			prepare: func() string {
 				dir := t.TempDir()
 				path := filepath.Join(dir, "file.txt")
-				_, err := os.Create(path)
+				f, err := os.Create(path)
+				defer f.Close()
 				require.NoError(t, err)
 				return path
 			},
@@ -296,7 +297,8 @@ func Test_renameIfDuplicate(t *testing.T) {
 			prepare: func() string {
 				dir := t.TempDir()
 				path := filepath.Join(dir, "file(2).txt")
-				_, err := os.Create(path)
+				f, err := os.Create(path)
+				defer f.Close()
 				require.NoError(t, err)
 				return path
 			},
@@ -335,7 +337,8 @@ func Test_renameIfDuplicate(t *testing.T) {
 func Benchmark_renameIfDuplicate(b *testing.B) {
 	dir := b.TempDir()
 	existingFile := filepath.Join(dir, "file.txt")
-	_, err := os.Create(existingFile)
+	f, err := os.Create(existingFile)
+	defer f.Close()
 	require.NoError(b, err)
 
 	existingDir := filepath.Join(dir, "docs")


### PR DESCRIPTION
 ## Summary
  - Refactored `renameIfDuplicate` function to eliminate high code duplication between file and directory handling
  - Unified the logic into a single, cleaner implementation
  - Added comprehensive test coverage including edge cases and benchmarks
  - Added safety limit (10,000 attempts) to prevent infinite loops
  
## Test Coverage
  - File doesn't exist case
  - File exists without suffix
  - File exists with existing suffix (increments correctly)
  - Directory handling
  - Performance benchmarks for different scenarios

for previous func:
<img width="606" height="310" alt="image" src="https://github.com/user-attachments/assets/0af7cfae-80da-4a95-b914-59ca1f516254" />

new one:
<img width="601" height="310" alt="image" src="https://github.com/user-attachments/assets/a72fdf0a-9b51-417a-b1ed-856b56b8564e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable handling of duplicate file and folder names with consistent “(N)” suffixing, correctly incrementing when a name already includes a numeric suffix and returning an error if no name is available.

* **Refactor**
  * Consolidated duplicate-name generation into a single, predictable flow to reduce special-case divergence and improve maintainability.

* **Tests**
  * Added tests and benchmarks covering multiple duplicate-name scenarios to validate correctness and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->