### PR TITLE
fix: only calculate checksum on files

### DIFF
--- a/src/internal/ui/metadata/metadata.go
+++ b/src/internal/ui/metadata/metadata.go
@@ -119,7 +119,7 @@ func getMetaDataUnsorted(filePath string, metadataFocussed bool, et *exiftool.Ex
 
 	updateExiftoolMetadata(filePath, et, &res)
 
-	if common.Config.EnableMD5Checksum {
+	if fileInfo.Mode().IsRegular() && common.Config.EnableMD5Checksum {
 		// Calculate MD5 checksum
 		checksum, err := calculateMD5Checksum(filePath)
 		if err != nil {


### PR DESCRIPTION
There is an error in the logs when trying to calculate the checksum of a folder.
I added a check if the selected item is a file before trying to calculate the checksum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MD5 checksums are now computed only for regular files when checksum verification is enabled, avoiding attempts on symlinks and directories. This reduces checksum-related errors during metadata processing and improves overall stability and predictability.
  * Skipping non-regular files can also speed up operations by preventing unnecessary work and ensures integrity checks apply only where meaningful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->