### PR TITLE
fix(ci): update input names to new ones from actions/first-interaction@v3

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             👋 Hi there, and welcome to **superfile**!
 
             Thanks for opening your first issue. We really appreciate your interest and involvement.
@@ -28,7 +28,7 @@ jobs:
 
             If you plan to submit a PR, make sure to check our [Contribution Guide](https://github.com/yorukot/superfile/blob/main/CONTRIBUTING.md)
 
-          pr-message: |
+          pr_message: |
             🎉 Thank you for your first contribution to **superfile**!
 
             We’re really excited to have you here 🙌


### PR DESCRIPTION
The input names of this action where changed (see https://github.com/actions/first-interaction/commit/ee654d9b4eda3665272ffa06f0736ae5a20aa01d#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R8)

Fixing the action for new contributors, as one of my first contributions 💪

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced welcome messages for first-time issue reporters and PR authors with clearer guidance, maintainer questions, contribution flow, review expectations, and links to the Contribution Guide and related resources.
* **Chores**
  * Standardized configuration for first-interaction automation to align input naming.
  * No changes to when the workflow runs or its overall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->