### PR TITLE
fix: Fetch latest version automatically - #854

### DIFF
--- a/website/public/install.ps1
+++ b/website/public/install.ps1
@@ -21,8 +21,23 @@ Write-Host -ForegroundColor DarkRed     "                    `$`$ |             
 Write-Host -ForegroundColor Red         "                    `$`$/                                                       "
 Write-Host ""
 
+function Get-LatestVersion {
+    try {
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/yorukot/superfile/releases/latest" -TimeoutSec 5
+        $version = $release.tag_name -replace '^v', ''
+        if ([string]::IsNullOrEmpty($version)) {
+            Write-Host "Failed to parse version from GitHub API"
+            exit 1
+        }
+        return $version
+    } catch {
+        Write-Host "Failed to fetch latest version from GitHub API: $_"
+        exit 1
+    }
+}
+
 $package = "superfile"
-$version = if ($env:SPF_INSTALL_VERSION) { $env:SPF_INSTALL_VERSION } else { "1.4.0" }
+$version = if ($env:SPF_INSTALL_VERSION) { $env:SPF_INSTALL_VERSION } else { Get-LatestVersion }
 
 $installInstructions = @'
 This installer is only available for Windows.

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -38,8 +38,25 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+fetch_latest_version() {
+    local response
+    if response=$(curl -s --max-time 5 "https://api.github.com/repos/yorukot/superfile/releases/latest"); then
+        local version
+        version=$(echo "$response" | grep '"tag_name"' | cut -d'"' -f4 | sed 's/^v//')
+        if [ -n "$version" ]; then
+            echo "$version"
+        else
+            echo -e "${red}❌ Failed to parse version from GitHub API${nc}" >&2
+            exit 1
+        fi
+    else
+        echo -e "${red}❌ Failed to fetch latest version from GitHub API${nc}" >&2
+        exit 1
+    fi
+}
+
 package=superfile
-version=${SPF_INSTALL_VERSION:-1.4.0}
+version=${SPF_INSTALL_VERSION:-$(fetch_latest_version)}
 arch=$(uname -m)
 os=$(uname -s)
 


### PR DESCRIPTION
Fixes - https://github.com/yorukot/superfile/issues/854

(1) Check if we should use this

```
Invoke-RestMethod "https://api.github.com/repos/yorukot/superfile/releases/latest"  | Select-Object -ExpandProperty tag_name
```

(2) Max time should be 5 sec, maybe?

(3) Test in Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer scripts now automatically detect and fetch the latest release version from the repository, ensuring installs use the most current release without manual version updates.

* **Bug Fixes / Reliability**
  * If version retrieval fails, the installer reports the error and stops to avoid installing an unknown or incorrect version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->