### PR TITLE
fix: Linter issue with PrintfAndExit

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -134,7 +134,7 @@ func spfAppAction(_ context.Context, c *cli.Command) error {
 	p := tea.NewProgram(internal.InitialModel(firstFilePanelDirs, firstUse),
 		tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
-		utils.PrintfAndExit("Alas, there's been an error: %v", err)
+		utils.PrintfAndExitf("Alas, there's been an error: %v", err)
 	}
 
 	// This must be after calling internal.InitialModel()
@@ -195,7 +195,7 @@ func checkFirstUse() bool {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		firstUse = true
 		if err = os.WriteFile(file, nil, 0644); err != nil {
-			utils.PrintfAndExit("Failed to create file: %v", err)
+			utils.PrintfAndExitf("Failed to create file: %v", err)
 		}
 	}
 	return firstUse

--- a/src/config/fixed_variable.go
+++ b/src/config/fixed_variable.go
@@ -94,7 +94,7 @@ func UpdateVarFromCliArgs(c *cli.Command) {
 	// Validate the config file exists
 	if configFileArg != "" {
 		if _, err := os.Stat(configFileArg); err != nil {
-			utils.PrintfAndExit("Error: While reading config file '%s' from argument : %v", configFileArg, err)
+			utils.PrintfAndExitf("Error: While reading config file '%s' from argument : %v", configFileArg, err)
 		}
 		ConfigFile = configFileArg
 	}
@@ -103,7 +103,7 @@ func UpdateVarFromCliArgs(c *cli.Command) {
 
 	if hotkeyFileArg != "" {
 		if _, err := os.Stat(hotkeyFileArg); err != nil {
-			utils.PrintfAndExit("Error: While reading hotkey file '%s' from argument : %v", hotkeyFileArg, err)
+			utils.PrintfAndExitf("Error: While reading hotkey file '%s' from argument : %v", hotkeyFileArg, err)
 		}
 		HotkeysFile = hotkeyFileArg
 	}

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -39,7 +39,7 @@ func LoadConfigFile() {
 			toExit = loadError.IsFatal()
 		}
 		if toExit {
-			utils.PrintfAndExit("%s\n", userMsg)
+			utils.PrintfAndExitf("%s\n", userMsg)
 		} else {
 			fmt.Println(userMsg)
 		}
@@ -123,7 +123,7 @@ func LoadHotkeysFile(ignoreMissingFields bool) {
 			toExit = loadError.IsFatal()
 		}
 		if toExit {
-			utils.PrintfAndExit("%s\n", userMsg)
+			utils.PrintfAndExitf("%s\n", userMsg)
 		} else {
 			fmt.Println(userMsg)
 		}
@@ -167,7 +167,7 @@ func LoadThemeFile() {
 
 	err = toml.Unmarshal([]byte(DefaultThemeString), &Theme)
 	if err != nil {
-		utils.PrintfAndExit("Unexpected error while reading default theme file : %v. Exiting...", err)
+		utils.PrintfAndExitf("Unexpected error while reading default theme file : %v. Exiting...", err)
 	}
 }
 

--- a/src/internal/config_function.go
+++ b/src/internal/config_function.go
@@ -34,7 +34,7 @@ func initialConfig(firstFilePanelDirs []string) (toggleDotFile bool, //nolint: n
 	// For example if the log file directories have access issues.
 	// we could pass a dummy object to log.SetOutput() and the app would still function.
 	if err != nil {
-		utils.PrintfAndExit("Error while opening superfile.log file : %v", err)
+		utils.PrintfAndExitf("Error while opening superfile.log file : %v", err)
 	}
 	common.LoadConfigFile()
 

--- a/src/internal/utils/log_utils.go
+++ b/src/internal/utils/log_utils.go
@@ -17,7 +17,7 @@ func PrintlnAndExit(args ...any) {
 // Print formatted output line to stderr and exit with status 1
 // Cannot use log.Fataln() as slog.SetDefault() causes those lines to
 // go into log file
-func PrintfAndExit(format string, args ...any) {
+func PrintfAndExitf(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, format, args...)
 	os.Exit(1)
 }


### PR DESCRIPTION
fails on make at linter step

```
🚀 Starting superfile development workflow

==> Tidying Go modules...
✓ Go modules tidied
==> Formatting Go code...
✓ Code formatted
==> Running golangci-lint...
src/internal/utils/log_utils.go:20:1: printf-like formatting function 'PrintfAndExit' should be named 'PrintfAndExitf' (goprintffuncname)
func PrintfAndExit(format string, args ...any) {
^
1 issues:
* goprintffuncname: 1
✗ Linting failed
make: *** [Makefile:8: dev] Error 1

```
<img width="1070" height="270" alt="image" src="https://github.com/user-attachments/assets/40d8d3ba-11ef-45de-a2c9-babdbea8d988" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error message formatting throughout the application for improved consistency and clarity when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->