### PR TITLE
chore: Bump golangci-lint to v2.5.0

### DIFF
--- a/.github/workflows/superfile-build-test.yml
+++ b/.github/workflows/superfile-build-test.yml
@@ -67,5 +67,5 @@ jobs:
         if: runner.os != 'Windows'
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.4.0
+          version: v2.5.0
           args: --timeout 3m


### PR DESCRIPTION
Fix made in 
- https://github.com/yorukot/superfile/pull/1133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure tooling to the latest version for improved build and test performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->