### PR TITLE
feat: add video preview support

### DIFF
--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -64,6 +64,30 @@ var (
 
 var (
 	UnsupportedPreviewFormats = []string{".pdf", ".torrent"}
+	ImageExtensions           = map[string]bool{
+		".jpg":  true,
+		".jpeg": true,
+		".png":  true,
+		".gif":  true,
+		".bmp":  true,
+		".tiff": true,
+		".svg":  true,
+		".webp": true,
+		".ico":  true,
+	}
+	VideoExtensions = map[string]bool{
+		".mkv":  true,
+		".mp4":  true,
+		".mov":  true,
+		".avi":  true,
+		".flv":  true,
+		".webm": true,
+		".wmv":  true,
+		".m4v":  true,
+		".mpeg": true,
+		".3gp":  true,
+		".ogv":  true,
+	}
 )
 
 // No dependencies

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -771,10 +771,12 @@ func (panel *filePanel) applyTargetFileCursor() {
 // Close superfile application. Cd into the current dir if CdOnQuit on and save
 // the path in state direcotory
 func (m *model) quitSuperfile(cdOnQuit bool) {
-	// close exiftool session
+	// Resource cleanup
 	if common.Config.Metadata && et != nil {
 		et.Close()
 	}
+	m.fileModel.filePreview.CleanUp()
+
 	// cd on quit
 	currentDir := m.fileModel.filePanels[m.filePanelFocusIndex].location
 	variable.SetLastDir(currentDir)
@@ -787,7 +789,6 @@ func (m *model) quitSuperfile(cdOnQuit bool) {
 			slog.Error("Error during writing lastdir file", "error", err)
 		}
 	}
-	m.fileModel.filePreview.CleanUp()
 	m.modelQuitState = quitDone
 	slog.Debug("Quitting superfile", "current dir", currentDir)
 }


### PR DESCRIPTION
This PR aims to add Video preview support by using ffmpeg to generate a thumbnail from the video.

<img width="2283" height="1186" alt="Screenshot From 2025-12-07 20:36:26" src="https://github.com/user-attachments/assets/b11e3674-16c0-40bd-b7c7-f2f17a8b617a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video files now display generated preview thumbnails for quicker visual identification.

* **Improvements**
  * Thumbnail caching speeds up repeated preview rendering.
  * Preview resources and temporary thumbnails are cleaned up on exit to reduce leftover temp data.
  * Broader image/video format recognition improves accurate preview selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->