### PR TITLE
chore: add gosec linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -84,13 +84,11 @@ linters:
     - goconst # finds repeated strings that could be replaced by a constant
     - gocritic # provides diagnostics that check for bugs, performance and style issues
     - gocyclo # computes and checks the cyclomatic complexity of functions
-    # TODO: Enable. Too much for us right now
+    # Not needed
     # - godot # checks if comments end in a period
     - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - goprintffuncname # checks that printf-like functions are named with f at the end
-    # TODO enable - ignore for a few int overflow, and fix file permissions
-    # weak md5 cryptography, Subprocess launched with a potential tainted input
-    # - gosec # inspects source code for security problems
+    - gosec # inspects source code for security problems
     - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
     - ineffassign # detects when assignments to existing variables are not used
@@ -98,7 +96,6 @@ linters:
     - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
     - makezero # finds slice declarations with non-zero initial length
     - mirror # reports wrong mirror patterns of bytes/strings usage
-    # TODO enable
     - mnd # detects magic numbers
     - musttag # enforces field tags in (un)marshaled structs
     - nakedret # finds naked returns in functions greater than a specified function length
@@ -119,7 +116,7 @@ linters:
     - recvcheck # checks for receiver type consistency
     - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
     - rowserrcheck # checks whether Err of rows is checked successfully
-    # TODO enable - Need to use non-root logger
+    # Need to use non-root logger. Not really needed.
     # - sloglint # ensure consistent code style when using log/slog
     - spancheck # checks for mistakes with OpenTelemetry/Census spans
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed

--- a/src/cmd/help_printer.go
+++ b/src/cmd/help_printer.go
@@ -31,12 +31,12 @@ func CustomHelpPrinter(w io.Writer, templ string, data interface{}) {
 		// Print version info if available
 		if v.Version != "" {
 			fmt.Printf("Version: ")
-			accentColor.Fprintf(w, "%s\n\n", v.Version)
+			_, _ = accentColor.Fprintf(w, "%s\n\n", v.Version)
 		}
 
 		// Print help footer using the actual binary name
 		fmt.Fprint(w, "Use \"")
-		accentColor.Fprintf(w, "%s", binaryName)
+		_, _ = accentColor.Fprintf(w, "%s", binaryName)
 		fmt.Fprint(w, " [COMMAND] --help\" for more information about a command.\n")
 
 	default:
@@ -46,9 +46,9 @@ func CustomHelpPrinter(w io.Writer, templ string, data interface{}) {
 }
 
 func printUsage(w io.Writer, titleColor *color.Color, accentColor *color.Color, binaryName string, v *cli.Command) {
-	titleColor.Fprintf(w, "Usage:")
+	_, _ = titleColor.Fprintf(w, "Usage:")
 	fmt.Fprint(w, " ")
-	accentColor.Fprintf(w, "%s", binaryName)
+	_, _ = accentColor.Fprintf(w, "%s", binaryName)
 	if len(v.Commands) > 0 {
 		fmt.Fprint(w, " [COMMAND]")
 	}
@@ -69,7 +69,7 @@ func printCommands(w io.Writer, titleColor *color.Color, commandColor *color.Col
 	if len(v.Commands) == 0 {
 		return
 	}
-	titleColor.Fprintf(w, "Commands:\n")
+	_, _ = titleColor.Fprintf(w, "Commands:\n")
 	for _, cmd := range v.Commands {
 		// Format command name with aliases
 		cmdDisplay := cmd.Name
@@ -77,7 +77,7 @@ func printCommands(w io.Writer, titleColor *color.Color, commandColor *color.Col
 			cmdDisplay = fmt.Sprintf("%s, %s", cmd.Name, strings.Join(cmd.Aliases, ", "))
 		}
 
-		commandColor.Fprintf(w, "  %-20s", cmdDisplay)
+		_, _ = commandColor.Fprintf(w, "  %-20s", cmdDisplay)
 		fmt.Fprintf(w, " %s\n", cmd.Usage)
 	}
 	fmt.Fprintln(w)
@@ -87,7 +87,7 @@ func printFlags(w io.Writer, titleColor *color.Color, flagColor *color.Color, v 
 	if len(v.Flags) == 0 {
 		return
 	}
-	titleColor.Fprintf(w, "Options:\n")
+	_, _ = titleColor.Fprintf(w, "Options:\n")
 	for _, flag := range v.Flags {
 		names := flag.Names()
 
@@ -131,7 +131,7 @@ func printFlags(w io.Writer, titleColor *color.Color, flagColor *color.Color, v 
 		}
 		flagStr := strings.Join(flagParts, ", ") + valuePlaceholder
 
-		flagColor.Fprintf(w, "  %-30s", flagStr)
+		_, _ = flagColor.Fprintf(w, "  %-30s", flagStr)
 		fmt.Fprintf(w, " %s\n", usage)
 	}
 	fmt.Fprintln(w)

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -203,7 +203,7 @@ func checkFirstUse() bool {
 	firstUse := false
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		firstUse = true
-		if err = os.WriteFile(file, nil, 0644); err != nil {
+		if err = os.WriteFile(file, nil, utils.ConfigFilePerm); err != nil {
 			utils.PrintfAndExitf("Failed to create file: %v", err)
 		}
 	}
@@ -213,7 +213,7 @@ func checkFirstUse() bool {
 // Write data to the path file if it does not exists
 func writeConfigFile(path, data string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err = os.WriteFile(path, []byte(data), 0644); err != nil {
+		if err = os.WriteFile(path, []byte(data), utils.ConfigFilePerm); err != nil {
 			return fmt.Errorf("failed to write config file %s: %w", path, err)
 		}
 	}
@@ -222,7 +222,7 @@ func writeConfigFile(path, data string) error {
 
 func initJSONFile(path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err = os.WriteFile(path, []byte("null"), 0644); err != nil {
+		if err = os.WriteFile(path, []byte("null"), utils.ConfigFilePerm); err != nil {
 			return fmt.Errorf("failed to initialize json file %s: %w", path, err)
 		}
 	}
@@ -230,7 +230,7 @@ func initJSONFile(path string) error {
 }
 
 func writeLastCheckTime(t time.Time) {
-	err := os.WriteFile(variable.LastCheckVersion, []byte(t.Format(time.RFC3339)), 0644)
+	err := os.WriteFile(variable.LastCheckVersion, []byte(t.Format(time.RFC3339)), utils.ConfigFilePerm)
 	if err != nil {
 		slog.Error("Error writing LastCheckVersion file", "error", err)
 	}

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -199,12 +199,12 @@ func LoadAllDefaultConfig(content embed.FS) {
 	}
 
 	// Prevent failure for first time app run by making sure parent directories exists
-	if err = os.MkdirAll(filepath.Dir(variable.ThemeFileVersion), 0o755); err != nil {
+	if err = os.MkdirAll(filepath.Dir(variable.ThemeFileVersion), utils.ConfigDirPerm); err != nil {
 		slog.Error("Error creating theme file parent directory", "error", err)
 		return
 	}
 
-	err = os.WriteFile(variable.ThemeFileVersion, []byte(variable.CurrentVersion), 0o644)
+	err = os.WriteFile(variable.ThemeFileVersion, []byte(variable.CurrentVersion), utils.ConfigFilePerm)
 	if err != nil {
 		slog.Error("Error writing theme file version", "error", err)
 	}
@@ -235,7 +235,7 @@ func WriteThemeFiles(content embed.FS) error {
 	_, err := os.Stat(variable.ThemeFolder)
 
 	if os.IsNotExist(err) {
-		if err = os.MkdirAll(variable.ThemeFolder, 0o755); err != nil {
+		if err = os.MkdirAll(variable.ThemeFolder, utils.ConfigDirPerm); err != nil {
 			slog.Error("Error creating theme directory", "error", err)
 			return err
 		}

--- a/src/internal/common/ui_consts.go
+++ b/src/internal/common/ui_consts.go
@@ -28,8 +28,6 @@ const (
 	DefaultPreviewTimeout = 500 * time.Millisecond // preview operation timeout
 
 	// File permissions
-	ExtractedFileMode = 0644 // default permissions for extracted files
-	ExtractedDirMode  = 0755 // default permissions for extracted directories
 
 	// UI positioning
 	CenterDivisor = 2 // divisor for centering UI elements

--- a/src/internal/config_function.go
+++ b/src/internal/config_function.go
@@ -28,7 +28,7 @@ import (
 func initialConfig(firstPanelPaths []string) (toggleDotFile bool, //nolint: nonamedreturns // See above
 	toggleFooter bool, zClient *zoxidelib.Client) {
 	// Open log stream
-	file, err := os.OpenFile(variable.LogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	file, err := os.OpenFile(variable.LogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, utils.LogFilePerm)
 
 	// TODO : This could be improved if we want to make superfile more resilient to errors
 	// For example if the log file directories have access issues.

--- a/src/internal/file_operations_extract.go
+++ b/src/internal/file_operations_extract.go
@@ -8,8 +8,8 @@ import (
 	"golift.io/xtractr"
 
 	"github.com/yorukot/superfile/src/config/icon"
-	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/ui/processbar"
+	"github.com/yorukot/superfile/src/internal/utils"
 )
 
 func extractCompressFile(src, dest string, processBar *processbar.Model) error {
@@ -21,8 +21,8 @@ func extractCompressFile(src, dest string, processBar *processbar.Model) error {
 	x := &xtractr.XFile{
 		FilePath:  src,
 		OutputDir: dest,
-		FileMode:  common.ExtractedFileMode,
-		DirMode:   common.ExtractedDirMode,
+		FileMode:  utils.ExtractedFileMode,
+		DirMode:   utils.ExtractedDirMode,
 	}
 
 	_, _, _, err = xtractr.ExtractFile(x)

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -287,9 +287,6 @@ func executePasteOperation(processBarModel *processbar.Model,
 			err = pasteDir(filePath, filepath.Join(panelLocation, filepath.Base(filePath)), &p, cut, processBarModel)
 			if err != nil {
 				errMessage = "paste item error"
-			} else if cut {
-				// TODO: Fix unhandled error
-				os.RemoveAll(filePath)
 			}
 		}
 
@@ -370,7 +367,10 @@ func (m *model) getExtractFileCmd() tea.Cmd {
 			return NewCompressOperationMsg(processbar.Failed, reqID)
 		}
 
-		err = os.MkdirAll(outputDir, 0o755)
+		err = os.MkdirAll(
+			outputDir,
+			utils.ExtractedDirMode,
+		)
 		if err != nil {
 			slog.Error("Error while making directory for extracting files", "error", err)
 			return NewCompressOperationMsg(processbar.Failed, reqID)
@@ -421,7 +421,7 @@ func (m *model) getCompressSelectedFilesCmd() tea.Cmd {
 
 func (m *model) chooserFileWriteAndQuit(path string) error {
 	// Attempt to write to the file
-	err := os.WriteFile(variable.ChooserFile, []byte(path), 0o644)
+	err := os.WriteFile(variable.ChooserFile, []byte(path), utils.ConfigFilePerm)
 	if err != nil {
 		return err
 	}

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -34,7 +34,7 @@ func (m *model) createItem() {
 	path := filepath.Join(m.typingModal.location, m.typingModal.textInput.Value())
 	if !strings.HasSuffix(m.typingModal.textInput.Value(), string(filepath.Separator)) {
 		path, _ = renameIfDuplicate(path)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), utils.UserDirPerm); err != nil {
 			slog.Error("Error while createItem during directory creation", "error", err)
 			return
 		}
@@ -45,7 +45,7 @@ func (m *model) createItem() {
 		}
 		defer f.Close()
 	} else {
-		err := os.MkdirAll(path, 0755)
+		err := os.MkdirAll(path, utils.UserDirPerm)
 		if err != nil {
 			slog.Error("Error while createItem during directory creation", "error", err)
 			return

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -68,6 +68,9 @@ func (m *model) enterPanel() {
 
 func (m *model) executeOpenCommand() {
 	panel := m.getFocusedFilePanel()
+
+	filePath := panel.element[panel.cursor].location
+
 	openCommand := "xdg-open"
 	switch runtime.GOOS {
 	case utils.OsDarwin:
@@ -76,7 +79,7 @@ func (m *model) executeOpenCommand() {
 		dllpath := filepath.Join(os.Getenv("SYSTEMROOT"), "System32", "rundll32.exe")
 		dllfile := "url.dll,FileProtocolHandler"
 
-		cmd := exec.Command(dllpath, dllfile, panel.element[panel.cursor].location)
+		cmd := exec.Command(dllpath, dllfile, filePath)
 		err := cmd.Start()
 		if err != nil {
 			slog.Error("Error while open file with", "error", err)
@@ -85,7 +88,7 @@ func (m *model) executeOpenCommand() {
 		return
 	}
 
-	cmd := exec.Command(openCommand, panel.element[panel.cursor].location)
+	cmd := exec.Command(openCommand, filePath)
 	utils.DetachFromTerminal(cmd)
 	err := cmd.Start()
 	if err != nil {

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -777,7 +777,7 @@ func (panel *filePanel) applyTargetFileCursor() {
 func (m *model) quitSuperfile(cdOnQuit bool) {
 	// Resource cleanup
 	if common.Config.Metadata && et != nil {
-		et.Close()
+		_ = et.Close()
 	}
 	m.fileModel.filePreview.CleanUp()
 
@@ -788,7 +788,7 @@ func (m *model) quitSuperfile(cdOnQuit bool) {
 	if cdOnQuit {
 		// escape single quote
 		currentDir = strings.ReplaceAll(currentDir, "'", "'\\''")
-		err := os.WriteFile(variable.LastDirFile, []byte("cd '"+currentDir+"'"), 0o755)
+		err := os.WriteFile(variable.LastDirFile, []byte("cd '"+currentDir+"'"), utils.ConfigFilePerm)
 		if err != nil {
 			slog.Error("Error during writing lastdir file", "error", err)
 		}

--- a/src/internal/ui/metadata/utils.go
+++ b/src/internal/ui/metadata/utils.go
@@ -1,7 +1,7 @@
 package metadata
 
 import (
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec // MD5 used for file checksum display only, not for security
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -60,7 +60,7 @@ func calculateMD5Checksum(filePath string) (string, error) {
 	}
 	defer file.Close()
 
-	hash := md5.New()
+	hash := md5.New() //nolint:gosec // MD5 is sufficient for file integrity display, not used for security
 	if _, err := io.Copy(hash, file); err != nil {
 		return "", fmt.Errorf("failed to calculate MD5 checksum: %w", err)
 	}

--- a/src/internal/ui/sidebar/pinned.go
+++ b/src/internal/ui/sidebar/pinned.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+
+	"github.com/yorukot/superfile/src/internal/utils"
 )
 
 type PinnedManager struct {
@@ -47,7 +49,7 @@ func (mgr *PinnedManager) Save(dirs []directory) error {
 		return fmt.Errorf("error marshaling pinned directories: %w", err)
 	}
 
-	if err := os.WriteFile(mgr.filePath, data, 0644); err != nil {
+	if err := os.WriteFile(mgr.filePath, data, utils.ConfigFilePerm); err != nil {
 		return fmt.Errorf("error writing pinned directories file: %w", err)
 	}
 

--- a/src/internal/utils/bool_file_store.go
+++ b/src/internal/utils/bool_file_store.go
@@ -31,5 +31,5 @@ func ReadBoolFile(path string, defaultValue bool) bool {
 }
 
 func WriteBoolFile(path string, value bool) error {
-	return os.WriteFile(path, []byte(strconv.FormatBool(value)), 0644)
+	return os.WriteFile(path, []byte(strconv.FormatBool(value)), ConfigFilePerm)
 }

--- a/src/internal/utils/bool_file_store_test.go
+++ b/src/internal/utils/bool_file_store_test.go
@@ -139,7 +139,7 @@ func TestWriteBoolFile(t *testing.T) {
 			if runtime.GOOS != OsWindows {
 				info, err := os.Stat(filePath)
 				require.NoError(t, err)
-				assert.Equal(t, os.FileMode(0644), info.Mode().Perm())
+				assert.Equal(t, os.FileMode(ConfigFilePerm), info.Mode().Perm())
 			}
 		})
 	}
@@ -168,13 +168,13 @@ func TestReadBoolFilePermissionDenied(t *testing.T) {
 
 	// Create a file
 	filePath := filepath.Join(tempDir, "no_read_perm.txt")
-	err := os.WriteFile(filePath, []byte(TrueString), 0644)
+	err := os.WriteFile(filePath, []byte(TrueString), ConfigFilePerm)
 	require.NoError(t, err)
 
 	// Remove read permissions
 	err = os.Chmod(filePath, 0)
 	require.NoError(t, err)
-	defer os.Chmod(filePath, 0644) // Reset permissions for cleanup
+	defer os.Chmod(filePath, ConfigFilePerm) // Reset permissions for cleanup
 
 	// The function should return the default value when it can't read the file
 	result := ReadBoolFile(filePath, false)

--- a/src/internal/utils/consts.go
+++ b/src/internal/utils/consts.go
@@ -9,4 +9,17 @@ const (
 	// OsDarwin represents the macOS (Darwin) operating system identifier
 	OsDarwin = "darwin"
 	OsLinux  = "linux"
+
+	// File permissions
+	ConfigFilePerm = 0600 // configuration files (owner read/write only)
+	UserFilePerm   = 0644 // user-created files (owner rw, others r)
+	LogFilePerm    = 0600 // log files (owner read/write only)
+
+	// Directory permissions
+	ConfigDirPerm = 0700 // configuration directories (owner only)
+	UserDirPerm   = 0755 // user-created directories (owner rwx, others rx)
+
+	// Extracted file permissions (from archives)
+	ExtractedFileMode = 0644 // extracted files
+	ExtractedDirMode  = 0755 // extracted directories
 )

--- a/src/internal/utils/test_utils.go
+++ b/src/internal/utils/test_utils.go
@@ -39,7 +39,7 @@ func SetupDirectories(t *testing.T, dirs ...string) {
 		if dir == "" {
 			continue
 		}
-		err := os.MkdirAll(dir, 0755)
+		err := os.MkdirAll(dir, UserDirPerm)
 		require.NoError(t, err)
 	}
 }
@@ -47,7 +47,7 @@ func SetupDirectories(t *testing.T, dirs ...string) {
 func SetupFilesWithData(t *testing.T, data []byte, files ...string) {
 	t.Helper()
 	for _, file := range files {
-		err := os.WriteFile(file, data, 0644)
+		err := os.WriteFile(file, data, UserFilePerm)
 		require.NoError(t, err)
 	}
 }

--- a/src/pkg/file_preview/image_preview.go
+++ b/src/pkg/file_preview/image_preview.go
@@ -325,14 +325,19 @@ func hexToColor(hex string) (color.RGBA, error) {
 		return color.RGBA{}, err
 	}
 	return color.RGBA{
-		R: uint8(values >> rgbShift16),
-		G: uint8((values >> rgbShift8) & rgbMask),
-		B: uint8(values & rgbMask),
+		R: uint8(values >> rgbShift16),            //nolint:gosec // RGB values are masked to 8-bit range
+		G: uint8((values >> rgbShift8) & rgbMask), //nolint:gosec // RGB values are masked to 8-bit range
+		B: uint8(values & rgbMask),                //nolint:gosec // RGB values are masked to 8-bit range
 		A: alphaOpaque,
 	}, nil
 }
 
 func colorToHex(color color.Color) string {
 	r, g, b, _ := color.RGBA()
-	return fmt.Sprintf("#%02x%02x%02x", uint8(r>>rgbShift8), uint8(g>>rgbShift8), uint8(b>>rgbShift8))
+	return fmt.Sprintf(
+		"#%02x%02x%02x",
+		uint8(r>>rgbShift8), //nolint:gosec // RGBA() returns 16-bit values, shifting by 8 gives 8-bit
+		uint8(g>>rgbShift8), //nolint:gosec // RGBA() returns 16-bit values, shifting by 8 gives 8-bit
+		uint8(b>>rgbShift8), //nolint:gosec // RGBA() returns 16-bit values, shifting by 8 gives 8-bit
+	)
 }

--- a/src/pkg/file_preview/kitty.go
+++ b/src/pkg/file_preview/kitty.go
@@ -89,7 +89,8 @@ func generatePlacementID(path string) uint32 {
 	for _, c := range path {
 		hash = hash*kittyHashPrime + int(c)
 	}
-	return uint32(hash&kittyMaxID) + kittyNonZeroOffset // Ensure it's not 0 and avoid low numbers
+	return uint32(hash&kittyMaxID) + //nolint:gosec // Hash is bounded by kittyMaxID mask before conversion
+		kittyNonZeroOffset
 }
 
 // renderWithKittyUsingTermCap renders an image using Kitty graphics protocol with terminal capabilities
@@ -125,13 +126,13 @@ func (p *ImagePreviewer) renderWithKittyUsingTermCap(img image.Image, path strin
 	if imgRatio > termRatio {
 		dstCols := maxWidth
 		dstRows := int(float64(dstCols*pixelsPerColumn) / imgRatio / float64(pixelsPerRow))
-		opts.DstCols = uint32(dstCols)
-		opts.DstRows = uint32(dstRows)
+		opts.DstCols = uint32(dstCols) //nolint:gosec // Terminal dimensions are bounded by maxWidth/maxHeight
+		opts.DstRows = uint32(dstRows) //nolint:gosec // Terminal dimensions are bounded by maxWidth/maxHeight
 	} else {
 		dstRows := maxHeight
 		dstCols := int(float64(dstRows*pixelsPerRow) * imgRatio / float64(pixelsPerColumn))
-		opts.DstRows = uint32(dstRows)
-		opts.DstCols = uint32(dstCols)
+		opts.DstRows = uint32(dstRows) //nolint:gosec // Terminal dimensions are bounded by maxWidth/maxHeight
+		opts.DstCols = uint32(dstCols) //nolint:gosec // Terminal dimensions are bounded by maxWidth/maxHeight
 	}
 
 	// Write image using Kitty protocol

--- a/src/pkg/file_preview/thumbnail_generator.go
+++ b/src/pkg/file_preview/thumbnail_generator.go
@@ -74,7 +74,7 @@ func (g *ThumbnailGenerator) generateThumbnail(inputPath string) (string, error)
 		return "", err
 	}
 	outputFilePath := outputFile.Name()
-	outputFile.Close()
+	_ = outputFile.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), thumbGenerationTimeout)
 	defer cancel()


### PR DESCRIPTION
```
➜  superfile git:(d2c5da0) golangci-lint run --enable=gosec
src/cmd/help_printer.go:34:4: G104: Errors unhandled (gosec)
			accentColor.Fprintf(w, "%s\n\n", v.Version)
			^
src/cmd/help_printer.go:39:3: G104: Errors unhandled (gosec)
		accentColor.Fprintf(w, "%s", binaryName)
		^
src/cmd/help_printer.go:49:2: G104: Errors unhandled (gosec)
	titleColor.Fprintf(w, "Usage:")
	^
src/cmd/help_printer.go:51:2: G104: Errors unhandled (gosec)
	accentColor.Fprintf(w, "%s", binaryName)
	^
src/cmd/help_printer.go:72:2: G104: Errors unhandled (gosec)
	titleColor.Fprintf(w, "Commands:\n")
	^
src/cmd/help_printer.go:80:3: G104: Errors unhandled (gosec)
		commandColor.Fprintf(w, "  %-20s", cmdDisplay)
		^
src/cmd/help_printer.go:90:2: G104: Errors unhandled (gosec)
	titleColor.Fprintf(w, "Options:\n")
	^
src/cmd/help_printer.go:134:3: G104: Errors unhandled (gosec)
		flagColor.Fprintf(w, "  %-30s", flagStr)
		^
src/cmd/main.go:206:12: G306: Expect WriteFile permissions to be 0600 or less (gosec)
		if err = os.WriteFile(file, nil, 0644); err != nil {
		         ^
src/cmd/main.go:216:12: G306: Expect WriteFile permissions to be 0600 or less (gosec)
		if err = os.WriteFile(path, []byte(data), 0644); err != nil {
		         ^
src/cmd/main.go:225:12: G306: Expect WriteFile permissions to be 0600 or less (gosec)
		if err = os.WriteFile(path, []byte("null"), 0644); err != nil {
		         ^
src/cmd/main.go:233:9: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	err := os.WriteFile(variable.LastCheckVersion, []byte(t.Format(time.RFC3339)), 0644)
	       ^
src/internal/common/load_config.go:202:11: G301: Expect directory permissions to be 0750 or less (gosec)
	if err = os.MkdirAll(filepath.Dir(variable.ThemeFileVersion), 0o755); err != nil {
	         ^
src/internal/common/load_config.go:207:8: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	err = os.WriteFile(variable.ThemeFileVersion, []byte(variable.CurrentVersion), 0o644)
	      ^
src/internal/common/load_config.go:238:12: G301: Expect directory permissions to be 0750 or less (gosec)
		if err = os.MkdirAll(variable.ThemeFolder, 0o755); err != nil {
		         ^
src/internal/config_function.go:31:15: G302: Expect file permissions to be 0600 or less (gosec)
	file, err := os.OpenFile(variable.LogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
	             ^
src/internal/handle_file_operations.go:292:5: G104: Errors unhandled (gosec)
				os.RemoveAll(filePath)
				^
src/internal/handle_file_operations.go:373:9: G301: Expect directory permissions to be 0750 or less (gosec)
		err = os.MkdirAll(outputDir, 0o755)
		      ^
src/internal/handle_file_operations.go:424:9: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	err := os.WriteFile(variable.ChooserFile, []byte(path), 0o644)
	       ^
src/internal/handle_modal.go:37:13: G301: Expect directory permissions to be 0750 or less (gosec)
		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
		          ^
src/internal/handle_modal.go:48:10: G301: Expect directory permissions to be 0750 or less (gosec)
		err := os.MkdirAll(path, 0755)
		       ^
src/internal/handle_panel_movement.go:88:9: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	cmd := exec.Command(openCommand, panel.element[panel.cursor].location)
	       ^
src/internal/model.go:780:3: G104: Errors unhandled (gosec)
		et.Close()
		^
src/internal/model.go:791:10: G306: Expect WriteFile permissions to be 0600 or less (gosec)
		err := os.WriteFile(variable.LastDirFile, []byte("cd '"+currentDir+"'"), 0o755)
		       ^
src/internal/ui/metadata/utils.go:4:2: G501: Blocklisted import crypto/md5: weak cryptographic primitive (gosec)
	"crypto/md5"
	^
src/internal/ui/metadata/utils.go:63:10: G401: Use of weak cryptographic primitive (gosec)
	hash := md5.New()
	        ^
src/internal/ui/sidebar/pinned.go:50:12: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	if err := os.WriteFile(mgr.filePath, data, 0644); err != nil {
	          ^
src/internal/utils/bool_file_store.go:34:9: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	return os.WriteFile(path, []byte(strconv.FormatBool(value)), 0644)
	       ^
src/internal/utils/file_utils.go:30:8: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	err = os.WriteFile(filePath, tomlData, 0o644)
	      ^
src/internal/utils/file_utils.go:138:3: G104: Errors unhandled (gosec)
		backupFile.Close()
		^
src/internal/utils/file_utils.go:149:19: G302: Expect file permissions to be 0600 or less (gosec)
	origFile, err := os.OpenFile(filePath, os.O_RDWR, 0o644)
	                 ^
src/internal/utils/file_utils.go:231:13: G301: Expect directory permissions to be 0750 or less (gosec)
		if err := os.MkdirAll(dir, 0o755); err != nil {
		          ^
src/internal/utils/file_utils.go:242:13: G306: Expect WriteFile permissions to be 0600 or less (gosec)
			if err = os.WriteFile(file, nil, 0o644); err != nil {
			         ^
src/internal/utils/test_utils.go:42:10: G301: Expect directory permissions to be 0750 or less (gosec)
		err := os.MkdirAll(dir, 0755)
		       ^
src/internal/utils/test_utils.go:50:10: G306: Expect WriteFile permissions to be 0600 or less (gosec)
		err := os.WriteFile(file, data, 0644)
		       ^
src/pkg/file_preview/image_preview.go:328:11: G115: integer overflow conversion uint64 -> uint8 (gosec)
		R: uint8(values >> rgbShift16),
		        ^
src/pkg/file_preview/image_preview.go:329:11: G115: integer overflow conversion uint64 -> uint8 (gosec)
		G: uint8((values >> rgbShift8) & rgbMask),
		        ^
src/pkg/file_preview/image_preview.go:330:11: G115: integer overflow conversion uint64 -> uint8 (gosec)
		B: uint8(values & rgbMask),
		        ^
src/pkg/file_preview/image_preview.go:337:43: G115: integer overflow conversion uint32 -> uint8 (gosec)
	return fmt.Sprintf("#%02x%02x%02x", uint8(r>>rgbShift8), uint8(g>>rgbShift8), uint8(b>>rgbShift8))
	                                         ^
src/pkg/file_preview/kitty.go:92:15: G115: integer overflow conversion int -> uint32 (gosec)
	return uint32(hash&kittyMaxID) + kittyNonZeroOffset // Ensure it's not 0 and avoid low numbers
	             ^
src/pkg/file_preview/kitty.go:128:24: G115: integer overflow conversion int -> uint32 (gosec)
		opts.DstCols = uint32(dstCols)
		                     ^
src/pkg/file_preview/kitty.go:129:24: G115: integer overflow conversion int -> uint32 (gosec)
		opts.DstRows = uint32(dstRows)
		                     ^
src/pkg/file_preview/kitty.go:133:24: G115: integer overflow conversion int -> uint32 (gosec)
		opts.DstRows = uint32(dstRows)
		                     ^
src/pkg/file_preview/kitty.go:134:24: G115: integer overflow conversion int -> uint32 (gosec)
		opts.DstCols = uint32(dstCols)
		                     ^
src/pkg/file_preview/thumbnail_generator.go:77:2: G104: Errors unhandled (gosec)
	outputFile.Close()
	^
45 issues:
* gosec: 45
➜  superfile git:(d2c5da0)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cut (paste) operations no longer remove the source item after paste to prevent accidental data loss.
  * Tightened file and directory permissions in multiple places for improved security.

* **Chores**
  * Centralized permission values into shared constants for consistent handling.
  * Enabled additional security linting to surface potential issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->