### PR TITLE
test: skip permission tests when running as root

### DIFF
--- a/src/internal/utils/bool_file_store_test.go
+++ b/src/internal/utils/bool_file_store_test.go
@@ -159,6 +159,11 @@ func TestReadBoolFilePermissionDenied(t *testing.T) {
 		t.Skip("Skipping permission test on Windows")
 	}
 
+	// Skip when running as root since root can read files with 000 permissions
+	if os.Geteuid() == 0 {
+		t.Skip("Skipping permission test when running as root")
+	}
+
 	tempDir := t.TempDir()
 
 	// Create a file
@@ -183,6 +188,11 @@ func TestWriteBoolFilePermissionDenied(t *testing.T) {
 	// Skip on Windows as permission handling differs
 	if runtime.GOOS == OsWindows {
 		t.Skip("Skipping permission test on Windows")
+	}
+
+	// Skip when running as root since root can write to read-only directories
+	if os.Geteuid() == 0 {
+		t.Skip("Skipping permission test when running as root")
 	}
 
 	tempDir := t.TempDir()


### PR DESCRIPTION
## Description

This PR fixes test failures that occur when running tests in containerized environments where tests run as root.

## Problem

The permission-based tests in `bool_file_store_test.go` fail when running as root because:
- Root bypasses Unix file permissions
- Root can read files with 000 permissions
- Root can write to read-only directories

## Solution

Added checks to skip these specific permission tests when `os.Geteuid() == 0` (running as root). This allows the test suite to pass in containerized environments while still maintaining test coverage in normal user environments.

## Changes

- Skip `TestReadBoolFilePermissionDenied` when running as root
- Skip `TestWriteBoolFilePermissionDenied` when running as root

## Testing

- ✅ All tests pass when running as root
- ✅ Tests still execute normally when not running as root
- ✅ No linter issues

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adding runtime guards to skip permission-related tests in root execution environments. Tests will no longer fail unexpectedly when run with elevated privileges.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->