### PR TITLE
feat: show count selected items in select mode

### DIFF
--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -66,7 +66,7 @@ func (panel *filePanel) Render(mainPanelHeight int, filePanelWidth int, focussed
 
 	panel.renderTopBar(r, filePanelWidth)
 	panel.renderSearchBar(r)
-	panel.renderFooter(r)
+	panel.renderFooter(r, uint(len(panel.selected)))
 	panel.renderFileEntries(r, mainPanelHeight, filePanelWidth)
 
 	return r.Render()
@@ -84,9 +84,9 @@ func (panel *filePanel) renderSearchBar(r *rendering.Renderer) {
 }
 
 // TODO : Unit test this
-func (panel *filePanel) renderFooter(r *rendering.Renderer) {
+func (panel *filePanel) renderFooter(r *rendering.Renderer, selectedCount uint) {
 	sortLabel, sortIcon := panel.getSortInfo()
-	modeLabel, modeIcon := panel.getPanelModeInfo()
+	modeLabel, modeIcon := panel.getPanelModeInfo(selectedCount)
 	cursorStr := panel.getCursorString()
 
 	if common.Config.Nerdfont {
@@ -166,12 +166,12 @@ func (panel *filePanel) getSortInfo() (string, string) {
 	return label, iconStr
 }
 
-func (panel *filePanel) getPanelModeInfo() (string, string) {
+func (panel *filePanel) getPanelModeInfo(selectedCount uint) (string, string) {
 	switch panel.panelMode {
 	case browserMode:
 		return "Browser", icon.Browser
 	case selectMode:
-		return "Select", icon.Select
+		return "Select" + icon.Space + fmt.Sprintf("(%d)", selectedCount), icon.Select
 	default:
 		return "", ""
 	}


### PR DESCRIPTION
**New Features**
When switching to Select mode there should be an indicator for how many files has been selected. issue #1164 
- when selected something
<img width="713" height="224" alt="image" src="https://github.com/user-attachments/assets/417d7079-9070-4464-8bb8-342143177a37" />
- when nothing selected
<img width="727" height="203" alt="image" src="https://github.com/user-attachments/assets/6b14f975-f800-4739-96b4-df146c0714cf" />
- browser mode is not changed
<img width="710" height="218" alt="image" src="https://github.com/user-attachments/assets/c35b6d0b-b4a5-43fe-ad87-35209bace173" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select mode in the file panel now displays a count of selected items in the footer label, showing "(N)" where N represents the total number of currently selected items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->