### PR TITLE
fix: Disable COPYFILE in macOS

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -6,6 +6,9 @@ osList=("darwin" "linux" "windows")
 archList=("amd64" "arm64")
 mkdir dist
 
+# Prevent macOS from adding ._* files to archives
+export COPYFILE_DISABLE=1
+
 for os in "${osList[@]}"; do
     if [ "$os" = "windows" ]; then
         for arch in "${archList[@]}"; do


### PR DESCRIPTION
Fix for 
https://github.com/yorukot/superfile/discussions/1182

Issue - https://superuser.com/questions/61185/why-do-i-get-files-like-foo-in-my-tarball-on-os-x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release packaging to prevent unnecessary metadata files in archives, resulting in cleaner and more consistent release artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->