### PR TITLE
docs: fix typo of macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
    </a>
 
 ### [Warp, the AI terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=superfile)
-[Available for MacOS, Linux, & Windows](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=superfile)<br>
+[Available for macOS, Linux, & Windows](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=superfile)<br>
 
 </div>
 <hr>
@@ -64,7 +64,7 @@
 
 ## Installation
 
-### MacOS and Linux
+### macOS and Linux
 
 ```bash
 bash -c "$(curl -sLo- https://superfile.dev/install.sh)"
@@ -114,7 +114,7 @@ Enter the downloaded directory:
 cd superfile
 ```
 
-### For MacOS/Linux
+### For macOS/Linux
 Run the `build.sh` file:
 
 ```bash
@@ -144,7 +144,7 @@ spf
 ## Supported Systems
 
 - \[x\] Linux
-- \[x\] MacOS
+- \[x\] macOS
 - \[x\] Windows (Not fully supported yet)
 
 ## Tutorial
@@ -178,9 +178,9 @@ You can turn this off, by setting `auto_check_update` to false in superfile conf
 
 ## Uninstalling
 
-### MacOS and Linux
+### macOS and Linux
 
-On MacOS and Linux, you can uninstall superfile by simply removing the binary. If you installed superfile with sudo, runw
+On macOS and Linux, you can uninstall superfile by simply removing the binary. If you installed superfile with sudo, runw
 
 ```bash
 sudo rm /usr/local/bin/spf

--- a/src/internal/function.go
+++ b/src/internal/function.go
@@ -45,7 +45,7 @@ func isExternalDiskPath(path string) bool {
 		return false
 	}
 
-	// exclude timemachine on MacOS
+	// exclude timemachine on macOS
 	if strings.HasPrefix(path, "/Volumes/.timemachine") {
 		return false
 	}

--- a/testsuite/Notes.md
+++ b/testsuite/Notes.md
@@ -15,7 +15,7 @@
 ### Pyautogui alternatives
 POC with pyautogui as a lot of issues, stated above.
 
-#### Linux / MacOS
+#### Linux / macOS
 
 - xdotool
   - Seems complicated. It wont be able to manage spf process that well

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -15,7 +15,7 @@
 ## Setup
 Requires python 3.9 or later.
 
-## Setup for MacOS / Linux
+## Setup for macOS / Linux
 
 ### Install tmux
 - You need to have tmux installed. See https://github.com/tmux/tmux/wiki

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -26,11 +26,11 @@ To see the path locations of your superfile files, use the command `spf pl`.
 
 - ###### editor
 
-The editor your files will be opened with (Leave blank to use the EDITOR environment variable. If EDITOR environment variable is not set, it will default to `nano` for MacOS/Linux, and `notepad` for Windows.
+The editor your files will be opened with (Leave blank to use the EDITOR environment variable. If EDITOR environment variable is not set, it will default to `nano` for macOS/Linux, and `notepad` for Windows.
 
 - ###### dir_editor
 
-The editor your directories will be opened with (Leave blank to use defaults : `vi` - Linux, `open` - MacOS, `explorer` - Windows).
+The editor your directories will be opened with (Leave blank to use defaults : `vi` - Linux, `open` - macOS, `explorer` - Windows).
 
 - ###### auto_check_update
 
@@ -46,7 +46,7 @@ The editor your directories will be opened with (Leave blank to use defaults : `
 
 After setting to `true`, you need to update your shell config file. Sample changes :
 
-##### MacOS/Linux (bash or fish)
+##### macOS/Linux (bash or fish)
 
 ###### Bash
 


### PR DESCRIPTION
# Description

As the title, fix typo of "macOS".

There are some peripheral change that doesn't affect functionality.

# Related Issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized platform name formatting across README files, configuration guides, and test documentation for proper branding conventions.

* **Style**
  * Updated capitalization of platform names in comments and documentation headers for consistency throughout the project.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->