### PR TITLE
feat: add icons to pinned directories

### DIFF
--- a/src/internal/ui/sidebar/render.go
+++ b/src/internal/ui/sidebar/render.go
@@ -50,6 +50,8 @@ func (s *Model) directoriesRender(mainPanelHeight int, curFilePanelFileLocation 
 	// TODO : This is not true when searchbar is not rendered(totalHeight is 2, not 3),
 	// so we end up underutilizing one line for our render. But it wont break anything.
 	totalHeight := sideBarInitialHeight
+	// Track if we're in the pinned section
+	inPinnedSection := false
 	for i := s.renderIndex; i < len(s.directories); i++ {
 		if totalHeight+s.directories[i].RequiredHeight() > mainPanelHeight {
 			break
@@ -60,8 +62,10 @@ func (s *Model) directoriesRender(mainPanelHeight int, curFilePanelFileLocation 
 		switch s.directories[i] {
 		case pinnedDividerDir:
 			r.AddLines("", common.SideBarPinnedDivider, "")
+			inPinnedSection = true
 		case diskDividerDir:
 			r.AddLines("", common.SideBarDisksDivider, "")
+			inPinnedSection = false
 		default:
 			cursor := " "
 			if s.cursor == i && sideBarFocussed && !s.searchBar.Focused() {
@@ -74,7 +78,12 @@ func (s *Model) directoriesRender(mainPanelHeight int, curFilePanelFileLocation 
 				if s.directories[i].Location == curFilePanelFileLocation {
 					renderStyle = common.SidebarSelectedStyle
 				}
-				line := common.FilePanelCursorStyle.Render(cursor+" ") + renderStyle.Render(s.directories[i].Name)
+				dirName := s.directories[i].Name
+				// Add pinned icon if we're in the pinned section and nerd font is enabled
+				if inPinnedSection && common.Config.Nerdfont {
+					dirName = icon.Pinned + icon.Space + dirName
+				}
+				line := common.FilePanelCursorStyle.Render(cursor+" ") + renderStyle.Render(dirName)
 				r.AddLineWithCustomTruncate(line, rendering.TailsTruncateRight)
 			}
 		}


### PR DESCRIPTION
## Description
Adds pinned icons (󰐃) to directories displayed in the pinned section of the sidebar when Nerdfont is enabled.

## Changes
- Modified `src/internal/ui/sidebar/render.go` to track when we're in the pinned section (between pinnedDividerDir and diskDividerDir)
- Prepends `icon.Pinned` + space to directory names when both conditions are met:
  - We're in the pinned section
  - Nerdfont is enabled in config

## Fixes
Fixes #1208

## Testing
Builds successfully. Should be tested with:
- Multiple pinned directories
- With Nerdfont enabled and disabled
- Long directory names to ensure proper truncation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pinned icon indicator for directories in the pinned section of the sidebar when Nerdfont is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->