### PR TITLE
fix: add directory-specific icons to pinned directories

### DIFF
--- a/src/internal/ui/sidebar/pinned.go
+++ b/src/internal/ui/sidebar/pinned.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/yorukot/superfile/src/config/icon"
+	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/utils"
 )
 
@@ -70,9 +72,19 @@ func (mgr *PinnedManager) Toggle(dir string) error {
 	}
 
 	if !unPinned {
+		// Get directory-specific icon for the directory being pinned
+		baseName := filepath.Base(dir)
+		dirName := baseName
+		if common.Config.Nerdfont {
+			// Use GetElementIcon to get directory-specific icon
+			dirStyle := common.GetElementIcon(baseName, true, false, common.Config.Nerdfont)
+			if dirStyle.Icon != "" {
+				dirName = dirStyle.Icon + icon.Space + baseName
+			}
+		}
 		dirs = append(dirs, directory{
 			Location: dir,
-			Name:     filepath.Base(dir),
+			Name:     dirName,
 		})
 	}
 

--- a/src/internal/ui/sidebar/render.go
+++ b/src/internal/ui/sidebar/render.go
@@ -50,6 +50,8 @@ func (s *Model) directoriesRender(mainPanelHeight int, curFilePanelFileLocation 
 	// TODO : This is not true when searchbar is not rendered(totalHeight is 2, not 3),
 	// so we end up underutilizing one line for our render. But it wont break anything.
 	totalHeight := sideBarInitialHeight
+	// Track if we're in the pinned section
+	inPinnedSection := false
 	for i := s.renderIndex; i < len(s.directories); i++ {
 		if totalHeight+s.directories[i].RequiredHeight() > mainPanelHeight {
 			break
@@ -60,8 +62,10 @@ func (s *Model) directoriesRender(mainPanelHeight int, curFilePanelFileLocation 
 		switch s.directories[i] {
 		case pinnedDividerDir:
 			r.AddLines("", common.SideBarPinnedDivider, "")
+			inPinnedSection = true
 		case diskDividerDir:
 			r.AddLines("", common.SideBarDisksDivider, "")
+			inPinnedSection = false
 		default:
 			cursor := " "
 			if s.cursor == i && sideBarFocussed && !s.searchBar.Focused() {
@@ -74,7 +78,16 @@ func (s *Model) directoriesRender(mainPanelHeight int, curFilePanelFileLocation 
 				if s.directories[i].Location == curFilePanelFileLocation {
 					renderStyle = common.SidebarSelectedStyle
 				}
-				line := common.FilePanelCursorStyle.Render(cursor+" ") + renderStyle.Render(s.directories[i].Name)
+				// Get directory-specific icon for pinned directories
+				dirName := s.directories[i].Name
+				if inPinnedSection && common.Config.Nerdfont {
+					// Use GetElementIcon to get directory-specific icon
+					dirStyle := common.GetElementIcon(s.directories[i].Name, true, false, common.Config.Nerdfont)
+					if dirStyle.Icon != "" {
+						dirName = dirStyle.Icon + icon.Space + dirName
+					}
+				}
+				line := common.FilePanelCursorStyle.Render(cursor+" ") + renderStyle.Render(dirName)
 				r.AddLineWithCustomTruncate(line, rendering.TailsTruncateRight)
 			}
 		}


### PR DESCRIPTION
## Description
Adds directory-specific icons to directories displayed in the pinned section of the sidebar when Nerdfont is enabled. Each directory gets its appropriate icon based on its name (e.g., `.git` gets the git folder icon, `node_modules` gets the npm folder icon, etc.).

## Changes
- Modified `src/internal/ui/sidebar/render.go` to:
  - Track when rendering is in the pinned section (between `pinnedDividerDir` and `diskDividerDir`)
  - For directories in the pinned section with Nerdfont enabled, use `common.GetElementIcon()` to get the appropriate directory-specific icon
  - Prepend the icon to the directory name for display

## Implementation Details
The implementation uses the same icon system that the file panel uses:
- Calls `common.GetElementIcon(dirName, true, false, nerdFontEnabled)` with `isDir=true` to get directory-specific icons
- Icons are determined based on the directory name (e.g., `.git`, `node_modules`, `Downloads`, etc.)
- Only adds icons when both conditions are met:
  1. Directory is in the pinned section
  2. Nerdfont is enabled in config

## Fixes
Fixes #1208

## Testing
Builds successfully. Should be tested with:
- Various pinned directories with recognizable names (`.git`, `node_modules`, `Downloads`, etc.)
- With Nerdfont enabled and disabled
- Long directory names to ensure proper truncation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pinned directory entries in the sidebar now show directory-specific icons when Nerdfont is enabled, including for newly pinned items — enhancing visual distinction while preserving existing selection, cursor, and truncation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->