### PR TITLE
fix: return QuitMsg after successful chooser file write

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -445,7 +445,7 @@ func (m *model) openFileWithEditor() tea.Cmd {
 	if variable.ChooserFile != "" {
 		err := m.chooserFileWriteAndQuit(panel.Element[panel.Cursor].Location)
 		if err == nil {
-			return nil
+			return func() tea.Msg { return tea.QuitMsg{} }
 		}
 		// Continue with preview if file is not writable
 		slog.Error("Error while writing to chooser file, continuing with open via file editor", "error", err)
@@ -484,7 +484,7 @@ func (m *model) openDirectoryWithEditor() tea.Cmd {
 	if variable.ChooserFile != "" {
 		err := m.chooserFileWriteAndQuit(m.getFocusedFilePanel().Location)
 		if err == nil {
-			return nil
+			return func() tea.Msg { return tea.QuitMsg{} }
 		}
 		// Continue with preview if file is not writable
 		slog.Error("Error while writing to chooser file, continuing with open via directory editor", "error", err)


### PR DESCRIPTION
[Claude Generated] Fix for Windows CI TestChooserFile

## Problem
The test `TestChooserFile/Open_with_directory_editor_valid_chooser_file` was failing intermittently on Windows CI.

## Root Cause Analysis
- Both `openFileWithEditor()` and `openDirectoryWithEditor()` returned `nil` after successfully writing the chooser file
- This prevented the quit flow from completing properly
- Windows CI requires an explicit `tea.QuitMsg` to be processed for the quit state to propagate through the Update loop
- The test's single `TeaUpdate()` call wasn't sufficient on Windows to process the nil return

## Solution
Return `func() tea.Msg { return tea.QuitMsg{} }` instead of `nil` after successful chooser file write.

This ensures the quit command is properly dispatched and processed on all platforms.

## Testing
- Verified locally with `go test ./src/internal -run TestChooserFile -count=10`
- All tests pass consistently
- Built successfully with `CGO_ENABLED=0 go build`
- Linter passes with no issues

Fixes the Windows CI failure seen in multiple PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the application would continue running after successfully saving a file through the chooser. The application now correctly closes after completing the save operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->