### PR TITLE
feat: add Trash bin to default directories for Linux

### DIFF
--- a/src/config/icon/icon.go
+++ b/src/config/icon/icon.go
@@ -19,6 +19,7 @@ var (
 	Music       = "♬"          // Printable Rune : "♬"
 	Templates   = "\U000f03e2" // Printable Rune : "󰏢"
 	PublicShare = "\uf0ac"     // Printable Rune : ""
+	Trash       = "\uf1f8"     // Printable Rune : ""
 
 	// file operations
 	CompressFile = "\U000f05c4" // Printable Rune : "󰗄"

--- a/src/internal/ui/sidebar/directory_utils.go
+++ b/src/internal/ui/sidebar/directory_utils.go
@@ -2,10 +2,12 @@ package sidebar
 
 import (
 	"os"
+	"runtime"
 	"slices"
 
 	"github.com/adrg/xdg"
 
+	variable "github.com/yorukot/superfile/src/config"
 	"github.com/yorukot/superfile/src/config/icon"
 	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/utils"
@@ -56,6 +58,14 @@ func getWellKnownDirectories() []directory {
 		{Location: xdg.UserDirs.Music, Name: icon.Music + icon.Space + "Music"},
 		{Location: xdg.UserDirs.Templates, Name: icon.Templates + icon.Space + "Templates"},
 		{Location: xdg.UserDirs.PublicShare, Name: icon.PublicShare + icon.Space + "PublicShare"},
+	}
+
+	// Add Trash directory for Linux only
+	if runtime.GOOS == utils.OsLinux {
+		wellKnownDirectories = append(wellKnownDirectories, directory{
+			Location: variable.LinuxTrashDirectory,
+			Name:     icon.Trash + icon.Space + "Trash",
+		})
 	}
 
 	return slices.DeleteFunc(wellKnownDirectories, func(d directory) bool {


### PR DESCRIPTION
[Claude Generated] Add Trash Directory to Sidebar

## Summary
This PR adds the Trash directory to the sidebar's well-known directories list for Linux systems only.

## Changes
- Added `Trash` icon constant in `src/config/icon/icon.go`
- Modified `getWellKnownDirectories()` in `src/internal/ui/sidebar/directory_utils.go` to include the Linux trash directory
- Uses `LinuxTrashDirectory` variable which points to `~/.local/share/Trash` as per XDG specification
- Only displays on Linux systems (runtime.GOOS check)

## Implementation Notes
- Following the comment in issue #1209, this uses the existing `LinuxTrashDirectory` variable from `fixed_variables.go`
- The trash directory only appears for Linux users, as macOS trash is protected and Windows recycle bin uses encoded filenames
- Icon uses unicode `\uf1f8` which renders as a trash can in nerd fonts

## Testing
- Built successfully with `CGO_ENABLED=0 go build -o bin/spf ./src/cmd`
- Linter passes with no issues
- Trash directory will only appear if it exists on the system

Fixes #1209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Trash icon to the application
  * Introduced Trash directory in the sidebar for Linux users

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->