### PR TITLE
fix: use ExtractOperationMsg for extraction operations

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -369,7 +369,7 @@ func (m *model) getExtractFileCmd() tea.Cmd {
 		outputDir, err := renameIfDuplicate(outputDir)
 		if err != nil {
 			slog.Error("Error while renaming for duplicates", "error", err)
-			return NewCompressOperationMsg(processbar.Failed, reqID)
+			return NewExtractOperationMsg(processbar.Failed, reqID)
 		}
 
 		err = os.MkdirAll(
@@ -378,14 +378,14 @@ func (m *model) getExtractFileCmd() tea.Cmd {
 		)
 		if err != nil {
 			slog.Error("Error while making directory for extracting files", "error", err)
-			return NewCompressOperationMsg(processbar.Failed, reqID)
+			return NewExtractOperationMsg(processbar.Failed, reqID)
 		}
 		err = extractCompressFile(item, outputDir, &m.processBarModel)
 		if err != nil {
 			slog.Error("Error extract file", "error", err)
-			return NewCompressOperationMsg(processbar.Failed, reqID)
+			return NewExtractOperationMsg(processbar.Failed, reqID)
 		}
-		return NewCompressOperationMsg(processbar.Successful, reqID)
+		return NewExtractOperationMsg(processbar.Successful, reqID)
 	}
 }
 


### PR DESCRIPTION
[Claude Generated]

## Summary
This PR fixes the extraction operation to use the proper `ExtractOperationMsg` type instead of `CompressOperationMsg`. This makes the code semantically correct and allows extraction operations to be distinguished from compression operations.

## Changes
- Replaced `NewCompressOperationMsg` with `NewExtractOperationMsg` in `getExtractFileCmd()` function for all extraction operations (success and failure cases)
- The `NewExtractOperationMsg` function was already defined but wasn't being used anywhere in the codebase, making it dead code

## Testing
- All existing tests pass
- Linter shows 0 issues
- Extraction functionality works as expected

## Context
The `ExtractOperationMsg` type was previously unused in the codebase (found during dead code analysis). This change puts it to proper use for extraction operations, improving code clarity and maintainability.