### PR TITLE
feat: add terminal stdout support for shell commands

### DIFF
--- a/src/internal/ui/prompt/model.go
+++ b/src/internal/ui/prompt/model.go
@@ -110,9 +110,12 @@ func (m *Model) handleNormalKeyInput(msg tea.KeyMsg) tea.Cmd {
 func (m *Model) HandleShellCommandResults(retCode int, output string) {
 	m.actionSuccess = retCode == 0
 	m.resultMsg = fmt.Sprintf("Command exited with status %d", retCode)
-	output = strings.TrimSpace(output)
+
+	output = strings.TrimSpace(common.MakePrintableWithEscCheck(output, false))
 	if output != "" {
-		m.resultMsg += "\n" + output
+		m.resultMsg += ", Output:\n" + output
+	} else {
+		m.resultMsg += " (No output)"
 	}
 	m.CloseOnSuccessIfNeeded()
 }

--- a/src/internal/ui/prompt/model_test.go
+++ b/src/internal/ui/prompt/model_test.go
@@ -182,20 +182,20 @@ func TestModel_HandleResults(t *testing.T) {
 
 		// Validate close happens when closeOnSuccess is true
 		assert.True(t, m.LastActionSucceeded())
-		assert.Equal(t, "Command exited with status 0", m.resultMsg)
+		assert.Equal(t, "Command exited with status 0 (No output)", m.resultMsg)
 		assert.False(t, m.IsOpen())
 
 		m.Open(true)
 		m.HandleShellCommandResults(1, "")
 		assert.False(t, m.LastActionSucceeded())
-		assert.Equal(t, "Command exited with status 1", m.resultMsg)
+		assert.Equal(t, "Command exited with status 1 (No output)", m.resultMsg)
 		assert.True(t, m.IsOpen())
 
 		m.closeOnSuccess = false
 		m.HandleShellCommandResults(0, "")
 		// Validate that close does not happen when closeOnSuccess is true
 		assert.True(t, m.LastActionSucceeded())
-		assert.Equal(t, "Command exited with status 0", m.resultMsg)
+		assert.Equal(t, "Command exited with status 0 (No output)", m.resultMsg)
 		assert.True(t, m.IsOpen())
 	})
 
@@ -206,20 +206,23 @@ func TestModel_HandleResults(t *testing.T) {
 
 		// Test with single line output
 		m.HandleShellCommandResults(0, "hello world")
-		assert.Equal(t, "Command exited with status 0\nhello world", m.resultMsg)
+		assert.Equal(t, "Command exited with status 0, Output:\nhello world", m.resultMsg)
 
 		// Test with multi-line output
 		m.HandleShellCommandResults(0, "line1\nline2\nline3")
-		assert.Equal(t, "Command exited with status 0\nline1\nline2\nline3", m.resultMsg)
+		assert.Equal(t, "Command exited with status 0, Output:\nline1\nline2\nline3", m.resultMsg)
 
 		// Test output is trimmed
 		m.HandleShellCommandResults(0, "  trimmed output  \n")
-		assert.Equal(t, "Command exited with status 0\ntrimmed output", m.resultMsg)
+		assert.Equal(t, "Command exited with status 0, Output:\ntrimmed output", m.resultMsg)
+
+		m.HandleShellCommandResults(0, "ESC SEQ\x1b[2;6H")
+		assert.Equal(t, "Command exited with status 0, Output:\nESC SEQ[2;6H", m.resultMsg)
 
 		// Test with failed command and output
 		m.HandleShellCommandResults(1, "error message")
 		assert.False(t, m.LastActionSucceeded())
-		assert.Equal(t, "Command exited with status 1\nerror message", m.resultMsg)
+		assert.Equal(t, "Command exited with status 1, Output:\nerror message", m.resultMsg)
 	})
 
 	t.Run("Verify SPF results update", func(t *testing.T) {
@@ -323,7 +326,7 @@ func TestModel_Render(t *testing.T) {
 			"├────────────────────────────────────────────────┤\n" +
 			"│ '>' - Get into SPF mode                        │\n" +
 			"├────────────────────────────────────────────────┤\n" +
-			"│ Success : Command exited with status 0         │\n" +
+			"│ Success : Command exited with status 0 (No outp│\n" +
 			"╰────────────────────────────────────────────────╯"
 		assert.Equal(t, exp, res)
 		m.HandleShellCommandResults(1, "")
@@ -336,7 +339,7 @@ func TestModel_Render(t *testing.T) {
 			"├────────────────────────────────────────────────┤\n" +
 			"│ '>' - Get into SPF mode                        │\n" +
 			"├────────────────────────────────────────────────┤\n" +
-			"│ Error : Command exited with status 1           │\n" +
+			"│ Error : Command exited with status 1 (No output│\n" +
 			"╰────────────────────────────────────────────────╯"
 		assert.Equal(t, exp, res)
 	})


### PR DESCRIPTION
Fixes 
- #1166

## Changes
- Display shell command stdout in the prompt result message
- Trim whitespace from output before displaying
- Add test coverage for output display scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shell command output is now included in command results (single- and multi-line preserved; ANSI sequences handled).
  * Empty command output is explicitly indicated as "(No output)"; extraneous whitespace is trimmed.
* **Tests**
  * Expanded tests to verify output display, trimming, ANSI handling, and "(No output)" messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->