### PR TITLE
fix: skip open_with field from missing field validation

### DIFF
--- a/src/internal/utils/file_utils.go
+++ b/src/internal/utils/file_utils.go
@@ -99,6 +99,10 @@ func LoadTomlFile(filePath string, defaultData string, target interface{},
 		} else {
 			fieldName = field.Name
 		}
+		// Skip open_with field as it's an optional table
+		if fieldName == "open_with" {
+			continue
+		}
 		if _, exists := rawData[fieldName]; !exists {
 			missingFields = append(missingFields, fieldName)
 		}


### PR DESCRIPTION
Fixes 
- #1247

```
➜  superfile git:(fix-open-with-optional) grep -C5 open_with "/Users/nitin/Library/Application Support/superfile/config.toml"
➜  superfile git:(fix-open-with-optional) bin/spf
➜  superfile git:(fix-open-with-optional) git switch develop
Switched to branch 'develop'
Your branch is up to date with 'origin/develop'.
➜  superfile git:(develop) go build -o bin/spf; bin/spf
Error ┃ missing fields: [open_with]
To add missing fields to configuration file automatically run superfile with the --fix-config-file flag `spf --fix-config-file`
➜  superfile git:(develop)
```