### PR TITLE
fix: Jump cursor to file/folder entry by first characters

### DIFF
--- a/src/internal/ui/filepanel/navigation_test.go
+++ b/src/internal/ui/filepanel/navigation_test.go
@@ -421,3 +421,89 @@ func TestPageScrollSizeConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestJumpToPrefix(t *testing.T) {
+	tests := []struct {
+		name           string
+		elements       []Element
+		chars          []string
+		expectedCursor int
+	}{
+		{
+			name: "Jump to first match with single char",
+			elements: []Element{
+				{Name: "apple.txt"},
+				{Name: "banana.txt"},
+				{Name: "cherry.txt"},
+			},
+			chars:          []string{"b"},
+			expectedCursor: 1,
+		},
+		{
+			name: "Jump with multiple chars",
+			elements: []Element{
+				{Name: "apple.txt"},
+				{Name: "banana.txt"},
+				{Name: "blueberry.txt"},
+			},
+			chars:          []string{"b", "l"},
+			expectedCursor: 2,
+		},
+		{
+			name: "Case insensitive match",
+			elements: []Element{
+				{Name: "Alpha"},
+				{Name: "BETA"},
+				{Name: "gamma"},
+			},
+			chars:          []string{"b"},
+			expectedCursor: 1,
+		},
+		{
+			name: "No match keeps cursor",
+			elements: []Element{
+				{Name: "file1.txt"},
+				{Name: "file2.txt"},
+			},
+			chars:          []string{"z"},
+			expectedCursor: 0,
+		},
+		{
+			name:           "Jump on empty panel",
+			elements:       []Element{},
+			chars:          []string{"a"},
+			expectedCursor: 0,
+		},
+		{
+			name: "Jump with digit",
+			elements: []Element{
+				{Name: "aaa.txt"},
+				{Name: "123.txt"},
+				{Name: "bbb.txt"},
+			},
+			chars:          []string{"1"},
+			expectedCursor: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testModel(0, 0, 12, BrowserMode, tt.elements)
+			for _, char := range tt.chars {
+				m.JumpToPrefix(char)
+			}
+			assert.Equal(t, tt.expectedCursor, m.Cursor)
+		})
+	}
+}
+
+func TestClearJumpBuffer(t *testing.T) {
+	m := testModel(0, 0, 12, BrowserMode, []Element{
+		{Name: "abc.txt"},
+		{Name: "def.txt"},
+	})
+	m.JumpToPrefix("a")
+	assert.NotEmpty(t, m.jumpBuffer)
+	m.ClearJumpBuffer()
+	assert.Empty(t, m.jumpBuffer)
+}

--- a/src/internal/ui/filepanel/types.go
+++ b/src/internal/ui/filepanel/types.go
@@ -35,6 +35,10 @@ type Model struct {
 	SearchBar          textinput.Model
 	LastTimeGetElement time.Time
 	TargetFile         string // filename to position cursor on after load
+
+	// Jump-to-file by first characters (like Windows Explorer)
+	jumpBuffer     string    // accumulated typed characters
+	jumpBufferTime time.Time // time of last character typed
 }
 
 // Sort options


### PR DESCRIPTION
Fixes #1225

## Changes
- Add jump-to-file feature in file panel by typing first characters (like Windows Explorer)
- Case-insensitive prefix matching with 500ms buffer timeout
- Add comprehensive tests for the new functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick file navigation: type the first character of a filename to jump to it instantly. Type consecutive characters within a short time window to match longer prefixes. The buffer automatically resets after a timeout for new searches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->