### PR TITLE
fix:  The case with 2 active panes

### DIFF
--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -59,12 +59,12 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen //
 		m.getFocusedFilePanel().ChangeFilePanelMode()
 
 	case slices.Contains(common.Hotkeys.NextFilePanel, msg):
-		if m.focusPanel != sidebarFocus && m.focusPanel != processBarFocus && m.focusPanel != metadataFocus {
+		if m.focusPanel == nonePanelFocus {
 			m.fileModel.NextFilePanel()
 		}
 
 	case slices.Contains(common.Hotkeys.PreviousFilePanel, msg):
-		if m.focusPanel != sidebarFocus && m.focusPanel != processBarFocus && m.focusPanel != metadataFocus {
+		if m.focusPanel == nonePanelFocus {
 			m.fileModel.PreviousFilePanel()
 		}
 


### PR DESCRIPTION
Bug description:

The side panel (or other non-file panel) is active. You can press "tab" to activate the file panel. So, you have two active panels (see picture). Here, you can use "up"/"down" on the side panel, but "left"/"right" are applied on the file panel.

<img width="685" height="241" alt="image" src="https://github.com/user-attachments/assets/2a5cd676-8eb5-4d7a-8d9c-85c9c1a27ee7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Next/Previous file navigation hotkeys now respect the current focus, preventing accidental file changes when interacting with the sidebar, progress bar, metadata fields, or other UI elements. This reduces unintended navigation during focused interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->