### PR TITLE
fix: Prune Inaccessible Items from clipboard before pasting

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -215,7 +215,7 @@ func (m *model) copyMultipleItem(cut bool) {
 }
 
 func (m *model) getPasteItemCmd() tea.Cmd {
-	copyItems := m.clipboard.GetItems()
+	copyItems := m.clipboard.PruneInaccessibleItemsAndGet()
 	cut := m.clipboard.IsCut()
 	if len(copyItems) == 0 {
 		return nil

--- a/src/internal/ui/clipboard/model_test.go
+++ b/src/internal/ui/clipboard/model_test.go
@@ -2,12 +2,14 @@ package clipboard
 
 import (
 	"flag"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yorukot/superfile/src/config/icon"
 	"github.com/yorukot/superfile/src/internal/common"
@@ -71,4 +73,16 @@ func TestClipboardRender_Empty(t *testing.T) {
 		}
 		assert.Contains(t, out, "2 items left....", "expected overflow indicator in render")
 	})
+}
+
+func TestPruneInaccessibleItemsAndGet(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{filepath.Join(dir, "f1"), filepath.Join(dir, "f2")}
+	utils.SetupFiles(t, files...)
+
+	m := &Model{}
+	m.SetItems(files)
+	assert.Equal(t, files, m.PruneInaccessibleItemsAndGet())
+	require.NoError(t, os.Remove(files[1]))
+	assert.Equal(t, []string{files[0]}, m.PruneInaccessibleItemsAndGet())
 }


### PR DESCRIPTION
Fixes https://github.com/yorukot/superfile/issues/577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clipboard now synchronizes with the filesystem and automatically filters out inaccessible or deleted items before paste operations, preventing failed pastes.

* **Tests**
  * Added automated tests to verify clipboard pruning behavior when files are removed, improving reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->