### PR TITLE
fix: grammar corrections in readme and removed a redundant link in site

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,13 @@ You can turn this off, by setting `auto_check_update` to false in superfile conf
 
 ### macOS and Linux
 
-On macOS and Linux, you can uninstall superfile by simply removing the binary. If you installed superfile with sudo, runw
+On macOS and Linux, you can uninstall superfile by simply removing the binary. If you installed superfile with sudo, run:
 
 ```bash
 sudo rm /usr/local/bin/spf
 ```
 
-If you installed superfile without sudo, run
+If you installed superfile without sudo, run:
 
 ```bash
 rm ~/.local/bin/spf

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -200,10 +200,6 @@ export default defineConfig({
           link: "/troubleshooting",
         },
         {
-          label: "How to contribute",
-          link: "/contribute/how-to-contribute",
-        },
-        {
           label: "Changelog",
           link: "/changelog",
         },


### PR DESCRIPTION
there were 2 grammer changes in readme, basically adding ":" ahead of two "run" in uninstallation section of the readme.

also i removed the link to "contributing" by the name of "how to contribute" in the website, because there's already a "contribute" section that already has the same link. it's redundant and confusing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the uninstall instructions and improved formatting consistency.

* **Documentation**
  * Removed "How to contribute" navigation links from the sidebar.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->