### PR TITLE
fix: correct jump back to parent directories cursor position

### DIFF
--- a/src/internal/ui/filepanel/update.go
+++ b/src/internal/ui/filepanel/update.go
@@ -62,11 +62,6 @@ func (m *Model) UpdateCurrentFilePanelDir(path string) error {
 
 	slog.Debug("updateCurrentFilePanelDir : After update", "cursor", m.cursor, "render", m.renderIndex)
 
-	// Reset cursor if setting it from cache made it invalid
-	if m.ValidateCursorAndRenderIndex() != nil {
-		m.scrollToCursor(0)
-	}
-
 	// Reset the searchbar Value
 	// TODO(Refactoring) : Have a common searchBar type for sidebar and this search bar.
 	m.SearchBar.SetValue("")


### PR DESCRIPTION
Fixes #1315

When jumping back from a directory to its parent directory the cursor position in the parent should be remembered. However, in some cases a bug occurs and the cursor in the parent jumps to the top. 

When calling `m.UpdateCurrentFilePanelDir` `m.Location` changes to the new `path` of the parent directory but the whole model isn't updated yet. When we then call `m.ValidateCursorAndRenderIndex` on this model we compare the cursor position `m.cursor` with the number of elements of the current directory `m.ElemCount()` and not the number of elements of the parent directory. 

In `m.UpdateElementsIfNeeded` the same lines of code exist that I removed in this PR and at this point the model has also been updated and the validation doesn't throw a bug anymore.

Before:
![superfile_issue](https://github.com/user-attachments/assets/d2dae463-c38e-4666-bae9-bddfc4edae59)

After:
![superfile_issue_fixed](https://github.com/user-attachments/assets/fda1b3ca-e773-4b92-9a1c-8ee810aa003d)


Also wrote a test with three cases. But not sure if those are really necessary or even expressive enough.


EDIT: Just realized that the same issue can happen when jumping back from a parent directory into a child directory. But this PR should fix this as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test for cursor position restoration during directory navigation.

* **Refactor**
  * Streamlined cursor and render index validation logic in directory update operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->