### PR TITLE
feat: add space key selection for files in file panel

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -90,6 +90,7 @@ type ConfigType struct {
 
 	Nerdfont                bool     `toml:"nerdfont" comment:"\n================   Style =================\n\n If you don't have or don't want Nerdfont installed you can turn this off"`
 	ShowSelectIcons         bool     `toml:"show_select_icons" comment:"\nShow checkbox icons in select mode (requires nerdfont)"`
+	SpaceSelects            bool     `toml:"space_selects" comment:"\nEnable space key to toggle selection of files/directories in file panel"`
 	TransparentBackground   bool     `toml:"transparent_background" comment:"\nSet transparent background or not (this only work when your terminal background is transparent)"`
 	FilePreviewWidth        int      `toml:"file_preview_width" comment:"\nFile preview width allow '0' (this mean same as file panel),'x' x must be less than 10 and greater than 1 (This means that the width of the file preview will be one xth of the total width.)"`
 	EnableFilePreviewBorder bool     `toml:"enable_file_preview_border" comment:"\nEnable border around the file preview panel (default: false)"`

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -111,7 +111,7 @@ func (m *model) getDeleteCmd(permDelete bool) tea.Cmd {
 	}
 
 	var items []string
-	if panel.PanelMode == filepanel.SelectMode {
+	if panel.PanelMode == filepanel.SelectMode || panel.SelectedCount() > 0 {
 		items = panel.GetSelectedLocations()
 	} else {
 		items = []string{panel.GetFocusedItem().Location}
@@ -168,7 +168,7 @@ func deleteOperation(processBarModel *processbar.Model, items []string, useTrash
 func (m *model) getDeleteTriggerCmd(deletePermanent bool) tea.Cmd {
 	panel := m.getFocusedFilePanel()
 	if (panel.PanelMode == filepanel.SelectMode && panel.SelectedCount() == 0) ||
-		(panel.PanelMode == filepanel.BrowserMode && panel.Empty()) {
+		(panel.PanelMode == filepanel.BrowserMode && panel.SelectedCount() == 0 && panel.Empty()) {
 		return nil
 	}
 

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -158,6 +158,8 @@ func (m *model) normalAndBrowserModeKey(msg string) tea.Cmd {
 	// Check if in the select mode and focusOn filepanel
 	if m.getFocusedFilePanel().PanelMode == filepanel.SelectMode {
 		switch {
+		case common.Config.SpaceSelects && msg == " ":
+			m.getFocusedFilePanel().SingleItemSelect()
 		case slices.Contains(common.Hotkeys.Confirm, msg):
 			m.getFocusedFilePanel().SingleItemSelect()
 		case slices.Contains(common.Hotkeys.FilePanelSelectModeItemsSelectUp, msg):
@@ -178,7 +180,10 @@ func (m *model) normalAndBrowserModeKey(msg string) tea.Cmd {
 		return nil
 	}
 
+	panel := m.getFocusedFilePanel()
 	switch {
+	case common.Config.SpaceSelects && msg == " ":
+		panel.SingleItemSelect()
 	case slices.Contains(common.Hotkeys.Confirm, msg):
 		m.enterPanel()
 	case slices.Contains(common.Hotkeys.ParentDirectory, msg):
@@ -188,9 +193,17 @@ func (m *model) normalAndBrowserModeKey(msg string) tea.Cmd {
 	case slices.Contains(common.Hotkeys.PermanentlyDeleteItems, msg):
 		return m.getDeleteTriggerCmd(true)
 	case slices.Contains(common.Hotkeys.CopyItems, msg):
-		m.copySingleItem(false)
+		if panel.SelectedCount() > 0 {
+			m.copyMultipleItem(false)
+		} else {
+			m.copySingleItem(false)
+		}
 	case slices.Contains(common.Hotkeys.CutItems, msg):
-		m.copySingleItem(true)
+		if panel.SelectedCount() > 0 {
+			m.copyMultipleItem(true)
+		} else {
+			m.copySingleItem(true)
+		}
 	case slices.Contains(common.Hotkeys.FilePanelItemRename, msg):
 		m.panelItemRename()
 	case slices.Contains(common.Hotkeys.SearchBar, msg):

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -109,6 +109,10 @@ nerdfont = true
 # Requires: nerdfont = true
 show_select_icons = true
 
+#-- Space key selection
+# Enable space key to toggle selection of files/directories in file panel
+space_selects = true
+
 #-- Transparent Background Support
 # Set to true to enable background transparency.
 # Requires: terminal support for colour transparency


### PR DESCRIPTION
## Summary

Add space key selection for files in file panel, allowing multi-select operations without entering select mode.

## Description

This PR implements a more intuitive way to select multiple files and directories in the file panel. Instead of having to switch to select mode first, users can now simply press the space key to toggle selection of files directly in normal (browser) mode.

How It Works
1. Normal Mode: Press space to select/deselect the current file or directory
2. Select Mode: Press space to select/deselect items (existing behavior enhanced)
3. Multi-file Operations: Once files are selected with space:
   - Ctrl+C (copy) copies all selected items
   - Ctrl+X (cut) cuts all selected items  
   - Delete/Ctrl+D deletes all selected items
   - Ctrl+A (compress) compresses all selected items

## Configuration

A new boolean config option space_selects controls this feature:
- Default: `true` (enabled)
- Location: config.toml
- Comment: "Enable space key to toggle selection of files/directories in file panel"

To disable the feature, set in your config: `space_selects = false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Space key support to toggle selection of files and directories in the file panel (configurable via `space_selects` setting).

* **Improvements**
  * Enhanced copy, cut, and delete operations to better handle single and multiple file selections based on selection mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->