### PR TITLE
fix: Prevent crash due to invalid theme

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -31,11 +31,12 @@ type ThemeType struct {
 	ModalFG      string `toml:"modal_fg"`
 
 	// Special Color
-	Cursor             string   `toml:"cursor"`
-	Correct            string   `toml:"correct"`
-	Error              string   `toml:"error"`
-	Hint               string   `toml:"hint"`
-	Cancel             string   `toml:"cancel"`
+	Cursor  string `toml:"cursor"`
+	Correct string `toml:"correct"`
+	Error   string `toml:"error"`
+	Hint    string `toml:"hint"`
+	Cancel  string `toml:"cancel"`
+	// Note: this is linked with `RequiredGradientColorCount` constant
 	GradientColor      []string `toml:"gradient_color"`
 	DirectoryIconColor string   `toml:"directory_icon_color"`
 

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -186,6 +186,11 @@ func LoadThemeFile() {
 	if err != nil {
 		utils.PrintfAndExitf("Unexpected error while reading default theme file : %v. Exiting...", err)
 	}
+
+	if len(Theme.GradientColor) != 2 {
+		utils.PrintlnAndExit(LoadThemeError("gradient_color"))
+	}
+
 }
 
 // LoadAllDefaultConfig : Load all default configurations from embedded superfile_config folder into global

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -54,31 +54,40 @@ func LoadConfigFile() {
 
 func ValidateConfig(c *ConfigType) error {
 	if (c.FilePreviewWidth > 10 || c.FilePreviewWidth < 2) && c.FilePreviewWidth != 0 {
-		return errors.New(LoadConfigError("file_preview_width"))
+		return errors.New(
+			LoadConfigError("file_preview_width", "File preview width must be 2–10, or 0 to disable preview."),
+		)
 	}
 
 	if c.SidebarWidth != 0 && (c.SidebarWidth < 5 || c.SidebarWidth > 20) {
-		return errors.New(LoadConfigError("sidebar_width"))
+		return errors.New(LoadConfigError("sidebar_width", "Sidebar width must be 5–20, or 0 to hide the sidebar."))
 	}
 
 	for _, order := range c.SidebarSections {
 		if order != utils.SidebarSectionHome &&
 			order != utils.SidebarSectionPinned &&
 			order != utils.SidebarSectionDisks {
-			return errors.New(LoadConfigError("sidebar_sections"))
+			return errors.New(
+				LoadConfigError(
+					"sidebar_sections",
+					"Sidebar sections contain an unsupported value. Allowed values are: home, pinned, disks.",
+				),
+			)
 		}
 	}
 
 	if c.DefaultSortType < 0 || c.DefaultSortType > 3 {
-		return errors.New(LoadConfigError("default_sort_type"))
+		return errors.New(LoadConfigError("default_sort_type", "Default sort type must be between 0 and 3."))
 	}
 
 	if c.FilePanelNamePercent < FileNameRatioMin || c.FilePanelNamePercent > FileNameRatioMax {
-		return errors.New(LoadConfigError("file_panel_name_percent"))
+		return errors.New(
+			LoadConfigError("file_panel_name_percent", "File panel name percent is outside the supported range."),
+		)
 	}
 
 	if ansi.StringWidth(c.BorderTop) != 1 {
-		return errors.New(LoadConfigError("border_top"))
+		return errors.New(LoadConfigError("border_top", "Border character must be exactly one cell wide."))
 	}
 
 	return validateBorders(c)
@@ -86,31 +95,31 @@ func ValidateConfig(c *ConfigType) error {
 
 func validateBorders(c *ConfigType) error {
 	if ansi.StringWidth(c.BorderBottom) != 1 {
-		return errors.New(LoadConfigError("border_bottom"))
+		return errors.New(LoadConfigError("border_bottom", "Border character must be exactly one cell wide."))
 	}
 	if ansi.StringWidth(c.BorderLeft) != 1 {
-		return errors.New(LoadConfigError("border_left"))
+		return errors.New(LoadConfigError("border_left", "Border character must be exactly one cell wide."))
 	}
 	if ansi.StringWidth(c.BorderRight) != 1 {
-		return errors.New(LoadConfigError("border_right"))
+		return errors.New(LoadConfigError("border_right", "Border character must be exactly one cell wide."))
 	}
 	if ansi.StringWidth(c.BorderBottomLeft) != 1 {
-		return errors.New(LoadConfigError("border_bottom_left"))
+		return errors.New(LoadConfigError("border_bottom_left", "Border character must be exactly one cell wide."))
 	}
 	if ansi.StringWidth(c.BorderBottomRight) != 1 {
-		return errors.New(LoadConfigError("border_bottom_right"))
+		return errors.New(LoadConfigError("border_bottom_right", "Border character must be exactly one cell wide."))
 	}
 	if ansi.StringWidth(c.BorderTopLeft) != 1 {
-		return errors.New(LoadConfigError("border_top_left"))
+		return errors.New(LoadConfigError("border_top_left", "Border character must be exactly one cell wide."))
 	}
 	if ansi.StringWidth(c.BorderTopRight) != 1 {
-		return errors.New(LoadConfigError("border_top_right"))
+		return errors.New(LoadConfigError("border_top_right", "Border character must be exactly one cell wide."))
 	}
 	if ansi.StringWidth(c.BorderMiddleLeft) != 1 {
-		return errors.New(LoadConfigError("border_middle_left"))
+		return errors.New(LoadConfigError("border_middle_left", "Border character must be exactly one cell wide."))
 	}
 	if ansi.StringWidth(c.BorderMiddleRight) != 1 {
-		return errors.New(LoadConfigError("border_middle_right"))
+		return errors.New(LoadConfigError("border_middle_right", "Border character must be exactly one cell wide."))
 	}
 
 	return nil
@@ -156,12 +165,22 @@ func LoadHotkeysFile(ignoreMissingFields bool) {
 		// This adds a layer against accidental struct modifications
 		// Makes sure its always be a string slice. It's somewhat like a unit test
 		if value.Kind() != reflect.Slice || value.Type().Elem().Kind() != reflect.String {
-			utils.PrintlnAndExit(LoadHotkeysError(field.Name))
+			utils.PrintlnAndExit(
+				LoadHotkeysError(
+					field.Name,
+					"Hotkey value must be a list of strings.",
+				),
+			)
 		}
 
 		hotkeysList, ok := value.Interface().([]string)
 		if !ok || len(hotkeysList) == 0 || hotkeysList[0] == "" {
-			utils.PrintlnAndExit(LoadHotkeysError(field.Name))
+			utils.PrintlnAndExit(
+				LoadHotkeysError(
+					field.Name,
+					"Hotkey list is empty; at least one key binding is required.",
+				),
+			)
 		}
 	}
 }
@@ -180,7 +199,12 @@ func LoadThemeFile() {
 
 	// Validations
 	if len(Theme.GradientColor) != RequiredGradientColorCount {
-		utils.PrintlnAndExit(LoadThemeError("gradient_color"))
+		utils.PrintlnAndExit(
+			LoadThemeError(
+				"gradient_color",
+				"Gradient color must contain exactly two values.",
+			),
+		)
 	}
 }
 

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -187,10 +187,9 @@ func LoadThemeFile() {
 		utils.PrintfAndExitf("Unexpected error while reading default theme file : %v. Exiting...", err)
 	}
 
-	if len(Theme.GradientColor) != 2 {
+	if len(Theme.GradientColor) != RequiredGradientColorCount {
 		utils.PrintlnAndExit(LoadThemeError("gradient_color"))
 	}
-
 }
 
 // LoadAllDefaultConfig : Load all default configurations from embedded superfile_config folder into global

--- a/src/internal/common/style_function.go
+++ b/src/internal/common/style_function.go
@@ -87,16 +87,21 @@ func GenerateBorder() lipgloss.Border {
 	}
 }
 
-// Generate config error style
 func LoadConfigError(value string) string {
-	return lipgloss.NewStyle().Foreground(lipgloss.Color("#FF5555")).Render("■ ERROR: ") +
-		"Config file \"" + lipgloss.NewStyle().Foreground(lipgloss.Color("#00D9FF")).Render(value) + "\" invalidation"
+	return UserConfigInvalidationErrorString(value, "Config")
 }
 
-// Generate config error style
 func LoadHotkeysError(value string) string {
+	return UserConfigInvalidationErrorString(value, "Hotkey")
+}
+
+func LoadThemeError(value string) string {
+	return UserConfigInvalidationErrorString(value, "Theme")
+}
+
+func UserConfigInvalidationErrorString(value string, configType string) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color("#FF5555")).Render("■ ERROR: ") +
-		"Hotkeys file \"" + lipgloss.NewStyle().Foreground(lipgloss.Color("#00D9FF")).Render(value) + "\" invalidation"
+		configType + " file \"" + lipgloss.NewStyle().Foreground(lipgloss.Color("#00D9FF")).Render(value) + "\" invalidation"
 }
 
 // TODO : Fix Code duplication in textInput.Model creation

--- a/src/internal/common/style_function.go
+++ b/src/internal/common/style_function.go
@@ -87,21 +87,22 @@ func GenerateBorder() lipgloss.Border {
 	}
 }
 
-func LoadConfigError(value string) string {
-	return UserConfigInvalidationErrorString(value, "Config")
+func LoadConfigError(value string, msg string) string {
+	return UserConfigInvalidationErrorString(value, "Config", msg)
 }
 
-func LoadHotkeysError(value string) string {
-	return UserConfigInvalidationErrorString(value, "Hotkey")
+func LoadHotkeysError(value string, msg string) string {
+	return UserConfigInvalidationErrorString(value, "Hotkey", msg)
 }
 
-func LoadThemeError(value string) string {
-	return UserConfigInvalidationErrorString(value, "Theme")
+func LoadThemeError(value string, msg string) string {
+	return UserConfigInvalidationErrorString(value, "Theme", msg)
 }
 
-func UserConfigInvalidationErrorString(value string, configType string) string {
+func UserConfigInvalidationErrorString(value string, configType string, msg string) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color("#FF5555")).Render("■ ERROR: ") +
-		configType + " file \"" + lipgloss.NewStyle().Foreground(lipgloss.Color("#00D9FF")).Render(value) + "\" invalidation"
+		configType + " value for \"" + lipgloss.NewStyle().Foreground(lipgloss.Color("#00D9FF")).Render(value) +
+		"\" is invalid : " + msg
 }
 
 // TODO : Fix Code duplication in textInput.Model creation

--- a/src/internal/common/ui_consts.go
+++ b/src/internal/common/ui_consts.go
@@ -27,7 +27,7 @@ const (
 	FileNameRatioMin = 25
 	FileNameRatioMax = 100
 
-	// File permissions
+	RequiredGradientColorCount = 2
 
 	// UI positioning
 	CenterDivisor = 2 // divisor for centering UI elements


### PR DESCRIPTION
Prevent any further occurrence of 
- https://github.com/yorukot/superfile/issues/1353
<img width="1146" height="184" alt="image" src="https://github.com/user-attachments/assets/01b0dcb2-fc83-4ff8-bf9f-f7df414c3af4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust theme loading with a user-theme fallback and validation to ensure required theme elements are present.
  * Added a public setting to enforce the required number of gradient entries.

* **Bug Fixes**
  * Clearer, standardized and more descriptive error messages when configuration or hotkey/theme files are invalid.

* **Style**
  * Minor formatting and comment updates for theme configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->