### PR TITLE
fix: removed showing two fractional digits of Byte for files with small size

### DIFF
--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -136,11 +136,13 @@ func FileNameWithoutExtension(fileName string) string {
 	return fileName
 }
 
-//nolint:gochecknoglobals // it's just constant
-var unitsDec = [...]string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
+func unitsDec() [7]string {
+	return [...]string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
+}
 
-//nolint:gochecknoglobals // it's just constant
-var unitsBin = [...]string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
+func unitsBin() [7]string {
+	return [...]string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
+}
 
 func formatSizeInternal(size int64, power int, unitlist [7]string) string {
 	if size == 0 {
@@ -155,10 +157,11 @@ func formatSizeInternal(size int64, power int, unitlist [7]string) string {
 }
 
 func FormatFileSize(size int64) string {
+	units := unitsBin()
 	if Config.FileSizeUseSI {
-		return formatSizeInternal(size, KilobyteSize, unitsDec)
+		units = unitsDec()
 	}
-	return formatSizeInternal(size, KibibyteSize, unitsBin)
+	return formatSizeInternal(size, KibibyteSize, units)
 }
 
 func GetHelpMenuHotkeyString(hotkeys []string) string {

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -213,31 +213,31 @@ func TestMakePrintable(t *testing.T) {
 
 func TestFormatSizeInternal(t *testing.T) {
 	t.Run("max int size", func(t *testing.T) {
-		actual := formatSizeInternal(math.MaxInt64, KilobyteSize, unitsDec)
+		actual := formatSizeInternal(math.MaxInt64, KilobyteSize, unitsDec())
 		assert.Equal(t, "9.22 EB", actual)
 	})
 	t.Run("zero size", func(t *testing.T) {
-		actual := formatSizeInternal(0, KilobyteSize, unitsDec)
+		actual := formatSizeInternal(0, KilobyteSize, unitsDec())
 		assert.Equal(t, "0 B", actual)
 	})
 	t.Run("100 bytes size", func(t *testing.T) {
-		actual := formatSizeInternal(100, KilobyteSize, unitsDec)
+		actual := formatSizeInternal(100, KilobyteSize, unitsDec())
 		assert.Equal(t, "100 B", actual)
 	})
 	t.Run("1005 bytes size", func(t *testing.T) {
-		actual := formatSizeInternal(1005, KilobyteSize, unitsDec)
+		actual := formatSizeInternal(1005, KilobyteSize, unitsDec())
 		assert.Equal(t, "1.00 kB", actual)
 	})
 	t.Run("1005 bytes size kibi", func(t *testing.T) {
-		actual := formatSizeInternal(1005, KibibyteSize, unitsBin)
+		actual := formatSizeInternal(1005, KibibyteSize, unitsBin())
 		assert.Equal(t, "1005 B", actual)
 	})
 	t.Run("1025 bytes size kibi", func(t *testing.T) {
-		actual := formatSizeInternal(1025, KibibyteSize, unitsBin)
+		actual := formatSizeInternal(1025, KibibyteSize, unitsBin())
 		assert.Equal(t, "1.00 KiB", actual)
 	})
 	t.Run("1035 bytes size kibi", func(t *testing.T) {
-		actual := formatSizeInternal(1035, KibibyteSize, unitsBin)
+		actual := formatSizeInternal(1035, KibibyteSize, unitsBin())
 		assert.Equal(t, "1.01 KiB", actual)
 	})
 }


### PR DESCRIPTION
issue #1368 
Removed showing two fractional digits of Byte for files with small size
before fix:
<img width="640" height="561" alt="image" src="https://github.com/user-attachments/assets/3137bf97-3ed5-4174-b8ea-fc20b23b427f" />

after fix:
<img width="807" height="512" alt="image" src="https://github.com/user-attachments/assets/45fa650d-8fac-4899-8722-7eb8dc15d4ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spacing in file-size display for zero-size values ("0 B").

* **Refactor**
  * Centralized and simplified file-size formatting logic to remove duplication and improve consistency; formatting now supports selectable decimal and binary units.

* **Tests**
  * Added comprehensive tests covering decimal vs binary formatting, edge cases (zero, small values), and very large values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->