### PR TITLE
feat: refresh file metadata when focusing metadata panel

### DIFF
--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -154,6 +154,11 @@ func (m *model) getMetadataCmd() tea.Cmd {
 		metadataFocused == m.fileMetaData.GetMetadataExpectedFocused() {
 		return nil
 	}
+
+	if metadataFocused {
+		m.fileMetaData.DropMetadataIfInCache(selectedItem.Location)
+	}
+
 	if m.fileMetaData.UpdateMetadataIfExistsInCache(selectedItem.Location, metadataFocused) {
 		return nil
 	}

--- a/src/internal/ui/metadata/update.go
+++ b/src/internal/ui/metadata/update.go
@@ -38,3 +38,8 @@ func (m *Model) UpdateMetadataIfExistsInCache(filepath string, metadataFocused b
 	}
 	return false
 }
+
+func (m *Model) DropMetadataIfInCache(filepath string) {
+	m.cache.Remove(cacheKey(filepath, true))
+	m.cache.Remove(cacheKey(filepath, false))
+}

--- a/src/pkg/cache/cache.go
+++ b/src/pkg/cache/cache.go
@@ -80,6 +80,12 @@ func (c *Cache[T]) Set(key string, obj T) {
 	}
 }
 
+func (c *Cache[T]) Remove(key string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	delete(c.cache, key)
+}
+
 // evictOldest removes the oldest entry from the cache
 func (c *Cache[T]) evictOldest() {
 	var oldestKey string


### PR DESCRIPTION
I think the command "m", that focuses  metadata panel, has the semantic of refreshing it. 
Also I believe that performance will not degrade because "m" is used intentionally and rare by the user to get actual meta.

Example before changes
after `touch temp/file2.txt`

<img width="817" height="345" alt="image" src="https://github.com/user-attachments/assets/6c0f7715-ec71-4dbc-8ab8-8b95e7c16bf2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata caching behavior to ensure stale data is properly cleared when metadata is refreshed, providing more accurate and up-to-date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->