### PR TITLE
fix(nix): disable broken check phase

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,10 @@
             src = ./.;
             modules = ./gomod2nix.toml;
 
+            # Temporary workaround: zoxide-related tests fail in the Nix sandbox.
+            # CI still runs build, test, fmt, and lint outside the flake build.
+            doCheck = false;
+
             nativeCheckInputs = with pkgs; [
               zoxide
               exiftool


### PR DESCRIPTION
The flake checks have been broken for quite some time when building with Nix. The main issue is that Nix builds run in an isolated environment, which interferes with the file paths expected by the checks.

I attempted to find a proper fix, but was unable to identify a clean solution.

The actual build works correctly (fixed in #1373), so if we disable the check phase, superfile builds and runs correctly using the Nix flake.

While users can disable the checks themselves as a workaround (which is what I have been doing for several months), this requires awareness of the issue. Anyone trying to build the flake normally will encounter a build failure.

Disabling the check phase in the flake would avoid this problem and allow the project to build successfully for everyone using Nix.

What do you think about disabling the check phase for now?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted build configuration to skip verification steps during a package build. No changes to public interfaces or exported behavior. Estimated impact: minor; review effort: small.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->