### PR TITLE
feat(sidebar): add Desktop directory to well-known directories

### DIFF
--- a/src/config/icon/icon.go
+++ b/src/config/icon/icon.go
@@ -12,6 +12,7 @@ var (
 
 	// Well Known Directories
 	Home        = "\U000f02dc" // Printable Rune : "󰋜"
+	Desktop     = "\U000f01c4" // Printable Rune : "󰇄"
 	Download    = "\U000f03d4" // Printable Rune : "󰏔"
 	Documents   = "\U000f0219" // Printable Rune : "󰈙"
 	Pictures    = "\U000f02e9" // Printable Rune : "󰋩"

--- a/src/internal/ui/sidebar/directory_utils.go
+++ b/src/internal/ui/sidebar/directory_utils.go
@@ -54,6 +54,7 @@ func getDirectories(pinnedMgr *PinnedManager, sections []string) []directory {
 func getWellKnownDirectories() []directory {
 	wellKnownDirectories := []directory{
 		{Location: xdg.Home, Name: icon.Home + icon.Space + "Home"},
+		{Location: xdg.UserDirs.Desktop, Name: icon.Desktop + icon.Space + "Desktop"},
 		{Location: xdg.UserDirs.Download, Name: icon.Download + icon.Space + "Downloads"},
 		{Location: xdg.UserDirs.Documents, Name: icon.Documents + icon.Space + "Documents"},
 		{Location: xdg.UserDirs.Pictures, Name: icon.Pictures + icon.Space + "Pictures"},


### PR DESCRIPTION
## Summary

This PR adds the Desktop directory to the well-known directories displayed in the sidebar.

## Related Issue

Partially addresses #312 - the xdg library used by superfile already reads `user-dirs.dirs` configuration file, which means superfile should already respect custom XDG paths. However, Desktop was missing from the well-known directories list.

## Changes

- Add `Desktop` icon constant in `icon.go`
- Add Desktop entry in `getWellKnownDirectories()` using `xdg.UserDirs.Desktop`

## Technical Notes

The `github.com/adrg/xdg` library already parses `~/.config/user-dirs.dirs` (on Linux) to resolve user directories. So if a user has custom paths configured like:

```
XDG_DESKTOP_DIR="$HOME/MyDesktop"
XDG_MUSIC_DIR="$HOME/Documents/Music"
```

The xdg library will correctly return these paths, and superfile will display them in the sidebar (assuming the directories exist).

## Testing

- [x] `go build ./...` passes
- [x] `go test ./src/internal/ui/sidebar/...` passes

The Desktop entry uses the same pattern as other well-known directories - it checks if the directory exists via `os.Stat` before displaying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Desktop directory is now displayed in the sidebar under well-known directories, providing quick access to desktop files in both standard and filtered views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->