### PR TITLE
chore: add new workflow for PR auto labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,66 @@
+changed-files-labels-limit: 5
+max-files-changed: 100
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - README.md
+          - CONTRIBUTING.md
+          - release/**/*.md
+          - .github/ISSUE_TEMPLATE/**
+          - .github/PULL_REQUEST_TEMPLATE/**
+          - website/README.md
+          - website/src/content/docs/**
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - go.mod
+          - go.sum
+          - .github/renovate.json
+          - website/package.json
+          - website/pnpm-lock.yaml
+
+test related:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*_test.go"
+          - testsuite/**
+          - .github/workflows/testsuite-run.yml
+          - .github/workflows/superfile-build-test.yml
+
+theme:
+  - changed-files:
+      - any-glob-to-any-file:
+          - asset/theme/**
+          - src/superfile_config/theme/**
+
+website:
+  - changed-files:
+      - any-glob-to-any-file:
+          - website/**
+
+new config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/config/**
+          - src/superfile_config/config.toml
+
+new hotkeys:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/superfile_config/hotkeys.toml
+          - src/superfile_config/vimHotkeys.toml
+
+packaging:
+  - changed-files:
+      - any-glob-to-any-file:
+          - Makefile
+          - build.sh
+          - flake.nix
+          - flake.lock
+          - gomod2nix.toml
+          - release/**
+          - asset/spf.desktop
+          - .github/workflows/update-gomod2nix.yml
+          - .github/workflows/winget.yml

--- a/.github/workflows/default-pr-labels.yml
+++ b/.github/workflows/default-pr-labels.yml
@@ -1,0 +1,23 @@
+name: Default PR Labels
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  add-awaiting-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add awaiting review label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "awaiting pr review"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,21 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          sync-labels: true


### PR DESCRIPTION
This PR create a new GitHub workflow for auto labeling new PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Pull requests now automatically receive category-based labels based on the types of files modified, including documentation, dependencies, tests, configuration, hotkeys, website, and packaging changes.
  * Newly opened and reopened pull requests automatically receive an "awaiting pr review" label for streamlined review tracking and triage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->