### PR TITLE
fix: clear kitty images before opening modal overlays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md — superfile
+
+## Build / Lint / Test Commands
+
+```bash
+make build        # Build only (skip tests)
+make test         # Run unit tests: go test ./...
+make lint         # Run golangci-lint
+make dev          # Full workflow: tidy → fmt → lint → test → build
+make testsuite    # Full workflow + Python integration tests
+make clean        # Remove bin/
+```
+
+### Running a single test
+
+```bash
+go test ./src/internal/ -run TestName
+go test ./src/internal/ -run TestName -v          # verbose
+go test ./src/internal/ -run TestName/SubTest     # subtest
+go test ./src/internal/ -run TestName -count=1    # disable cache
+```
+
+### Lint formatting
+
+```bash
+golangci-lint fmt          # Format with goimports + golines
+go fmt ./...               # Standard Go formatting
+```
+
+### Build binary
+
+```bash
+CGO_ENABLED=0 go build -o ./bin/spf   # or: ./build.sh
+```
+
+## Code Style
+
+### Imports
+
+- Three groups separated by blank lines: stdlib → third-party → internal
+- Internal imports use full path: `github.com/yorukot/superfile/src/internal/common`
+- Use aliases for disambiguation: `tea "github.com/charmbracelet/bubbletea"`
+- `goimports` enforces local-prefixes: `github.com/yorukot/superfile`
+
+### Formatting
+
+- Max line length: **120 chars** (enforced by `golines`)
+- Run `golangci-lint fmt` or `go fmt ./...` before committing
+
+### Naming
+
+- `PascalCase` for exported identifiers, `camelCase` for unexported
+- Sentinel errors: prefix with `Err` (e.g., `ErrNotFound`)
+- Error types: suffix with `Error` (e.g., `TomlLoadError`)
+- Test structs: descriptive field names (`expectedZipName`, `shouldClear`)
+- Method receivers: short, consistent names per type
+
+### Error Handling
+
+- Return errors, never panic (except in test setup via `os.Exit`)
+- Wrap with `fmt.Errorf("context: %w", err)`; create with `errors.New()`
+- Always check: `if err != nil { return ... }`
+- Use `slog` for logging: `slog.Error("msg", "key", value)`
+- Inline error handling (`if err := ...; err != nil`) is acceptable
+
+### Types & Structs
+
+- No embedded `sync.Mutex` or `sync.RWMutex` (enforced by linter)
+- Use struct tags for (un)marshaling (enforced by `musttag`)
+- No named returns (enforced by `nonamedreturns`)
+- Global variables allowed only in config/icon files (use `//nolint:gochecknoglobals` elsewhere with justification)
+
+### Testing
+
+- **Table-driven tests** are the dominant pattern
+- Use `testify/assert` and `testify/require` for assertions
+- Test files use same package (`package internal`), not `_test`
+- Use `t.TempDir()` and `t.Cleanup()` for cleanup
+- Async tests: `assert.Eventually()` with `1s` timeout / `10ms` tick
+- `TestMain` for shared setup/teardown in `model_test.go`
+- No `t.Parallel()` (disabled in CI due to false positives)
+
+### Linter
+
+- 80+ linters enabled via `.golangci.yaml` (very strict)
+- Always run `make lint` before committing
+- `//nolint:lintname` requires explanation
+- PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/): `feat(scope): description`
+
+### Architecture
+
+- Bubble Tea Elm architecture: `Init()`, `Update(msg tea.Msg)`, `View()`
+- UI components in `src/internal/ui/` (filepanel, sidebar, preview, etc.)
+- Shared utilities in `src/internal/common/` and `src/pkg/`
+- Config/theme TOML files embedded via `//go:embed`

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -119,13 +119,17 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen //
 		return m.getCompressSelectedFilesCmd()
 
 	case slices.Contains(common.Hotkeys.OpenCommandLine, msg):
+		m.fileModel.FilePreview.ClearKittyImages()
 		m.promptModal.Open(true)
 	case slices.Contains(common.Hotkeys.OpenSPFPrompt, msg):
+		m.fileModel.FilePreview.ClearKittyImages()
 		m.promptModal.Open(false)
 	case slices.Contains(common.Hotkeys.OpenZoxide, msg):
+		m.fileModel.FilePreview.ClearKittyImages()
 		return m.zoxideModal.Open()
 
 	case slices.Contains(common.Hotkeys.OpenHelpMenu, msg):
+		m.fileModel.FilePreview.ClearKittyImages()
 		m.helpMenu.Open()
 
 	case slices.Contains(common.Hotkeys.OpenSortOptionsMenu, msg):

--- a/src/internal/ui/preview/model.go
+++ b/src/internal/ui/preview/model.go
@@ -2,6 +2,7 @@ package preview
 
 import (
 	"log/slog"
+	"os"
 
 	"github.com/yorukot/superfile/src/internal/common"
 
@@ -44,5 +45,18 @@ func New() Model {
 		thumbnailGenerator: generator,
 		// TODO:  This is an IO operation, move to async ?
 		batCmd: checkBatCmd(),
+	}
+}
+
+// ClearKittyImages returns the escape sequence to clear kitty protocol
+// images from the terminal. Should be called before rendering any modal
+// overlay to prevent image pixels bleeding through.
+func (m *Model) ClearKittyImages() {
+	if m.imagePreviewer == nil {
+		return
+	}
+	cmd := m.imagePreviewer.ClearKittyImages()
+	if cmd != "" {
+		_, _ = os.Stdout.WriteString(cmd)
 	}
 }


### PR DESCRIPTION
Fixes #1393

## Problem
When a picture or PDF is being previewed using the Kitty graphics protocol, opening any modal overlay (help menu, sort options, prompt, zoxide, typing modal) causes the image pixels to bleed through on top of the modal.

This happens because the Kitty protocol paints pixels **directly to the terminal** outside of Bubbletea's render cycle, so Bubbletea's text rendering cannot cover them.

## Solution
- Added `ClearKittyImages()` method to `preview.Model` that writes the Kitty clear escape sequence directly to `os.Stdout`
- Called `m.fileModel.FilePreview.ClearKittyImages()` before each modal is opened in `key_function.go`
- Also clears the image when toggling the preview panel off via `ToggleFilePreviewPanel()`

## Testing
1. Open superfile in a Kitty-capable terminal (Kitty, Ghostty, WezTerm etc.)
2. Navigate to a directory containing images or PDFs
3. Open the preview panel and select an image
4. Open any modal (`?` help, `s` sort, `z` zoxide, `:` prompt, `n` new file)
5. Image should no longer bleed through the modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file preview image cache clearing when opening command prompts and menus to prevent stale images.

* **Documentation**
  * Added a new repository-wide developer guide that standardizes workflows, formatting, testing, linting, and architectural conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->