### PR TITLE
docs: add download badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/yorukot/superfile/refs/heads/main/LICENSE)
 [![Discord Link](https://img.shields.io/discord/1338415256875307110?label=discord&logo=discord&logoColor=white)](https://discord.gg/YYtJ23Du7B)
 [![Release](https://img.shields.io/github/v/release/yorukot/superfile.svg?style=flat-square)](https://github.com/yorukot/superfile/releases/latest)
-![HomeBrew downloads](https://img.shields.io/homebrew/installs/dy/superfile?label=homebrew)
-![Github downloads](https://img.shields.io/github/downloads/yorukot/superfile/total?label=github%20downloads%20assets%2Freleases)
+![Homebrew downloads](https://img.shields.io/homebrew/installs/dy/superfile?label=Homebrew)
+![GitHub downloads](https://img.shields.io/github/downloads/yorukot/superfile/total?label=GitHub%20downloads%20assets%2Freleases)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/yorukot/superfile?utm_source=oss&utm_medium=github&utm_campaign=yorukot%2Fsuperfile&labelColor=171717&color=FF570A&&label=CodeRabbit+Reviews)](https://www.coderabbit.ai/)
 
 ![](/asset/demo.png)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/yorukot/superfile/refs/heads/main/LICENSE)
 [![Discord Link](https://img.shields.io/discord/1338415256875307110?label=discord&logo=discord&logoColor=white)](https://discord.gg/YYtJ23Du7B)
 [![Release](https://img.shields.io/github/v/release/yorukot/superfile.svg?style=flat-square)](https://github.com/yorukot/superfile/releases/latest)
+![HomeBrew downloads](https://img.shields.io/homebrew/installs/dy/superfile?label=homebrew)
+![Github downloads](https://img.shields.io/github/downloads/yorukot/superfile/total?label=github%20downloads%20assets%2Freleases)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/yorukot/superfile?utm_source=oss&utm_medium=github&utm_campaign=yorukot%2Fsuperfile&labelColor=171717&color=FF570A&&label=CodeRabbit+Reviews)](https://www.coderabbit.ai/)
 
 ![](/asset/demo.png)


### PR DESCRIPTION
## Summary
- add the Homebrew download badge from `download_stats` to `README.md`
- add the GitHub downloads badge from `download_stats` to `README.md`
- keep the rest of the README unchanged


<img width="734" height="199" alt="image" src="https://github.com/user-attachments/assets/f9542d1b-66c4-4063-b65f-04a8dbc5fa55" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Homebrew installation badge to showcase an alternative installation method and provide quick visibility of Homebrew installs.
  * Added a GitHub downloads badge to display total and release asset download metrics directly in the README.
  * No other README content or project behavior was modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->