### PR TITLE
feat(columns): add file type byte to permissions column

### DIFF
--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -83,7 +83,7 @@ func (m *Model) renderPermissions(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
 	return common.FilePanelItemRender(
-		elem.Info.Mode().Perm().String(),
+		elem.Info.Mode().String(),
 		columnWidth,
 		isSelected,
 		common.FilePanelBGColor,


### PR DESCRIPTION
The permissions column is missing the file type (the first letter).

For a regular file, it should be `-` and for a directory, `d`. Not `-` for all types.

Before:
<img width="688" height="152" alt="2026-04-14T17:43:26" src="https://github.com/user-attachments/assets/ad121f5b-56ab-4d2c-820e-e7ebc04c70f0" />

After:
<img width="688" height="120" alt="2026-04-14T17:43:51" src="https://github.com/user-attachments/assets/48146d59-e3df-4805-b7fd-b3a2cff96126" />

`ls` shows this so I believe superfile should, too.
<img width="408" height="118" alt="2026-04-14T17:47:17" src="https://github.com/user-attachments/assets/f8cc0659-fffb-4665-a12e-bea7003a7af2" /> 

And the metadata section already has it.
<img width="202" height="113" alt="2026-04-14T17:44:01" src="https://github.com/user-attachments/assets/096a24fc-327d-4a57-8f77-8dfaafd531b0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated file permission display in the file panel to show complete file mode information rather than permission bits only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->