### PR TITLE
feat: add save-file flow and ordered chooser output

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,21 @@ Edit System Environment Variables and add superfile repo's `bin` directory to yo
 spf
 ```
 
+## Chooser and save mode
+
+superfile can be used as a terminal file chooser integration target:
+
+```bash
+spf --chooser-file /tmp/selected-paths.txt
+spf --save-file /tmp/save-target.txt /path/to/suggested-name.txt
+```
+
+- `--chooser-file` writes the selected open path or paths to the output file.
+- In select mode, `e` writes the selected paths in selection order as newline-delimited absolute paths.
+- `--save-file` opens a dedicated save flow with a pinned save target ghost. Use `ctrl+r` to rename the ghost, `e` to confirm the focused file or ghost, and `E` to confirm the current directory plus the ghost name.
+- `--chooser-file` and `--save-file` are mutually exclusive and accept at most one startup path.
+- If you use `xdg-desktop-portal-termfilechooser`, its superfile wrapper should be updated to call `spf --save-file="$out" "$path"` for save requests.
+
 ## Supported Systems
 
 - \[x\] Linux

--- a/contrib/superfile-wrapper.sh
+++ b/contrib/superfile-wrapper.sh
@@ -22,14 +22,10 @@ termcmd="${TERMCMD:-kitty --title 'termfilechooser'}"
 if [ "$save" = "1" ]; then
     # save a file
     set -- --save-file="$out" "$path"
-elif [ "$directory" = "1" ]; then
-    # upload files from a directory
-    set -- --chooser-file="$out" "$path"
-elif [ "$multiple" = "1" ]; then
-    # upload multiple files
-    set -- --chooser-file="$out" "$path"
 else
-    # upload only 1 file
+    # Open chooser requests currently use the same invocation for single-file,
+    # multi-file, and directory selection. TODO: split these branches if
+    # superfile ever needs different behavior for $multiple or $directory later.
     set -- --chooser-file="$out" "$path"
 fi
 

--- a/contrib/superfile-wrapper.sh
+++ b/contrib/superfile-wrapper.sh
@@ -29,12 +29,4 @@ else
     set -- --chooser-file="$out" "$path"
 fi
 
-command="$termcmd $cmd"
-for arg in "$@"; do
-    # escape double quotes
-    escaped=$(printf "%s" "$arg" | sed 's/"/\\"/g')
-    # escape special
-    command="$command \"$escaped\""
-done
-
-sh -c "$command"
+exec env -S "$termcmd" "$cmd" "$@"

--- a/contrib/superfile-wrapper.sh
+++ b/contrib/superfile-wrapper.sh
@@ -10,6 +10,8 @@ path="$4"
 out="$5"
 debug="$6"
 
+: "$multiple" "$directory"
+
 set -e
 
 if [ "$debug" = 1 ]; then

--- a/contrib/superfile-wrapper.sh
+++ b/contrib/superfile-wrapper.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+# This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
+#
+# For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`
+
+multiple="$1"
+directory="$2"
+save="$3"
+path="$4"
+out="$5"
+debug="$6"
+
+set -e
+
+if [ "$debug" = 1 ]; then
+    set -x
+fi
+
+cmd="spf"
+termcmd="${TERMCMD:-kitty --title 'termfilechooser'}"
+
+if [ "$save" = "1" ]; then
+    # save a file
+    set -- --save-file="$out" "$path"
+elif [ "$directory" = "1" ]; then
+    # upload files from a directory
+    set -- --chooser-file="$out" "$path"
+elif [ "$multiple" = "1" ]; then
+    # upload multiple files
+    set -- --chooser-file="$out" "$path"
+else
+    # upload only 1 file
+    set -- --chooser-file="$out" "$path"
+fi
+
+command="$termcmd $cmd"
+for arg in "$@"; do
+    # escape double quotes
+    escaped=$(printf "%s" "$arg" | sed 's/"/\\"/g')
+    # escape special
+    command="$command \"$escaped\""
+done
+
+sh -c "$command"

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -120,8 +121,13 @@ func Run(content embed.FS) {
 			&cli.StringFlag{
 				Name:    "chooser-file",
 				Aliases: []string{"cf"},
-				Usage:   "On trying to open any file, superfile will write to its path to this file, and exit",
+				Usage:   "Write the chosen open-selection path or paths to this file, and exit",
 				Value:   "", // Default to the blank string indicating non-usage of flag
+			},
+			&cli.StringFlag{
+				Name:  "save-file",
+				Usage: "Open superfile in save mode, write the confirmed save path to this file, and exit",
+				Value: "", // Default to the blank string indicating non-usage of flag
 			},
 		},
 		Action: spfAppAction,
@@ -146,6 +152,12 @@ func spfAppAction(_ context.Context, c *cli.Command) error {
 		firstPanelPaths = c.Args().Slice()
 	}
 
+	req, err := buildChooserRequest(firstPanelPaths, c.String("chooser-file"), c.String("save-file"))
+	if err != nil {
+		return err
+	}
+	variable.SetChooserRequest(req)
+
 	InitConfigFile()
 
 	firstUse := checkFirstUse()
@@ -167,6 +179,40 @@ func spfAppAction(_ context.Context, c *cli.Command) error {
 	}
 
 	return nil
+}
+
+func buildChooserRequest(firstPanelPaths []string, chooserFile string, saveFile string) (variable.ChooserRequest, error) {
+	if chooserFile != "" && saveFile != "" {
+		return variable.ChooserRequest{}, errors.New("--chooser-file and --save-file cannot be used together")
+	}
+
+	if chooserFile == "" && saveFile == "" {
+		return variable.ChooserRequest{}, nil
+	}
+
+	if len(firstPanelPaths) > 1 {
+		return variable.ChooserRequest{}, errors.New("chooser/save mode accepts at most one startup path")
+	}
+
+	req := variable.ChooserRequest{}
+	switch {
+	case chooserFile != "":
+		req.Mode = variable.ChooserModeOpen
+		req.OutputFile = chooserFile
+	case saveFile != "":
+		req.Mode = variable.ChooserModeSave
+		req.OutputFile = saveFile
+	}
+
+	if len(firstPanelPaths) == 1 && firstPanelPaths[0] != "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return variable.ChooserRequest{}, fmt.Errorf("get working directory: %w", err)
+		}
+		req.SuggestedPath = utils.ResolveAbsPath(cwd, firstPanelPaths[0])
+	}
+
+	return req, nil
 }
 
 // Create proper directories for storing configuration and write default

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Run superfile app
-func Run(content embed.FS) {
+func Run(content embed.FS) { //nolint:funlen // CLI wiring keeps command/flag registration in one place.
 	// Enable custom colored help output
 	cli.HelpPrinter = CustomHelpPrinter //nolint:reassign // Intentionally reassigning to customize help output
 
@@ -181,7 +181,11 @@ func spfAppAction(_ context.Context, c *cli.Command) error {
 	return nil
 }
 
-func buildChooserRequest(firstPanelPaths []string, chooserFile string, saveFile string) (variable.ChooserRequest, error) {
+func buildChooserRequest(
+	firstPanelPaths []string,
+	chooserFile string,
+	saveFile string,
+) (variable.ChooserRequest, error) {
 	if chooserFile != "" && saveFile != "" {
 		return variable.ChooserRequest{}, errors.New("--chooser-file and --save-file cannot be used together")
 	}

--- a/src/cmd/main_test.go
+++ b/src/cmd/main_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	variable "github.com/yorukot/superfile/src/config"
+)
+
+func TestBuildChooserRequest(t *testing.T) {
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWD))
+	})
+
+	testdata := []struct {
+		name           string
+		firstPanelPath []string
+		chooserFile    string
+		saveFile       string
+		expected       variable.ChooserRequest
+		wantErr        bool
+	}{
+		{
+			name:           "open chooser with relative path",
+			firstPanelPath: []string{"relative/file.txt"},
+			chooserFile:    "out.txt",
+			expected: variable.ChooserRequest{
+				Mode:          variable.ChooserModeOpen,
+				OutputFile:    "out.txt",
+				SuggestedPath: filepath.Join(tempDir, "relative", "file.txt"),
+			},
+		},
+		{
+			name:           "save chooser with no startup path",
+			firstPanelPath: []string{""},
+			saveFile:       "save-out.txt",
+			expected: variable.ChooserRequest{
+				Mode:       variable.ChooserModeSave,
+				OutputFile: "save-out.txt",
+			},
+		},
+		{
+			name:           "mutually exclusive flags",
+			firstPanelPath: []string{"one"},
+			chooserFile:    "open.txt",
+			saveFile:       "save.txt",
+			wantErr:        true,
+		},
+		{
+			name:           "too many startup paths",
+			firstPanelPath: []string{"one", "two"},
+			chooserFile:    "open.txt",
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := buildChooserRequest(tt.firstPanelPath, tt.chooserFile, tt.saveFile)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, req)
+		})
+	}
+}

--- a/src/cmd/main_test.go
+++ b/src/cmd/main_test.go
@@ -16,6 +16,9 @@ func TestBuildChooserRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	tempDir := t.TempDir()
+	tempDir, err = filepath.EvalSymlinks(tempDir)
+	require.NoError(t, err)
+
 	require.NoError(t, os.Chdir(tempDir))
 	t.Cleanup(func() {
 		require.NoError(t, os.Chdir(originalWD))

--- a/src/cmd/main_test.go
+++ b/src/cmd/main_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,17 +11,12 @@ import (
 )
 
 func TestBuildChooserRequest(t *testing.T) {
-	originalWD, err := os.Getwd()
-	require.NoError(t, err)
-
 	tempDir := t.TempDir()
+	var err error
 	tempDir, err = filepath.EvalSymlinks(tempDir)
 	require.NoError(t, err)
 
-	require.NoError(t, os.Chdir(tempDir))
-	t.Cleanup(func() {
-		require.NoError(t, os.Chdir(originalWD))
-	})
+	t.Chdir(tempDir)
 
 	testdata := []struct {
 		name           string

--- a/src/config/fixed_variable.go
+++ b/src/config/fixed_variable.go
@@ -11,6 +11,24 @@ import (
 	"github.com/adrg/xdg"
 )
 
+type ChooserMode uint8
+
+const (
+	ChooserModeNone ChooserMode = iota
+	ChooserModeOpen
+	ChooserModeSave
+)
+
+type ChooserRequest struct {
+	Mode          ChooserMode
+	OutputFile    string
+	SuggestedPath string
+}
+
+func (r ChooserRequest) Active() bool {
+	return r.Mode != ChooserModeNone && r.OutputFile != ""
+}
+
 const (
 	CurrentVersion = "v1.5.0"
 	// Allowing pre-releases with non production version
@@ -66,9 +84,7 @@ var (
 	ConfigFile  = filepath.Join(SuperFileMainDir, "config.toml")
 	HotkeysFile = filepath.Join(SuperFileMainDir, "hotkeys.toml")
 
-	// ChooserFile is the path where superfile will write the file's path, which is to be
-	// opened, before exiting
-	ChooserFile = ""
+	chooserRequest = ChooserRequest{}
 
 	// Other state variables
 	FixHotkeys    = false
@@ -83,8 +99,12 @@ func SetLastDir(path string) {
 	LastDir = path
 }
 
-func SetChooserFile(path string) {
-	ChooserFile = path
+func SetChooserRequest(req ChooserRequest) {
+	chooserRequest = req
+}
+
+func GetChooserRequest() ChooserRequest {
+	return chooserRequest
 }
 
 func UpdateVarFromCliArgs(c *cli.Command) {
@@ -107,9 +127,6 @@ func UpdateVarFromCliArgs(c *cli.Command) {
 		}
 		HotkeysFile = hotkeyFileArg
 	}
-
-	// It could be non existent. We are writing to the file. If file doesn't exists, we would attempt to create it.
-	SetChooserFile(c.String("chooser-file"))
 
 	FixHotkeys = c.Bool("fix-hotkeys")
 	FixConfigFile = c.Bool("fix-config-file")

--- a/src/internal/chooser.go
+++ b/src/internal/chooser.go
@@ -22,9 +22,22 @@ func (m *model) initializeChooserState() {
 	}
 
 	panel := m.getFocusedFilePanel()
-	startDir, saveName := resolveSaveChooserStartPath(m.chooser.request.SuggestedPath, panel.Location)
+	fallbackDir := panel.Location
+	startDir, saveName := resolveSaveChooserStartPath(m.chooser.request.SuggestedPath, fallbackDir)
 	if err := panel.UpdateCurrentFilePanelDir(startDir); err != nil {
+		notifyErr := err
 		slog.Error("Failed to initialize save chooser directory", "path", startDir, "error", err)
+		if fallbackDir != startDir {
+			if fallbackErr := panel.UpdateCurrentFilePanelDir(fallbackDir); fallbackErr == nil {
+				panel.EnableSaveMode(saveName)
+				return
+			} else {
+				notifyErr = fallbackErr
+				slog.Error("Failed to initialize fallback save chooser directory", "path", fallbackDir, "error", fallbackErr)
+			}
+		}
+		m.notifyModel = notify.New(true, common.SaveInitErrorTitle, notifyErr.Error(), notify.NoAction)
+		return
 	}
 	panel.EnableSaveMode(saveName)
 }
@@ -119,7 +132,7 @@ func (m *model) confirmSaveChooserPath(path string) {
 	switch {
 	case err == nil:
 		if info.IsDir() {
-			m.notifyModel = notify.New(true, "Cannot save to a directory", "Please choose a file name instead of a directory.", notify.NoAction)
+			m.notifyModel = notify.New(true, common.SaveDirErrorTitle, common.SaveDirErrorContent, notify.NoAction)
 			return
 		}
 		if m.isPortalSavePlaceholder(path) {
@@ -153,7 +166,7 @@ func (m *model) confirmSaveChooserPath(path string) {
 				"writeError", writeErr, "path", path)
 		}
 	default:
-		m.notifyModel = notify.New(true, "Cannot access target path", err.Error(), notify.NoAction)
+		m.notifyModel = notify.New(true, common.SaveAccessErrorTitle, err.Error(), notify.NoAction)
 		slog.Error("Save chooser target stat failed", "path", path, "error", err)
 	}
 }

--- a/src/internal/chooser.go
+++ b/src/internal/chooser.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -33,7 +34,13 @@ func (m *model) initializeChooserState() {
 				return
 			} else {
 				notifyErr = fallbackErr
-				slog.Error("Failed to initialize fallback save chooser directory", "path", fallbackDir, "error", fallbackErr)
+				slog.Error(
+					"Failed to initialize fallback save chooser directory",
+					"path",
+					fallbackDir,
+					"error",
+					fallbackErr,
+				)
 			}
 		}
 		m.notifyModel = notify.New(true, common.SaveInitErrorTitle, notifyErr.Error(), notify.NoAction)
@@ -131,49 +138,80 @@ func (m *model) confirmSaveChooserPath(path string) {
 	info, err := os.Stat(path)
 	switch {
 	case err == nil:
-		if info.IsDir() {
-			m.notifyModel = notify.New(true, common.SaveDirErrorTitle, common.SaveDirErrorContent, notify.NoAction)
-			return
-		}
-		if m.isPortalSavePlaceholder(path) {
-			if writeErr := m.chooserWriteAndQuit([]string{path}); writeErr != nil {
-				slog.Error("Error while writing save chooser result", "error", writeErr)
-			}
-			return
-		}
-		m.warnModalForSaveOverwrite(path)
+		m.confirmExistingSaveChooserPath(path, info)
 	case os.IsNotExist(err):
-		parentDir := filepath.Dir(path)
-		parentInfo, statErr := os.Stat(parentDir)
-		if statErr != nil || !parentInfo.IsDir() {
-			slog.Error("Save chooser target parent is invalid", "path", path, "error", statErr)
-			return
-		}
-
-		if createErr := createSaveChooserPlaceholder(path); createErr != nil {
-			slog.Error("Error while creating save chooser placeholder", "path", path, "error", createErr)
-			return
-		}
-
-		if writeErr := m.chooserWriteAndQuit([]string{path}); writeErr != nil {
-			removeErr := os.Remove(path)
-			if removeErr != nil {
-				slog.Error("Error while writing save chooser result and removing placeholder",
-					"writeError", writeErr, "removeError", removeErr, "path", path)
-				return
-			}
-			slog.Error("Error while writing save chooser result; removed placeholder",
-				"writeError", writeErr, "path", path)
-		}
+		m.confirmNewSaveChooserPath(path)
 	default:
 		m.notifyModel = notify.New(true, common.SaveAccessErrorTitle, err.Error(), notify.NoAction)
 		slog.Error("Save chooser target stat failed", "path", path, "error", err)
 	}
 }
 
+func (m *model) confirmExistingSaveChooserPath(path string, info os.FileInfo) {
+	if info.IsDir() {
+		m.notifyModel = notify.New(true, common.SaveDirErrorTitle, common.SaveDirErrorContent, notify.NoAction)
+		return
+	}
+
+	if m.isPortalSavePlaceholder(path) {
+		if writeErr := m.chooserWriteAndQuit([]string{path}); writeErr != nil {
+			slog.Error("Error while writing save chooser result", "error", writeErr)
+		}
+		return
+	}
+
+	m.warnModalForSaveOverwrite(path)
+}
+
+func (m *model) confirmNewSaveChooserPath(path string) {
+	parentDir := filepath.Dir(path)
+	parentInfo, statErr := os.Stat(parentDir)
+	if statErr != nil || !parentInfo.IsDir() {
+		slog.Error("Save chooser target parent is invalid", "path", path, "error", statErr)
+		return
+	}
+
+	if createErr := createSaveChooserPlaceholder(path); createErr != nil {
+		if errors.Is(createErr, os.ErrExist) {
+			m.warnModalForSaveOverwrite(path)
+			return
+		}
+		slog.Error("Error while creating save chooser placeholder", "path", path, "error", createErr)
+		return
+	}
+
+	if writeErr := m.chooserWriteAndQuit([]string{path}); writeErr != nil {
+		removeErr := os.Remove(path)
+		if removeErr != nil {
+			slog.Error(
+				"Error while writing save chooser result and removing placeholder",
+				"writeError",
+				writeErr,
+				"removeError",
+				removeErr,
+				"path",
+				path,
+			)
+			return
+		}
+		slog.Error(
+			"Error while writing save chooser result; removed placeholder",
+			"writeError",
+			writeErr,
+			"path",
+			path,
+		)
+	}
+}
+
 func (m *model) warnModalForSaveOverwrite(path string) {
 	m.chooser.overwritePath = path
-	m.notifyModel = notify.New(true, common.SaveOverwriteWarnTitle, common.SaveOverwriteWarnContent, notify.SaveOverwriteAction)
+	m.notifyModel = notify.New(
+		true,
+		common.SaveOverwriteWarnTitle,
+		common.SaveOverwriteWarnContent,
+		notify.SaveOverwriteAction,
+	)
 }
 
 func (m *model) confirmSaveOverwrite() {
@@ -193,7 +231,11 @@ func (m *model) cancelSaveOverwrite() {
 }
 
 func createSaveChooserPlaceholder(path string) error {
-	return os.WriteFile(path, []byte{}, utils.UserFilePerm)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, utils.UserFilePerm)
+	if err != nil {
+		return err
+	}
+	return file.Close()
 }
 
 func (m *model) isPortalSavePlaceholder(path string) bool {

--- a/src/internal/chooser.go
+++ b/src/internal/chooser.go
@@ -1,0 +1,195 @@
+package internal
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	variable "github.com/yorukot/superfile/src/config"
+	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/ui/filepanel"
+	"github.com/yorukot/superfile/src/internal/ui/notify"
+	"github.com/yorukot/superfile/src/pkg/utils"
+)
+
+const termfilechooserInstructionsPrefix = "* xdg-desktop-portal-termfilechooser instructions *"
+
+func (m *model) initializeChooserState() {
+	if !m.chooser.request.Active() || !m.isSaveChooserMode() {
+		return
+	}
+
+	panel := m.getFocusedFilePanel()
+	startDir, saveName := resolveSaveChooserStartPath(m.chooser.request.SuggestedPath, panel.Location)
+	if err := panel.UpdateCurrentFilePanelDir(startDir); err != nil {
+		slog.Error("Failed to initialize save chooser directory", "path", startDir, "error", err)
+	}
+	panel.EnableSaveMode(saveName)
+}
+
+func resolveSaveChooserStartPath(suggestedPath string, fallbackDir string) (string, string) {
+	if suggestedPath == "" {
+		return fallbackDir, ""
+	}
+
+	info, err := os.Stat(suggestedPath)
+	if err == nil {
+		if info.IsDir() {
+			return suggestedPath, ""
+		}
+		return filepath.Dir(suggestedPath), filepath.Base(suggestedPath)
+	}
+
+	parentDir := filepath.Dir(suggestedPath)
+	parentInfo, parentErr := os.Stat(parentDir)
+	if parentErr == nil && parentInfo.IsDir() {
+		return parentDir, filepath.Base(suggestedPath)
+	}
+
+	return fallbackDir, filepath.Base(suggestedPath)
+}
+
+func (m *model) hasChooserRequest() bool {
+	return m.chooser.request.Active()
+}
+
+func (m *model) isOpenChooserMode() bool {
+	return m.chooser.request.Mode == variable.ChooserModeOpen
+}
+
+func (m *model) isSaveChooserMode() bool {
+	return m.chooser.request.Mode == variable.ChooserModeSave
+}
+
+func (m *model) chooserWriteAndQuit(paths []string) error {
+	if !m.hasChooserRequest() {
+		return nil
+	}
+
+	err := os.WriteFile(m.chooser.request.OutputFile, []byte(strings.Join(paths, "\n")), utils.ConfigFilePerm)
+	if err != nil {
+		return err
+	}
+	m.modelQuitState = quitInitiated
+	return nil
+}
+
+func (m *model) openChooserWriteSelectionAndQuit() error {
+	panel := m.getFocusedFilePanel()
+	if panel.Empty() {
+		return nil
+	}
+
+	paths := []string{panel.GetFocusedItem().Location}
+	if panel.PanelMode == filepanel.SelectMode && panel.SelectedCount() > 0 {
+		paths = panel.GetOrderedSelectedLocations()
+	}
+	return m.chooserWriteAndQuit(paths)
+}
+
+func (m *model) saveChooserConfirmFocusedItem() {
+	panel := m.getFocusedFilePanel()
+	if panel.Empty() {
+		return
+	}
+
+	focused := panel.GetFocusedItem()
+	switch {
+	case focused.SaveTarget:
+		m.confirmSaveChooserPath(panel.GetSaveEntryLocation())
+	case focused.Directory:
+		return
+	default:
+		m.confirmSaveChooserPath(focused.Location)
+	}
+}
+
+func (m *model) saveChooserConfirmCurrentDirectory() {
+	m.confirmSaveChooserPath(m.getFocusedFilePanel().GetSaveEntryLocation())
+}
+
+func (m *model) confirmSaveChooserPath(path string) {
+	if path == "" {
+		return
+	}
+
+	info, err := os.Stat(path)
+	switch {
+	case err == nil:
+		if info.IsDir() {
+			return
+		}
+		if m.isPortalSavePlaceholder(path) {
+			if writeErr := m.chooserWriteAndQuit([]string{path}); writeErr != nil {
+				slog.Error("Error while writing save chooser result", "error", writeErr)
+			}
+			return
+		}
+		m.warnModalForSaveOverwrite(path)
+	case os.IsNotExist(err):
+		parentDir := filepath.Dir(path)
+		parentInfo, statErr := os.Stat(parentDir)
+		if statErr != nil || !parentInfo.IsDir() {
+			slog.Error("Save chooser target parent is invalid", "path", path, "error", statErr)
+			return
+		}
+
+		if createErr := createSaveChooserPlaceholder(path); createErr != nil {
+			slog.Error("Error while creating save chooser placeholder", "path", path, "error", createErr)
+			return
+		}
+
+		if writeErr := m.chooserWriteAndQuit([]string{path}); writeErr != nil {
+			slog.Error("Error while writing save chooser result", "error", writeErr)
+		}
+	default:
+		slog.Error("Save chooser target stat failed", "path", path, "error", err)
+	}
+}
+
+func (m *model) warnModalForSaveOverwrite(path string) {
+	m.chooser.overwritePath = path
+	m.notifyModel = notify.New(true, common.SaveOverwriteWarnTitle, common.SaveOverwriteWarnContent, notify.SaveOverwriteAction)
+}
+
+func (m *model) confirmSaveOverwrite() {
+	if m.chooser.overwritePath == "" {
+		return
+	}
+
+	path := m.chooser.overwritePath
+	m.chooser.overwritePath = ""
+	if err := m.chooserWriteAndQuit([]string{path}); err != nil {
+		slog.Error("Error while confirming save overwrite", "error", err)
+	}
+}
+
+func (m *model) cancelSaveOverwrite() {
+	m.chooser.overwritePath = ""
+}
+
+func createSaveChooserPlaceholder(path string) error {
+	return os.WriteFile(path, []byte{}, utils.ConfigFilePerm)
+}
+
+func (m *model) isPortalSavePlaceholder(path string) bool {
+	if path == "" || path != m.chooser.request.SuggestedPath {
+		return false
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	buf := make([]byte, len(termfilechooserInstructionsPrefix))
+	n, readErr := io.ReadFull(file, buf)
+	if readErr != nil && readErr != io.ErrUnexpectedEOF {
+		return false
+	}
+
+	return string(buf[:n]) == termfilechooserInstructionsPrefix
+}

--- a/src/internal/chooser.go
+++ b/src/internal/chooser.go
@@ -68,7 +68,7 @@ func (m *model) chooserWriteAndQuit(paths []string) error {
 		return nil
 	}
 
-	err := os.WriteFile(m.chooser.request.OutputFile, []byte(strings.Join(paths, "\n")), utils.ConfigFilePerm)
+	err := os.WriteFile(m.chooser.request.OutputFile, []byte(strings.Join(paths, "\n")), utils.UserFilePerm)
 	if err != nil {
 		return err
 	}
@@ -119,6 +119,7 @@ func (m *model) confirmSaveChooserPath(path string) {
 	switch {
 	case err == nil:
 		if info.IsDir() {
+			m.notifyModel = notify.New(true, "Cannot save to a directory", "Please choose a file name instead of a directory.", notify.NoAction)
 			return
 		}
 		if m.isPortalSavePlaceholder(path) {
@@ -142,9 +143,17 @@ func (m *model) confirmSaveChooserPath(path string) {
 		}
 
 		if writeErr := m.chooserWriteAndQuit([]string{path}); writeErr != nil {
-			slog.Error("Error while writing save chooser result", "error", writeErr)
+			removeErr := os.Remove(path)
+			if removeErr != nil {
+				slog.Error("Error while writing save chooser result and removing placeholder",
+					"writeError", writeErr, "removeError", removeErr, "path", path)
+				return
+			}
+			slog.Error("Error while writing save chooser result; removed placeholder",
+				"writeError", writeErr, "path", path)
 		}
 	default:
+		m.notifyModel = notify.New(true, "Cannot access target path", err.Error(), notify.NoAction)
 		slog.Error("Save chooser target stat failed", "path", path, "error", err)
 	}
 }
@@ -171,7 +180,7 @@ func (m *model) cancelSaveOverwrite() {
 }
 
 func createSaveChooserPlaceholder(path string) error {
-	return os.WriteFile(path, []byte{}, utils.ConfigFilePerm)
+	return os.WriteFile(path, []byte{}, utils.UserFilePerm)
 }
 
 func (m *model) isPortalSavePlaceholder(path string) bool {

--- a/src/internal/chooser_test.go
+++ b/src/internal/chooser_test.go
@@ -1,0 +1,65 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSaveChooserStartPath(t *testing.T) {
+	tempDir := t.TempDir()
+	existingDir := filepath.Join(tempDir, "dir")
+	existingFile := filepath.Join(existingDir, "file.txt")
+	nonExistentFile := filepath.Join(existingDir, "save.txt")
+
+	require.NoError(t, os.MkdirAll(existingDir, 0o755))
+	require.NoError(t, os.WriteFile(existingFile, []byte("data"), 0o644))
+
+	testdata := []struct {
+		name           string
+		suggestedPath  string
+		fallbackDir    string
+		expectedDir    string
+		expectedTarget string
+	}{
+		{
+			name:           "empty suggestion uses fallback",
+			suggestedPath:  "",
+			fallbackDir:    tempDir,
+			expectedDir:    tempDir,
+			expectedTarget: "",
+		},
+		{
+			name:           "existing directory",
+			suggestedPath:  existingDir,
+			fallbackDir:    tempDir,
+			expectedDir:    existingDir,
+			expectedTarget: "",
+		},
+		{
+			name:           "existing file",
+			suggestedPath:  existingFile,
+			fallbackDir:    tempDir,
+			expectedDir:    existingDir,
+			expectedTarget: "file.txt",
+		},
+		{
+			name:           "non existent file with existing parent",
+			suggestedPath:  nonExistentFile,
+			fallbackDir:    tempDir,
+			expectedDir:    existingDir,
+			expectedTarget: "save.txt",
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, target := resolveSaveChooserStartPath(tt.suggestedPath, tt.fallbackDir)
+			assert.Equal(t, tt.expectedDir, dir)
+			assert.Equal(t, tt.expectedTarget, target)
+		})
+	}
+}

--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -174,8 +174,9 @@ type HotkeysType struct {
 	ConfirmTyping []string `toml:"confirm_typing" comment:"=================================================================================================\nTyping hotkeys (can conflict with all hotkeys)"`
 	CancelTyping  []string `toml:"cancel_typing"`
 
-	ParentDirectory []string `toml:"parent_directory" comment:"=================================================================================================\nNormal mode hotkeys (can conflict with other modes, cannot conflict with global hotkeys)"`
-	SearchBar       []string `toml:"search_bar"`
+	ParentDirectory        []string `toml:"parent_directory" comment:"=================================================================================================\nNormal mode hotkeys (can conflict with other modes, cannot conflict with global hotkeys)"`
+	SearchBar              []string `toml:"search_bar"`
+	SaveChooserFocusTarget []string `toml:"save_chooser_focus_target"`
 
 	FilePanelSelectModeItemsSelectDown []string `toml:"file_panel_select_mode_items_select_down" comment:"=================================================================================================\nSelect mode hotkeys (can conflict with other modes, cannot conflict with global hotkeys)"`
 	FilePanelSelectModeItemsSelectUp   []string `toml:"file_panel_select_mode_items_select_up"`

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -25,6 +25,8 @@ const (
 	TrashWarnContent           = "This operation will move file or directory to trash can."
 	PermanentDeleteWarnTitle   = "Are you sure you want to completely delete"
 	PermanentDeleteWarnContent = "This operation cannot be undone and your data will be completely lost."
+	SaveOverwriteWarnTitle     = "The selected save target already exists"
+	SaveOverwriteWarnContent   = "This operation will return an existing file path and may overwrite that file."
 )
 
 const (

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -27,6 +27,10 @@ const (
 	PermanentDeleteWarnContent = "This operation cannot be undone and your data will be completely lost."
 	SaveOverwriteWarnTitle     = "The selected save target already exists"
 	SaveOverwriteWarnContent   = "This operation will return an existing file path and may overwrite that file."
+	SaveDirErrorTitle          = "Cannot save to a directory"
+	SaveDirErrorContent        = "Please choose a file name instead of a directory."
+	SaveAccessErrorTitle       = "Cannot access target path"
+	SaveInitErrorTitle         = "Cannot open save target directory"
 )
 
 const (

--- a/src/internal/common/style.go
+++ b/src/internal/common/style.go
@@ -36,6 +36,7 @@ var (
 	FilePanelTopDirectoryIconStyle lipgloss.Style
 	FilePanelTopPathStyle          lipgloss.Style
 	FilePanelItemSelectedStyle     lipgloss.Style
+	FilePanelSaveTargetStyle       lipgloss.Style
 	FilePanelSelectBoxStyle        lipgloss.Style
 )
 
@@ -192,6 +193,7 @@ func LoadThemeConfig() { //nolint: funlen // Variable initialization
 	FilePanelTopPathStyle = lipgloss.NewStyle().Foreground(filePanelTopPathColor).Background(FilePanelBGColor)
 	FilePanelItemSelectedStyle = lipgloss.NewStyle().Foreground(filePanelItemSelectedFGColor).
 		Background(filePanelItemSelectedBGColor)
+	FilePanelSaveTargetStyle = lipgloss.NewStyle().Foreground(cursorColor).Background(FilePanelBGColor)
 	FilePanelSelectBoxStyle = lipgloss.NewStyle().Background(FilePanelBGColor)
 
 	// Sidebar Special Style

--- a/src/internal/default_config.go
+++ b/src/internal/default_config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yorukot/superfile/src/internal/ui/processbar"
 	"github.com/yorukot/superfile/src/internal/ui/sidebar"
 
+	variable "github.com/yorukot/superfile/src/config"
 	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/ui/prompt"
 	zoxideui "github.com/yorukot/superfile/src/internal/ui/zoxide"
@@ -28,7 +29,7 @@ import (
 //     to prevent noise in test logs. Same with imagePreviewer
 func defaultModelConfig(toggleDotFile, toggleFooter, firstUse bool,
 	firstPanelPaths []string, zClient *zoxidelib.Client) *model {
-	return &model{
+	m := &model{
 		focusPanel:      nonePanelFocus,
 		processBarModel: processbar.New(),
 		sidebarModel:    sidebar.New(),
@@ -43,5 +44,10 @@ func defaultModelConfig(toggleDotFile, toggleFooter, firstUse bool,
 		toggleFooter:    toggleFooter,
 		firstUse:        firstUse,
 		hasTrash:        common.InitTrash(),
+		chooser: chooserState{
+			request: variable.GetChooserRequest(),
+		},
 	}
+	m.initializeChooserState()
+	return m
 }

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	variable "github.com/yorukot/superfile/src/config"
 	"github.com/yorukot/superfile/src/internal/ui/filepanel"
 	"github.com/yorukot/superfile/src/pkg/utils"
 
@@ -27,6 +26,10 @@ import (
 // TODO: Fix it. It doesn't creates a new file. It just opens a file model,
 // that allows you to create a file. Actual creation happens here - createItem() in handle_modal.go
 func (m *model) panelCreateNewFile() {
+	if m.isSaveChooserMode() {
+		return
+	}
+
 	panel := m.getFocusedFilePanel()
 
 	m.typingModal.location = panel.Location
@@ -43,6 +46,11 @@ func (m *model) IsRenamingConflicting() bool {
 		slog.Error("IsRenamingConflicting() being called on empty panel")
 		return false
 	}
+
+	if m.isSaveChooserMode() {
+		return false
+	}
+
 	oldPath := panel.GetFocusedItem().Location
 	newPath := filepath.Join(panel.Location, panel.Rename.Value())
 
@@ -78,17 +86,9 @@ func (m *model) panelItemRename() {
 		return
 	}
 
-	cursorPos := -1
-	nameRunes := []rune(panel.GetFocusedItem().Name)
-	nameLen := len(nameRunes)
-	for i := nameLen - 1; i >= 0; i-- {
-		if nameRunes[i] == '.' {
-			cursorPos = i
-			break
-		}
-	}
-	if cursorPos == -1 || cursorPos == 0 && nameLen > 0 || panel.GetFocusedItem().Directory {
-		cursorPos = nameLen
+	focused := panel.GetFocusedItem()
+	if m.isSaveChooserMode() && !focused.SaveTarget {
+		return
 	}
 
 	m.fileModel.Renaming = true
@@ -99,11 +99,15 @@ func (m *model) panelItemRename() {
 	// Maintain its state, dimensions. Update its cursor and text when needed
 	panel.Rename = common.GenerateRenameTextInput(
 		m.fileModel.SinglePanelWidth-common.InnerPadding,
-		cursorPos,
-		panel.GetFocusedItem().Name)
+		getRenameCursorPos(focused.Name, focused.Directory),
+		focused.Name)
 }
 
 func (m *model) getDeleteCmd(permDelete bool) tea.Cmd {
+	if m.isSaveChooserMode() {
+		return nil
+	}
+
 	panel := m.getFocusedFilePanel()
 	if panel.Empty() {
 		return nil
@@ -165,6 +169,10 @@ func deleteOperation(processBarModel *processbar.Model, items []string, useTrash
 }
 
 func (m *model) getDeleteTriggerCmd(deletePermanent bool) tea.Cmd {
+	if m.isSaveChooserMode() {
+		return nil
+	}
+
 	panel := m.getFocusedFilePanel()
 	if (panel.PanelMode == filepanel.SelectMode && panel.SelectedCount() == 0) ||
 		(panel.PanelMode == filepanel.BrowserMode && panel.Empty()) {
@@ -191,6 +199,10 @@ func (m *model) getDeleteTriggerCmd(deletePermanent bool) tea.Cmd {
 // Copy directory or file's path to superfile's clipboard
 // set cut to true/false accordingly
 func (m *model) copySingleItem(cut bool) {
+	if m.isSaveChooserMode() {
+		return
+	}
+
 	panel := m.getFocusedFilePanel()
 	m.clipboard.Reset(cut)
 	if panel.Empty() {
@@ -203,6 +215,10 @@ func (m *model) copySingleItem(cut bool) {
 
 // Copy all selected file or directory's paths to the clipboard
 func (m *model) copyMultipleItem(cut bool) {
+	if m.isSaveChooserMode() {
+		return
+	}
+
 	panel := m.getFocusedFilePanel()
 	m.clipboard.Reset(cut)
 	if panel.SelectedCount() == 0 {
@@ -214,6 +230,10 @@ func (m *model) copyMultipleItem(cut bool) {
 }
 
 func (m *model) getPasteItemCmd() tea.Cmd {
+	if m.isSaveChooserMode() {
+		return nil
+	}
+
 	copyItems := m.clipboard.PruneInaccessibleItemsAndGet()
 	cut := m.clipboard.IsCut()
 	if len(copyItems) == 0 {
@@ -428,13 +448,7 @@ func (m *model) getCompressSelectedFilesCmd() tea.Cmd {
 }
 
 func (m *model) chooserFileWriteAndQuit(path string) error {
-	// Attempt to write to the file
-	err := os.WriteFile(variable.ChooserFile, []byte(path), utils.ConfigFilePerm)
-	if err != nil {
-		return err
-	}
-	m.modelQuitState = quitInitiated
-	return nil
+	return m.chooserWriteAndQuit([]string{path})
 }
 
 // Open file with default editor
@@ -445,13 +459,16 @@ func (m *model) openFileWithEditor() tea.Cmd {
 		return nil
 	}
 
-	if variable.ChooserFile != "" {
-		err := m.chooserFileWriteAndQuit(panel.GetFocusedItem().Location)
+	switch {
+	case m.isSaveChooserMode():
+		m.saveChooserConfirmFocusedItem()
+		return nil
+	case m.isOpenChooserMode():
+		err := m.openChooserWriteSelectionAndQuit()
 		if err == nil {
 			return nil
 		}
-		// Continue with preview if file is not writable
-		slog.Error("Error while writing to chooser file, continuing with open via file editor", "error", err)
+		slog.Error("Error while writing chooser output, continuing with open via file editor", "error", err)
 	}
 
 	editor := common.Config.Editor
@@ -484,13 +501,16 @@ func (m *model) openFileWithEditor() tea.Cmd {
 
 // Open directory with default editor
 func (m *model) openDirectoryWithEditor() tea.Cmd {
-	if variable.ChooserFile != "" {
+	switch {
+	case m.isSaveChooserMode():
+		m.saveChooserConfirmCurrentDirectory()
+		return nil
+	case m.isOpenChooserMode():
 		err := m.chooserFileWriteAndQuit(m.getFocusedFilePanel().Location)
 		if err == nil {
 			return nil
 		}
-		// Continue with preview if file is not writable
-		slog.Error("Error while writing to chooser file, continuing with open via directory editor", "error", err)
+		slog.Error("Error while writing chooser output, continuing with open via directory editor", "error", err)
 	}
 
 	editor := common.Config.DirEditor
@@ -521,6 +541,10 @@ func (m *model) openDirectoryWithEditor() tea.Cmd {
 // Copy file path
 // TODO: This is also an IO operations, do it via tea.Cmd
 func (m *model) copyPath() {
+	if m.isSaveChooserMode() {
+		return
+	}
+
 	panel := m.getFocusedFilePanel()
 
 	if panel.Empty() {
@@ -534,8 +558,28 @@ func (m *model) copyPath() {
 
 // TODO: This is also an IO operations, do it via tea.Cmd
 func (m *model) copyPWD() {
+	if m.isSaveChooserMode() {
+		return
+	}
+
 	panel := m.getFocusedFilePanel()
 	if err := clipboard.WriteAll(panel.Location); err != nil {
 		slog.Error("Error while copy present working directory", "error", err)
 	}
+}
+
+func getRenameCursorPos(name string, isDirectory bool) int {
+	cursorPos := -1
+	nameRunes := []rune(name)
+	nameLen := len(nameRunes)
+	for i := nameLen - 1; i >= 0; i-- {
+		if nameRunes[i] == '.' {
+			cursorPos = i
+			break
+		}
+	}
+	if cursorPos == -1 || cursorPos == 0 && nameLen > 0 || isDirectory {
+		cursorPos = nameLen
+	}
+	return cursorPos
 }

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -578,7 +578,7 @@ func getRenameCursorPos(name string, isDirectory bool) int {
 			break
 		}
 	}
-	if cursorPos == -1 || cursorPos == 0 && nameLen > 0 || isDirectory {
+	if cursorPos <= 0 || isDirectory {
 		cursorPos = nameLen
 	}
 	return cursorPos

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -56,9 +56,7 @@ func (m *model) createItem() {
 // Cancel rename file or directory
 func (m *model) cancelRename() {
 	panel := m.getFocusedFilePanel()
-	panel.Rename.Blur()
-	panel.Renaming = false
-	m.fileModel.Renaming = false
+	m.clearRenamingState(panel)
 }
 
 // Connfirm rename file or directory
@@ -74,9 +72,7 @@ func (m *model) confirmRename() {
 
 	if m.isSaveChooserMode() {
 		panel.SetSaveEntryName(panel.Rename.Value())
-		m.fileModel.Renaming = false
-		panel.Rename.Blur()
-		panel.Renaming = false
+		m.clearRenamingState(panel)
 		return
 	}
 
@@ -89,9 +85,7 @@ func (m *model) confirmRename() {
 		slog.Error("Error while confirmRename during rename", "error", err)
 		// Dont return. We have to also reset the panel and model information
 	}
-	m.fileModel.Renaming = false
-	panel.Rename.Blur()
-	panel.Renaming = false
+	m.clearRenamingState(panel)
 }
 
 func (m *model) confirmSortOptions() {
@@ -115,4 +109,10 @@ func (m *model) confirmSearch() {
 
 func (m *model) getFocusedFilePanel() *filepanel.Model {
 	return m.fileModel.GetFocusedFilePanel()
+}
+
+func (m *model) clearRenamingState(panel *filepanel.Model) {
+	m.fileModel.Renaming = false
+	panel.Rename.Blur()
+	panel.Renaming = false
 }

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -72,6 +72,14 @@ func (m *model) confirmRename() {
 		return
 	}
 
+	if m.isSaveChooserMode() {
+		panel.SetSaveEntryName(panel.Rename.Value())
+		m.fileModel.Renaming = false
+		panel.Rename.Blur()
+		panel.Renaming = false
+		return
+	}
+
 	oldPath := panel.GetFocusedItem().Location
 	newPath := filepath.Join(panel.Location, panel.Rename.Value())
 

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -56,13 +56,17 @@ func (m *model) enterPanel() {
 		return
 	}
 
-	if variable.ChooserFile != "" {
+	if m.isSaveChooserMode() {
+		return
+	}
+
+	if m.isOpenChooserMode() {
 		chooserErr := m.chooserFileWriteAndQuit(panel.GetFocusedItem().Location)
 		if chooserErr == nil {
 			return
 		}
 		// Continue with preview if file is not writable
-		slog.Error("Error while writing to chooser file, continuing with file open", "error", chooserErr)
+		slog.Error("Error while writing chooser output, continuing with file open", "error", chooserErr)
 	}
 	m.executeOpenCommand()
 }

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -23,6 +23,10 @@ import (
 // updates and fixes in key handling code
 func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocognit,gocyclo,cyclop,funlen // See above
 	switch {
+	case m.isSaveChooserMode() && slices.Contains(common.Hotkeys.SaveChooserFocusTarget, msg):
+		if m.focusPanel == nonePanelFocus {
+			m.getFocusedFilePanel().FocusSaveEntry()
+		}
 	// If move up Key is pressed, check the current state and executes
 	case slices.Contains(common.Hotkeys.ListUp, msg):
 		switch m.focusPanel {

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -56,31 +56,49 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen //
 		m.getFocusedFilePanel().PgDown()
 
 	case slices.Contains(common.Hotkeys.ChangePanelMode, msg):
+		if m.isSaveChooserMode() {
+			return nil
+		}
 		m.getFocusedFilePanel().ChangeFilePanelMode()
 
 	case slices.Contains(common.Hotkeys.NextFilePanel, msg):
+		if m.isSaveChooserMode() {
+			return nil
+		}
 		if m.focusPanel == nonePanelFocus {
 			m.fileModel.NextFilePanel()
 		}
 
 	case slices.Contains(common.Hotkeys.PreviousFilePanel, msg):
+		if m.isSaveChooserMode() {
+			return nil
+		}
 		if m.focusPanel == nonePanelFocus {
 			m.fileModel.PreviousFilePanel()
 		}
 
 	case slices.Contains(common.Hotkeys.CloseFilePanel, msg):
+		if m.isSaveChooserMode() {
+			return nil
+		}
 		cmd, err := m.fileModel.CloseFilePanel()
 		if err != nil && !errors.Is(err, filemodel.ErrMinimumPanelCount) {
 			slog.Error("unexpected error while closing new panel", "error", err)
 		}
 		return cmd
 	case slices.Contains(common.Hotkeys.CreateNewFilePanel, msg):
+		if m.isSaveChooserMode() {
+			return nil
+		}
 		cmd, err := m.fileModel.CreateNewFilePanel(variable.HomeDir)
 		if err != nil && !errors.Is(err, filemodel.ErrMaximumPanelCount) {
 			slog.Error("unexpected error while creating new panel", "error", err)
 		}
 		return cmd
 	case slices.Contains(common.Hotkeys.SplitFilePanel, msg):
+		if m.isSaveChooserMode() {
+			return nil
+		}
 		cmd, err := m.splitPanel()
 		if err != nil && !errors.Is(err, filemodel.ErrMaximumPanelCount) {
 			slog.Error("unexpected error while splitting panel", "error", err)
@@ -119,8 +137,14 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen //
 		return m.getCompressSelectedFilesCmd()
 
 	case slices.Contains(common.Hotkeys.OpenCommandLine, msg):
+		if m.isSaveChooserMode() {
+			return nil
+		}
 		m.promptModal.Open(true)
 	case slices.Contains(common.Hotkeys.OpenSPFPrompt, msg):
+		if m.isSaveChooserMode() {
+			return nil
+		}
 		m.promptModal.Open(false)
 	case slices.Contains(common.Hotkeys.OpenZoxide, msg):
 		return m.zoxideModal.Open()
@@ -242,6 +266,8 @@ func (m *model) handleNotifyModelCancel(action notify.ConfirmActionType) tea.Cmd
 		m.cancelRename()
 	case notify.QuitAction:
 		m.modelQuitState = notQuitting
+	case notify.SaveOverwriteAction:
+		m.cancelSaveOverwrite()
 	case notify.DeleteAction, notify.NoAction, notify.PermanentDeleteAction:
 		// Do nothing
 	default:
@@ -260,6 +286,8 @@ func (m *model) handleNotifyModelConfirm(action notify.ConfirmActionType) tea.Cm
 		m.confirmRename()
 	case notify.QuitAction:
 		m.modelQuitState = quitConfirmationReceived
+	case notify.SaveOverwriteAction:
+		m.confirmSaveOverwrite()
 	case notify.NoAction:
 		// Ignore
 	default:

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -21,7 +21,7 @@ import (
 // check the state of model m and handle properly.
 // TODO: This function has grown too big. It needs to be fixed, via major
 // updates and fixes in key handling code
-func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen // See above
+func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocognit,gocyclo,cyclop,funlen // See above
 	switch {
 	// If move up Key is pressed, check the current state and executes
 	case slices.Contains(common.Hotkeys.ListUp, msg):

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -147,6 +147,10 @@ func (m *model) getMetadataCmd() tea.Cmd {
 		return nil
 	}
 	selectedItem := m.getFocusedFilePanel().GetFocusedItem()
+	if selectedItem.SaveTarget {
+		m.fileMetaData.SetBlank()
+		return nil
+	}
 	metadataFocused := m.focusPanel == metadataFocus
 	// Note : This will cause metadata not being refreshed there is any file update events.
 	// We can have a cache with TTL or watch filesystem changes to fix this

--- a/src/internal/model_test.go
+++ b/src/internal/model_test.go
@@ -435,7 +435,14 @@ func TestSaveChooserPortalPlaceholderDoesNotTriggerOverwrite(t *testing.T) {
 	saveOutput := filepath.Join(curTestDir, "save_output.txt")
 
 	utils.SetupDirectories(t, curTestDir, dir1)
-	require.NoError(t, os.WriteFile(placeholderFile, []byte("* xdg-desktop-portal-termfilechooser instructions *\nplaceholder"), 0o644))
+	require.NoError(
+		t,
+		os.WriteFile(
+			placeholderFile,
+			[]byte("* xdg-desktop-portal-termfilechooser instructions *\nplaceholder"),
+			0o644,
+		),
+	)
 
 	variable.SetChooserRequest(variable.ChooserRequest{
 		Mode:          variable.ChooserModeSave,

--- a/src/internal/model_test.go
+++ b/src/internal/model_test.go
@@ -260,15 +260,25 @@ func TestChooserFile(t *testing.T) {
 		},
 	}
 
-	// Must be sequential as we are using global variable chooserfile
+	// Must be sequential as we are using global chooser request state.
 	for _, tt := range testdata {
 		t.Run(tt.name, func(t *testing.T) {
+			req := variable.ChooserRequest{}
+			if tt.chooserFile != "" {
+				req = variable.ChooserRequest{
+					Mode:       variable.ChooserModeOpen,
+					OutputFile: tt.chooserFile,
+				}
+			}
+			variable.SetChooserRequest(req)
+			t.Cleanup(func() {
+				variable.SetChooserRequest(variable.ChooserRequest{})
+			})
 			m := defaultTestModel(dir1)
 			if tt.expectedQuit {
 				err := os.WriteFile(tt.chooserFile, []byte{}, 0o644)
 				require.NoError(t, err)
 			}
-			variable.SetChooserFile(tt.chooserFile)
 			cmd := TeaUpdate(m, utils.TeaRuneKeyMsg(tt.hotkey))
 
 			if tt.expectedQuit {
@@ -284,6 +294,170 @@ func TestChooserFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChooserFileMultiSelectWritesSelectionOrder(t *testing.T) {
+	curTestDir := filepath.Join(testDir, "TestChooserFileMultiSelectWritesSelectionOrder")
+	dir1 := filepath.Join(curTestDir, "dir1")
+	dir2 := filepath.Join(curTestDir, "dir2")
+	file1 := filepath.Join(dir1, "file1.txt")
+	file2 := filepath.Join(dir1, "file2.txt")
+	chooserOutput := filepath.Join(dir2, "chooser_file.txt")
+
+	utils.SetupDirectories(t, curTestDir, dir1, dir2)
+	utils.SetupFiles(t, file1, file2)
+
+	variable.SetChooserRequest(variable.ChooserRequest{
+		Mode:       variable.ChooserModeOpen,
+		OutputFile: chooserOutput,
+	})
+	t.Cleanup(func() {
+		variable.SetChooserRequest(variable.ChooserRequest{})
+	})
+
+	m := defaultTestModel(dir1)
+	panel := m.getFocusedFilePanel()
+	panel.ChangeFilePanelMode()
+	panel.SetSelected(file2)
+	panel.SetSelected(file1)
+
+	cmd := TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenFileWithEditor[0]))
+
+	assert.Equal(t, quitDone, m.modelQuitState)
+	assert.True(t, IsTeaQuit(cmd))
+
+	data, err := os.ReadFile(chooserOutput)
+	require.NoError(t, err)
+	assert.Equal(t, file2+"\n"+file1, string(data))
+}
+
+func TestSaveChooserInitializesGhostFromSuggestedPath(t *testing.T) {
+	curTestDir := filepath.Join(testDir, "TestSaveChooserInitializesGhostFromSuggestedPath")
+	dir1 := filepath.Join(curTestDir, "dir1")
+	utils.SetupDirectories(t, curTestDir, dir1)
+
+	saveOutput := filepath.Join(curTestDir, "save_output.txt")
+	suggestedPath := filepath.Join(dir1, "download.txt")
+
+	variable.SetChooserRequest(variable.ChooserRequest{
+		Mode:          variable.ChooserModeSave,
+		OutputFile:    saveOutput,
+		SuggestedPath: suggestedPath,
+	})
+	t.Cleanup(func() {
+		variable.SetChooserRequest(variable.ChooserRequest{})
+	})
+
+	m := defaultTestModel(curTestDir)
+	TeaUpdate(m, nil)
+
+	panel := m.getFocusedFilePanel()
+	require.True(t, panel.SaveMode)
+	assert.Equal(t, dir1, panel.Location)
+	assert.Equal(t, "download.txt", panel.GetSaveEntryName())
+	assert.True(t, panel.GetFocusedItem().SaveTarget)
+	assert.Equal(t, suggestedPath, panel.GetFocusedItem().Location)
+}
+
+func TestSaveChooserConfirmCurrentDirectoryWritesGhostPath(t *testing.T) {
+	curTestDir := filepath.Join(testDir, "TestSaveChooserConfirmCurrentDirectoryWritesGhostPath")
+	dir1 := filepath.Join(curTestDir, "dir1")
+	utils.SetupDirectories(t, curTestDir, dir1)
+
+	saveOutput := filepath.Join(curTestDir, "save_output.txt")
+	suggestedPath := filepath.Join(dir1, "download.txt")
+
+	variable.SetChooserRequest(variable.ChooserRequest{
+		Mode:          variable.ChooserModeSave,
+		OutputFile:    saveOutput,
+		SuggestedPath: suggestedPath,
+	})
+	t.Cleanup(func() {
+		variable.SetChooserRequest(variable.ChooserRequest{})
+	})
+
+	m := defaultTestModel(curTestDir)
+	TeaUpdate(m, nil)
+
+	cmd := TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenCurrentDirectoryWithEditor[0]))
+
+	assert.Equal(t, quitDone, m.modelQuitState)
+	assert.True(t, IsTeaQuit(cmd))
+
+	data, err := os.ReadFile(saveOutput)
+	require.NoError(t, err)
+	assert.Equal(t, suggestedPath, string(data))
+	assert.FileExists(t, suggestedPath)
+}
+
+func TestSaveChooserOverwriteRequiresConfirmation(t *testing.T) {
+	curTestDir := filepath.Join(testDir, "TestSaveChooserOverwriteRequiresConfirmation")
+	dir1 := filepath.Join(curTestDir, "dir1")
+	existingFile := filepath.Join(dir1, "file1.txt")
+	saveOutput := filepath.Join(curTestDir, "save_output.txt")
+
+	utils.SetupDirectories(t, curTestDir, dir1)
+	utils.SetupFiles(t, existingFile)
+
+	variable.SetChooserRequest(variable.ChooserRequest{
+		Mode:          variable.ChooserModeSave,
+		OutputFile:    saveOutput,
+		SuggestedPath: existingFile,
+	})
+	t.Cleanup(func() {
+		variable.SetChooserRequest(variable.ChooserRequest{})
+	})
+
+	m := defaultTestModel(curTestDir)
+	TeaUpdate(m, nil)
+
+	cmd := TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenCurrentDirectoryWithEditor[0]))
+
+	assert.Equal(t, notQuitting, m.modelQuitState)
+	assert.False(t, IsTeaQuit(cmd))
+	assert.True(t, m.notifyModel.IsOpen())
+	assert.Equal(t, existingFile, m.chooser.overwritePath)
+
+	cmd = TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.ConfirmTyping[0]))
+
+	assert.Equal(t, quitDone, m.modelQuitState)
+	assert.True(t, IsTeaQuit(cmd))
+
+	data, err := os.ReadFile(saveOutput)
+	require.NoError(t, err)
+	assert.Equal(t, existingFile, string(data))
+}
+
+func TestSaveChooserPortalPlaceholderDoesNotTriggerOverwrite(t *testing.T) {
+	curTestDir := filepath.Join(testDir, "TestSaveChooserPortalPlaceholderDoesNotTriggerOverwrite")
+	dir1 := filepath.Join(curTestDir, "dir1")
+	placeholderFile := filepath.Join(dir1, "download.txt")
+	saveOutput := filepath.Join(curTestDir, "save_output.txt")
+
+	utils.SetupDirectories(t, curTestDir, dir1)
+	require.NoError(t, os.WriteFile(placeholderFile, []byte("* xdg-desktop-portal-termfilechooser instructions *\nplaceholder"), 0o644))
+
+	variable.SetChooserRequest(variable.ChooserRequest{
+		Mode:          variable.ChooserModeSave,
+		OutputFile:    saveOutput,
+		SuggestedPath: placeholderFile,
+	})
+	t.Cleanup(func() {
+		variable.SetChooserRequest(variable.ChooserRequest{})
+	})
+
+	m := defaultTestModel(curTestDir)
+	TeaUpdate(m, nil)
+
+	cmd := TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.OpenCurrentDirectoryWithEditor[0]))
+
+	assert.Equal(t, quitDone, m.modelQuitState)
+	assert.True(t, IsTeaQuit(cmd))
+	assert.False(t, m.notifyModel.IsOpen())
+
+	data, err := os.ReadFile(saveOutput)
+	require.NoError(t, err)
+	assert.Equal(t, placeholderFile, string(data))
 }
 
 func eventuallyEnsurePreviewContent(t *testing.T, m *model, content string, msgAndArgs ...any) {

--- a/src/internal/model_test.go
+++ b/src/internal/model_test.go
@@ -467,6 +467,40 @@ func TestSaveChooserPortalPlaceholderDoesNotTriggerOverwrite(t *testing.T) {
 	assert.Equal(t, placeholderFile, string(data))
 }
 
+func TestSaveChooserFocusTargetHotkeyMovesCursorToGhost(t *testing.T) {
+	curTestDir := filepath.Join(testDir, "TestSaveChooserFocusTargetHotkeyMovesCursorToGhost")
+	dir1 := filepath.Join(curTestDir, "dir1")
+	file1 := filepath.Join(dir1, "file1.txt")
+	file2 := filepath.Join(dir1, "file2.txt")
+	saveOutput := filepath.Join(curTestDir, "save_output.txt")
+	suggestedPath := filepath.Join(dir1, "download.txt")
+
+	utils.SetupDirectories(t, curTestDir, dir1)
+	utils.SetupFiles(t, file1, file2)
+
+	variable.SetChooserRequest(variable.ChooserRequest{
+		Mode:          variable.ChooserModeSave,
+		OutputFile:    saveOutput,
+		SuggestedPath: suggestedPath,
+	})
+	t.Cleanup(func() {
+		variable.SetChooserRequest(variable.ChooserRequest{})
+	})
+
+	m := defaultTestModel(curTestDir)
+	TeaUpdate(m, nil)
+
+	panel := m.getFocusedFilePanel()
+	panel.ListDown()
+	require.False(t, panel.GetFocusedItem().SaveTarget)
+
+	TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.SaveChooserFocusTarget[2]))
+
+	assert.True(t, panel.GetFocusedItem().SaveTarget)
+	assert.Equal(t, 0, panel.GetCursor())
+	assert.Equal(t, suggestedPath, panel.GetFocusedItem().Location)
+}
+
 func eventuallyEnsurePreviewContent(t *testing.T, m *model, content string, msgAndArgs ...any) {
 	contains := false
 	assert.Eventually(t, func() bool {

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/yorukot/superfile/src/internal/ui/prompt"
 	zoxideui "github.com/yorukot/superfile/src/internal/ui/zoxide"
+
+	variable "github.com/yorukot/superfile/src/config"
 )
 
 // Type representing the type of focused panel
@@ -54,6 +56,7 @@ type model struct {
 	processBarModel processbar.Model
 	clipboard       clipboard.Model
 	focusPanel      focusPanelType
+	chooser         chooserState
 
 	// Modals
 	notifyModel notify.Model
@@ -96,6 +99,11 @@ type typingModal struct {
 	open          bool
 	textInput     textinput.Model
 	errorMesssage string
+}
+
+type chooserState struct {
+	request       variable.ChooserRequest
+	overwritePath string
 }
 
 type editorFinishedMsg struct{ err error }

--- a/src/internal/ui/filemodel/update.go
+++ b/src/internal/ui/filemodel/update.go
@@ -92,6 +92,10 @@ func (m *Model) GetFilePreviewCmd(forcePreviewRender bool) tea.Cmd {
 		return nil
 	}
 	selectedItem := panel.GetFocusedItem()
+	if selectedItem.SaveTarget {
+		m.FilePreview.SetEmptyWithDimensions(m.ExpectedPreviewWidth, m.Height)
+		return nil
+	}
 	if m.FilePreview.GetLocation() == selectedItem.Location && !forcePreviewRender {
 		return nil
 	}

--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -99,7 +99,11 @@ func (m *Model) renderElementName(elem Element, width int, isSelected bool) stri
 			displayName = "[save target]"
 		}
 		label := "save " + displayName
-		return common.FilePanelItemRender(label, width, isSelected, common.FilePanelBGColor, lipgloss.Left)
+		if common.Config.Nerdfont {
+			label = icon.Download + icon.Space + displayName
+		}
+		return common.FilePanelSaveTargetStyle.Width(width).Align(lipgloss.Left).
+			Render(ansi.Truncate(label, width, "..."))
 	}
 
 	isLink := false

--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -44,7 +44,7 @@ func (m *Model) renderDelimiter(indexElement int, columnWidth int) string {
 func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
-	if elem.SaveTarget {
+	if elem.SaveTarget || elem.Info == nil {
 		return common.FilePanelItemRender("", columnWidth, isSelected, common.FilePanelBGColor, lipgloss.Right)
 	}
 	sizeValue := common.FormatFileSize(elem.Info.Size())
@@ -64,7 +64,7 @@ func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 func (m *Model) renderModifyTime(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
-	if elem.SaveTarget {
+	if elem.SaveTarget || elem.Info == nil {
 		return common.FilePanelItemRender("", columnWidth, isSelected, common.FilePanelBGColor, lipgloss.Right)
 	}
 	modifyTime := elem.Info.ModTime().Format("2006-01-02 15:04")
@@ -80,7 +80,7 @@ func (m *Model) renderModifyTime(indexElement int, columnWidth int) string {
 func (m *Model) renderPermissions(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
-	if elem.SaveTarget {
+	if elem.SaveTarget || elem.Info == nil {
 		return common.FilePanelItemRender("", columnWidth, isSelected, common.FilePanelBGColor, lipgloss.Right)
 	}
 	return common.FilePanelItemRender(
@@ -102,9 +102,17 @@ func (m *Model) renderElementName(elem Element, width int, isSelected bool) stri
 		return common.FilePanelItemRender(label, width, isSelected, common.FilePanelBGColor, lipgloss.Left)
 	}
 
-	isLink := elem.Info.Mode()&os.ModeSymlink != 0
+	isLink := false
+	if elem.Info != nil {
+		isLink = elem.Info.Mode()&os.ModeSymlink != 0
+	}
+
+	displayName := elem.Name
+	if displayName == "" {
+		displayName = "[unknown]"
+	}
 	return common.FilePanelItemRenderWithIcon(
-		elem.Name,
+		displayName,
 		width,
 		elem.Directory,
 		isLink,

--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -25,15 +25,7 @@ func (m *Model) renderFileName(indexElement int, columnWidth int) string {
 	// Calculate the actual prefix width for proper alignment
 	prefixWidth := ansi.StringWidth(cursor+" ") + ansi.StringWidth(selectBox)
 
-	isLink := elem.Info.Mode()&os.ModeSymlink != 0
-	renderedName := common.FilePanelItemRenderWithIcon(
-		elem.Name,
-		columnWidth-prefixWidth,
-		elem.Directory,
-		isLink,
-		isSelected,
-		common.FilePanelBGColor,
-	)
+	renderedName := m.renderElementName(elem, columnWidth-prefixWidth, isSelected)
 	return common.FilePanelCursorStyle.Render(cursor+" ") + selectBox + renderedName
 }
 
@@ -52,6 +44,9 @@ func (m *Model) renderDelimiter(indexElement int, columnWidth int) string {
 func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
+	if elem.SaveTarget {
+		return common.FilePanelItemRender("", columnWidth, isSelected, common.FilePanelBGColor, lipgloss.Right)
+	}
 	sizeValue := common.FormatFileSize(elem.Info.Size())
 	if elem.Info.IsDir() {
 		sizeValue = ""
@@ -69,6 +64,9 @@ func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 func (m *Model) renderModifyTime(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
+	if elem.SaveTarget {
+		return common.FilePanelItemRender("", columnWidth, isSelected, common.FilePanelBGColor, lipgloss.Right)
+	}
 	modifyTime := elem.Info.ModTime().Format("2006-01-02 15:04")
 	return common.FilePanelItemRender(
 		modifyTime,
@@ -82,12 +80,36 @@ func (m *Model) renderModifyTime(indexElement int, columnWidth int) string {
 func (m *Model) renderPermissions(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
+	if elem.SaveTarget {
+		return common.FilePanelItemRender("", columnWidth, isSelected, common.FilePanelBGColor, lipgloss.Right)
+	}
 	return common.FilePanelItemRender(
 		elem.Info.Mode().Perm().String(),
 		columnWidth,
 		isSelected,
 		common.FilePanelBGColor,
 		lipgloss.Right,
+	)
+}
+
+func (m *Model) renderElementName(elem Element, width int, isSelected bool) string {
+	if elem.SaveTarget {
+		displayName := elem.Name
+		if displayName == "" {
+			displayName = "[save target]"
+		}
+		label := "save " + displayName
+		return common.FilePanelItemRender(label, width, isSelected, common.FilePanelBGColor, lipgloss.Left)
+	}
+
+	isLink := elem.Info.Mode()&os.ModeSymlink != 0
+	return common.FilePanelItemRenderWithIcon(
+		elem.Name,
+		width,
+		elem.Directory,
+		isLink,
+		isSelected,
+		common.FilePanelBGColor,
 	)
 }
 

--- a/src/internal/ui/filepanel/get_elements.go
+++ b/src/internal/ui/filepanel/get_elements.go
@@ -108,8 +108,23 @@ func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) {
 
 // Retrieves elements for a panel based on search bar value and sort options.
 func (m *Model) getElements(displayDotFile bool) []Element {
+	var elements []Element
 	if m.SearchBar.Value() != "" {
-		return m.getDirectoryElementsBySearch(displayDotFile)
+		elements = m.getDirectoryElementsBySearch(displayDotFile)
+	} else {
+		elements = m.getDirectoryElements(displayDotFile)
 	}
-	return m.getDirectoryElements(displayDotFile)
+	if m.SaveMode {
+		elements = append([]Element{m.getSaveEntryElement()}, elements...)
+	}
+	return elements
+}
+
+func (m *Model) getSaveEntryElement() Element {
+	return Element{
+		Name:       m.SaveEntryName,
+		Location:   m.GetSaveEntryLocation(),
+		Directory:  false,
+		SaveTarget: true,
+	}
 }

--- a/src/internal/ui/filepanel/navigation.go
+++ b/src/internal/ui/filepanel/navigation.go
@@ -66,7 +66,13 @@ func (m *Model) ItemSelectDown() {
 
 // Applies targetFile cursor positioning, if configured for the panel.
 func (m *Model) applyTargetFileCursor() {
-	idx := m.FindElementIndexByName(m.TargetFile)
+	idx := -1
+	for i, elem := range m.element {
+		if elem.Name == m.TargetFile && !elem.SaveTarget {
+			idx = i
+			break
+		}
+	}
 	if idx != -1 {
 		m.scrollToCursor(idx)
 	}

--- a/src/internal/ui/filepanel/navigation.go
+++ b/src/internal/ui/filepanel/navigation.go
@@ -11,13 +11,14 @@ func (m *Model) scrollToCursor(cursor int) {
 	m.cursor = cursor
 
 	// Modify renderIndex if needed
-	renderCount := m.PanelElementHeight()
-	if m.cursor < m.renderIndex {
+	renderCount := m.visibleScrollableElementCount()
+	renderIndex := m.effectiveRenderIndex()
+	if m.cursor < renderIndex {
 		// Due to size change, when last element is selected, we might have
 		// empty space (renderIndex ... ElemCount()-1 spans less then renderCount)
 		// Even with >0 renderIndex
 		m.renderIndex = m.cursor
-	} else if m.cursor > m.renderIndex+renderCount-1 {
+	} else if m.cursor > renderIndex+renderCount-1 {
 		m.renderIndex = m.cursor - renderCount + 1
 	}
 }
@@ -83,10 +84,19 @@ func (m *Model) ValidateCursorAndRenderIndex() error {
 	if m.cursor < 0 || m.ElemCount() <= m.cursor {
 		return fmt.Errorf("invalid cursor : %d, element count : %d", m.cursor, m.ElemCount())
 	}
-	renderCount := m.PanelElementHeight()
-	if (m.cursor < m.renderIndex) || (m.cursor > m.renderIndex+renderCount-1) {
+
+	if m.SaveMode && m.ElemCount() > 1 && m.cursor == 0 {
+		if m.renderIndex < 0 || m.ElemCount() <= m.renderIndex {
+			return fmt.Errorf("invalid renderIndex : %d, element count : %d", m.renderIndex, m.ElemCount())
+		}
+		return nil
+	}
+
+	renderCount := m.visibleScrollableElementCount()
+	renderIndex := m.effectiveRenderIndex()
+	if (m.cursor < renderIndex) || (m.cursor > renderIndex+renderCount-1) {
 		return fmt.Errorf("invalid renderIndex : %d, cursor : %d, renderCount : %d",
-			m.renderIndex, m.cursor, renderCount)
+			renderIndex, m.cursor, renderCount)
 	}
 	return nil
 }

--- a/src/internal/ui/filepanel/navigation_test.go
+++ b/src/internal/ui/filepanel/navigation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yorukot/superfile/src/internal/common"
 )
@@ -327,6 +328,31 @@ func TestScrollToCursor(t *testing.T) {
 			assert.Equal(t, tt.expectedRender, tt.panel.GetRenderIndex())
 		})
 	}
+}
+
+func TestSaveModeScrollKeepsGhostPinned(t *testing.T) {
+	panel := testModel(0, 0, 12, BrowserMode, make([]Element, 20))
+	panel.SaveMode = true
+
+	panel.scrollToCursor(15)
+	assert.Equal(t, 15, panel.GetCursor())
+	assert.Equal(t, 10, panel.GetRenderIndex())
+
+	panel.scrollToCursor(0)
+	assert.Equal(t, 0, panel.GetCursor())
+	assert.Equal(t, 0, panel.GetRenderIndex())
+	require.NoError(t, panel.ValidateCursorAndRenderIndex())
+}
+
+func TestFocusSaveEntry(t *testing.T) {
+	panel := testModel(3, 2, 12, BrowserMode, make([]Element, 5))
+	panel.SaveMode = true
+
+	panel.FocusSaveEntry()
+
+	assert.Equal(t, 0, panel.GetCursor())
+	assert.Equal(t, 0, panel.GetRenderIndex())
+	require.NoError(t, panel.ValidateCursorAndRenderIndex())
 }
 
 func TestApplyTargetFileCursor(t *testing.T) {

--- a/src/internal/ui/filepanel/render.go
+++ b/src/internal/ui/filepanel/render.go
@@ -115,9 +115,9 @@ func (m *Model) getPanelModeInfo(selectedCount uint) (string, string) {
 			return "Save", icon.Select
 		}
 		if m.PanelMode == SelectMode && selectedCount > 0 {
-			return fmt.Sprintf("(%d)", selectedCount), icon.Download
+			return "Save" + icon.Space + fmt.Sprintf("(%d)", selectedCount), icon.Download
 		}
-		return "", icon.Download
+		return "Save", icon.Download
 	}
 	switch m.PanelMode {
 	case BrowserMode:

--- a/src/internal/ui/filepanel/render.go
+++ b/src/internal/ui/filepanel/render.go
@@ -108,6 +108,9 @@ func (m *Model) getSortInfo() (string, string) {
 
 func (m *Model) getPanelModeInfo(selectedCount uint) (string, string) {
 	if m.SaveMode {
+		if m.PanelMode == SelectMode && selectedCount > 0 {
+			return "Save" + icon.Space + fmt.Sprintf("(%d)", selectedCount), icon.Select
+		}
 		return "Save", icon.Select
 	}
 	switch m.PanelMode {

--- a/src/internal/ui/filepanel/render.go
+++ b/src/internal/ui/filepanel/render.go
@@ -82,20 +82,39 @@ func (m *Model) renderFileEntries(r *rendering.Renderer) {
 		r.AddLines(common.FilePanelNoneText)
 		return
 	}
-	end := min(m.renderIndex+m.PanelElementHeight(), m.ElemCount())
 
-	for itemIndex := m.renderIndex; itemIndex < end; itemIndex++ {
-		if m.Renaming && itemIndex == m.GetCursor() {
-			r.AddLines(m.Rename.View())
-			continue
+	if m.SaveMode {
+		m.renderFileEntry(r, 0)
+		if m.ElemCount() == 1 {
+			return
 		}
-		var builder strings.Builder
-		for _, column := range m.columns {
-			colData := column.Render(itemIndex)
-			builder.WriteString(colData)
+
+		start := m.effectiveRenderIndex()
+		end := min(start+m.visibleScrollableElementCount(), m.ElemCount())
+		for itemIndex := start; itemIndex < end; itemIndex++ {
+			m.renderFileEntry(r, itemIndex)
 		}
-		r.AddLines(builder.String())
+		return
 	}
+
+	end := min(m.renderIndex+m.PanelElementHeight(), m.ElemCount())
+	for itemIndex := m.renderIndex; itemIndex < end; itemIndex++ {
+		m.renderFileEntry(r, itemIndex)
+	}
+}
+
+func (m *Model) renderFileEntry(r *rendering.Renderer, itemIndex int) {
+	if m.Renaming && itemIndex == m.GetCursor() {
+		r.AddLines(m.Rename.View())
+		return
+	}
+
+	var builder strings.Builder
+	for _, column := range m.columns {
+		colData := column.Render(itemIndex)
+		builder.WriteString(colData)
+	}
+	r.AddLines(builder.String())
 }
 
 func (m *Model) getSortInfo() (string, string) {

--- a/src/internal/ui/filepanel/render.go
+++ b/src/internal/ui/filepanel/render.go
@@ -107,6 +107,9 @@ func (m *Model) getSortInfo() (string, string) {
 }
 
 func (m *Model) getPanelModeInfo(selectedCount uint) (string, string) {
+	if m.SaveMode {
+		return "Save", icon.Select
+	}
 	switch m.PanelMode {
 	case BrowserMode:
 		return "Browser", icon.Browser

--- a/src/internal/ui/filepanel/render.go
+++ b/src/internal/ui/filepanel/render.go
@@ -51,8 +51,8 @@ func (m *Model) renderFooter(r *rendering.Renderer, selectedCount uint) {
 	cursorStr := m.getCursorString()
 
 	if common.Config.Nerdfont {
-		sortLabel = sortIcon + icon.Space + sortLabel
-		modeLabel = modeIcon + icon.Space + modeLabel
+		sortLabel = renderFooterInfoLabel(sortLabel, sortIcon)
+		modeLabel = renderFooterInfoLabel(modeLabel, modeIcon)
 	} else {
 		// TODO : Figure out if we can set icon.Space to " " if nerdfont is false
 		// That would simplify code
@@ -108,10 +108,16 @@ func (m *Model) getSortInfo() (string, string) {
 
 func (m *Model) getPanelModeInfo(selectedCount uint) (string, string) {
 	if m.SaveMode {
-		if m.PanelMode == SelectMode && selectedCount > 0 {
-			return "Save" + icon.Space + fmt.Sprintf("(%d)", selectedCount), icon.Select
+		if !common.Config.Nerdfont {
+			if m.PanelMode == SelectMode && selectedCount > 0 {
+				return "Save" + icon.Space + fmt.Sprintf("(%d)", selectedCount), icon.Select
+			}
+			return "Save", icon.Select
 		}
-		return "Save", icon.Select
+		if m.PanelMode == SelectMode && selectedCount > 0 {
+			return fmt.Sprintf("(%d)", selectedCount), icon.Download
+		}
+		return "", icon.Download
 	}
 	switch m.PanelMode {
 	case BrowserMode:
@@ -121,6 +127,13 @@ func (m *Model) getPanelModeInfo(selectedCount uint) (string, string) {
 	default:
 		return "", ""
 	}
+}
+
+func renderFooterInfoLabel(label string, iconValue string) string {
+	if label == "" {
+		return iconValue
+	}
+	return iconValue + icon.Space + label
 }
 
 func (m *Model) getCursorString() string {

--- a/src/internal/ui/filepanel/render_test.go
+++ b/src/internal/ui/filepanel/render_test.go
@@ -40,11 +40,11 @@ func TestGetPanelModeInfoForSaveModeUsesDownloadIcon(t *testing.T) {
 	panel.SaveMode = true
 
 	label, iconValue := panel.getPanelModeInfo(0)
-	assert.Equal(t, "", label)
+	assert.Equal(t, "Save", label)
 	assert.Equal(t, icon.Download, iconValue)
 
 	panel.PanelMode = SelectMode
 	label, iconValue = panel.getPanelModeInfo(2)
-	assert.Equal(t, "(2)", label)
+	assert.Equal(t, "Save (2)", label)
 	assert.Equal(t, icon.Download, iconValue)
 }

--- a/src/internal/ui/filepanel/render_test.go
+++ b/src/internal/ui/filepanel/render_test.go
@@ -1,0 +1,50 @@
+package filepanel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorukot/superfile/src/config/icon"
+	"github.com/yorukot/superfile/src/internal/common"
+)
+
+func TestRenderElementNameForSaveTargetUsesDownloadIcon(t *testing.T) {
+	previousNerdfont := common.Config.Nerdfont
+	common.Config.Nerdfont = true
+	t.Cleanup(func() {
+		common.Config.Nerdfont = previousNerdfont
+	})
+
+	panel := testModel(0, 0, 12, BrowserMode, nil)
+
+	rendered := panel.renderElementName(Element{
+		Name:       "download.txt",
+		Location:   "/tmp/download.txt",
+		SaveTarget: true,
+	}, 40, false)
+
+	assert.Contains(t, rendered, icon.Download)
+	assert.Contains(t, rendered, "download.txt")
+	assert.NotContains(t, rendered, "save download.txt")
+}
+
+func TestGetPanelModeInfoForSaveModeUsesDownloadIcon(t *testing.T) {
+	previousNerdfont := common.Config.Nerdfont
+	common.Config.Nerdfont = true
+	t.Cleanup(func() {
+		common.Config.Nerdfont = previousNerdfont
+	})
+
+	panel := testModel(0, 0, 12, BrowserMode, nil)
+	panel.SaveMode = true
+
+	label, iconValue := panel.getPanelModeInfo(0)
+	assert.Equal(t, "", label)
+	assert.Equal(t, icon.Download, iconValue)
+
+	panel.PanelMode = SelectMode
+	label, iconValue = panel.getPanelModeInfo(2)
+	assert.Equal(t, "(2)", label)
+	assert.Equal(t, icon.Download, iconValue)
+}

--- a/src/internal/ui/filepanel/selection_test.go
+++ b/src/internal/ui/filepanel/selection_test.go
@@ -53,3 +53,19 @@ func TestPanelSelectionLifeCycle(t *testing.T) {
 	assert.Equal(t, map[string]int{}, panel.selected)
 	assert.Equal(t, 0, panel.selectOrderCounter)
 }
+
+func TestGetOrderedSelectedLocations(t *testing.T) {
+	panel := testModel(0, 0, 0, BrowserMode, []Element{
+		{Name: "file1.txt", Location: "/tmp/file1.txt"},
+		{Name: "file2.txt", Location: "/tmp/file2.txt"},
+		{Name: "file3.txt", Location: "/tmp/file3.txt"},
+		{Name: "file4.txt", Location: "/tmp/file4.txt"},
+	})
+
+	panel.SetSelected("/tmp/file3.txt")
+	panel.SetSelected("/tmp/file1.txt")
+	panel.SetSelected("/tmp/file4.txt")
+	panel.SetUnSelected("/tmp/file1.txt")
+
+	assert.Equal(t, []string{"/tmp/file3.txt", "/tmp/file4.txt"}, panel.GetOrderedSelectedLocations())
+}

--- a/src/internal/ui/filepanel/types.go
+++ b/src/internal/ui/filepanel/types.go
@@ -40,6 +40,8 @@ type Model struct {
 	SearchBar          textinput.Model
 	LastTimeGetElement time.Time
 	TargetFile         string             // filename to position cursor on after load
+	SaveMode           bool               // when true, a synthetic save target entry is pinned to the panel
+	SaveEntryName      string             // current file name for the synthetic save target
 	columns            []columnDefinition // columns for rendering
 }
 
@@ -51,10 +53,11 @@ type directoryRecord struct {
 
 // Element within a file panel
 type Element struct {
-	Name      string
-	Location  string
-	Directory bool
-	Info      os.FileInfo
+	Name       string
+	Location   string
+	Directory  bool
+	Info       os.FileInfo
+	SaveTarget bool
 }
 
 // Type representing the mode of the panel

--- a/src/internal/ui/filepanel/update.go
+++ b/src/internal/ui/filepanel/update.go
@@ -83,6 +83,9 @@ func (m *Model) ParentDirectory() error {
 // Select all item in the file panel (only work on select mode)
 func (m *Model) SelectAllItem() {
 	for _, item := range m.element {
+		if item.SaveTarget {
+			continue
+		}
 		m.SetSelected(item.Location)
 	}
 }

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -1,6 +1,7 @@
 package filepanel
 
 import (
+	"cmp"
 	"math"
 	"path/filepath"
 	"slices"
@@ -99,7 +100,7 @@ func (m *Model) GetOrderedSelectedLocations() []string {
 	}
 
 	slices.SortFunc(ordered, func(a, b orderedSelection) int {
-		return a.order - b.order
+		return cmp.Compare(a.order, b.order)
 	})
 
 	result := make([]string, 0, len(ordered))
@@ -126,9 +127,16 @@ func (m *Model) GetFirstSelectedLocation() string {
 
 // Select the item where cursor located (only work on select mode)
 func (m *Model) SingleItemSelect() {
-	if !m.EmptyOrInvalid() {
-		m.ToggleSelected(m.GetFocusedItem().Location)
+	if m.EmptyOrInvalid() {
+		return
 	}
+
+	focused := m.GetFocusedItem()
+	if focused.SaveTarget {
+		return
+	}
+
+	m.ToggleSelected(focused.Location)
 }
 
 func (m *Model) ElemCount() int {
@@ -178,7 +186,8 @@ func (m *Model) FindElementIndexByLocation(location string) int {
 func (m *Model) EnableSaveMode(fileName string) {
 	m.SaveMode = true
 	m.SaveEntryName = fileName
-	m.scrollToCursor(0)
+	m.cursor = 0
+	m.renderIndex = 0
 }
 
 func (m *Model) DisableSaveMode() {

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -1,6 +1,10 @@
 package filepanel
 
-import "math"
+import (
+	"math"
+	"path/filepath"
+	"slices"
+)
 
 func (m *Model) GetCursor() int {
 	return m.cursor
@@ -80,6 +84,31 @@ func (m *Model) GetSelectedLocations() []string {
 	return result
 }
 
+func (m *Model) GetOrderedSelectedLocations() []string {
+	type orderedSelection struct {
+		location string
+		order    int
+	}
+
+	ordered := make([]orderedSelection, 0, len(m.selected))
+	for location, order := range m.selected {
+		ordered = append(ordered, orderedSelection{
+			location: location,
+			order:    order,
+		})
+	}
+
+	slices.SortFunc(ordered, func(a, b orderedSelection) int {
+		return a.order - b.order
+	})
+
+	result := make([]string, 0, len(ordered))
+	for _, item := range ordered {
+		result = append(result, item.location)
+	}
+	return result
+}
+
 func (m *Model) GetFirstSelectedLocation() string {
 	if len(m.selected) == 0 {
 		return ""
@@ -144,4 +173,38 @@ func (m *Model) FindElementIndexByLocation(location string) int {
 		}
 	}
 	return -1
+}
+
+func (m *Model) EnableSaveMode(fileName string) {
+	m.SaveMode = true
+	m.SaveEntryName = fileName
+	m.scrollToCursor(0)
+}
+
+func (m *Model) DisableSaveMode() {
+	m.SaveMode = false
+	m.SaveEntryName = ""
+}
+
+func (m *Model) HasSaveEntry() bool {
+	return m.SaveMode
+}
+
+func (m *Model) GetSaveEntryName() string {
+	return m.SaveEntryName
+}
+
+func (m *Model) SetSaveEntryName(name string) {
+	m.SaveEntryName = name
+}
+
+func (m *Model) GetSaveEntryLocation() string {
+	if m.SaveEntryName == "" {
+		return m.Location
+	}
+	return filepath.Join(m.Location, m.SaveEntryName)
+}
+
+func (m *Model) IsSaveEntryFocused() bool {
+	return m.SaveMode && m.GetCursor() == 0
 }

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -15,6 +15,21 @@ func (m *Model) GetRenderIndex() int {
 	return m.renderIndex
 }
 
+func (m *Model) effectiveRenderIndex() int {
+	if m.SaveMode && m.ElemCount() > 1 {
+		return max(m.renderIndex, 1)
+	}
+	return m.renderIndex
+}
+
+func (m *Model) visibleScrollableElementCount() int {
+	count := m.PanelElementHeight()
+	if m.SaveMode && m.ElemCount() > 1 {
+		count--
+	}
+	return max(count, 1)
+}
+
 func (m *Model) GetFocusedItem() Element {
 	return m.GetElementAtIdx(m.GetCursor())
 }
@@ -163,6 +178,13 @@ func (m *Model) ToggleReverseSort() {
 // Note: Intended for test utilities only!!!!!
 func (m *Model) SetCursorPosition(cursor int) {
 	m.scrollToCursor(cursor)
+}
+
+func (m *Model) FocusSaveEntry() {
+	if !m.SaveMode || m.Empty() {
+		return
+	}
+	m.scrollToCursor(0)
 }
 
 func (m *Model) FindElementIndexByName(name string) int {

--- a/src/internal/ui/helpmenu/data.go
+++ b/src/internal/ui/helpmenu/data.go
@@ -181,6 +181,11 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 			hotkeyWorkType: globalType,
 		},
 		{
+			hotkey:         common.Hotkeys.SaveChooserFocusTarget,
+			description:    "In save mode, focus the save target ghost entry",
+			hotkeyWorkType: normalType,
+		},
+		{
 			hotkey:         common.Hotkeys.ChangePanelMode,
 			description:    "Change between selection mode or normal mode",
 			hotkeyWorkType: globalType,

--- a/src/internal/ui/notify/type.go
+++ b/src/internal/ui/notify/type.go
@@ -8,4 +8,5 @@ const (
 	QuitAction
 	NoAction
 	PermanentDeleteAction
+	SaveOverwriteAction
 )

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -89,6 +89,7 @@ cancel_typing = ['ctrl+c', 'esc']
 #-- Normal Mode Actions
 parent_directory = ['h', 'left', 'backspace']
 search_bar = ['/', '']
+save_chooser_focus_target = ['shift+up', 'shift+down', 'K', 'J']
 
 #-- Selection Mode Actions
 file_panel_select_mode_items_select_down = ['shift+down', 'J']

--- a/testsuite/tests/chooser_file_multiselect_test.py
+++ b/testsuite/tests/chooser_file_multiselect_test.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import time
+
+from core.base_test import GenericTestImpl
+from core.environment import Environment
+import core.test_constants as tconst
+
+TESTROOT = Path("chooser_file_multiselect_ops")
+DIR1 = TESTROOT / "dir1"
+DIR2 = TESTROOT / "dir2"
+FILE1 = DIR1 / "file1.txt"
+FILE2 = DIR1 / "file2.txt"
+CHOOSER_FILE = DIR2 / "chooser_file.txt"
+
+
+class ChooserFileMultiSelectTest(GenericTestImpl):
+
+    def __init__(self, test_env: Environment):
+        super().__init__(
+            test_env=test_env,
+            test_root=TESTROOT,
+            start_dir=DIR1,
+            test_dirs=[DIR1, DIR2],
+            test_files=[(FILE1, tconst.FILE_TEXT1), (FILE2, tconst.FILE_TEXT1)],
+            key_inputs=['v', 'J', 'J', 'e'],
+            validate_spf_closed=True,
+            close_wait_time=3,
+        )
+
+        self.spf_opts += ["--chooser-file", str(self.env.fs_mgr.abspath(CHOOSER_FILE))]
+
+    def end_execution(self) -> None:
+        self.logger.debug("Skipping esc key press for chooser file multiselect test")
+        time.sleep(self.close_wait_time)
+        self.logger.debug("Finished Execution")
+
+    def validate(self) -> bool:
+        if not super().validate():
+            return False
+
+        try:
+            assert self.env.fs_mgr.check_exists(CHOOSER_FILE), f"File {CHOOSER_FILE} does not exists"
+            chooser_file_content = self.env.fs_mgr.read_file(CHOOSER_FILE)
+            expected = "\n".join([
+                str(self.env.fs_mgr.abspath(FILE1)),
+                str(self.env.fs_mgr.abspath(FILE2)),
+            ])
+            assert chooser_file_content == expected, f"Expected '{expected}', got '{chooser_file_content}'"
+        except AssertionError as ae:
+            self.logger.debug("Test assertion failed : %s", ae, exc_info=True)
+            return False
+
+        return True

--- a/testsuite/tests/chooser_file_multiselect_test.py
+++ b/testsuite/tests/chooser_file_multiselect_test.py
@@ -31,7 +31,11 @@ class ChooserFileMultiSelectTest(GenericTestImpl):
 
     def end_execution(self) -> None:
         self.logger.debug("Skipping esc key press for chooser file multiselect test")
-        time.sleep(self.close_wait_time)
+        deadline = time.time() + self.close_wait_time
+        while time.time() < deadline:
+            if not self.env.spf_mgr.is_spf_running():
+                break
+            time.sleep(0.1)
         self.logger.debug("Finished Execution")
 
     def validate(self) -> bool:
@@ -39,7 +43,7 @@ class ChooserFileMultiSelectTest(GenericTestImpl):
             return False
 
         try:
-            assert self.env.fs_mgr.check_exists(CHOOSER_FILE), f"File {CHOOSER_FILE} does not exists"
+            assert self.env.fs_mgr.check_exists(CHOOSER_FILE), f"File {CHOOSER_FILE} does not exist"
             chooser_file_content = self.env.fs_mgr.read_file(CHOOSER_FILE)
             expected = "\n".join([
                 str(self.env.fs_mgr.abspath(FILE1)),

--- a/testsuite/tests/save_file_overwrite_test.py
+++ b/testsuite/tests/save_file_overwrite_test.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import time
+
+from core.base_test import GenericTestImpl
+from core.environment import Environment
+import core.test_constants as tconst
+import core.keys as keys
+
+TESTROOT = Path("save_file_overwrite_ops")
+DIR1 = TESTROOT / "dir1"
+FILE1 = DIR1 / "file1.txt"
+SAVE_OUT = TESTROOT / "save_out.txt"
+
+
+class SaveFileOverwriteTest(GenericTestImpl):
+
+    def __init__(self, test_env: Environment):
+        super().__init__(
+            test_env=test_env,
+            test_root=TESTROOT,
+            start_dir=DIR1,
+            test_dirs=[DIR1],
+            test_files=[(FILE1, tconst.FILE_TEXT1)],
+            key_inputs=["E", keys.KEY_ENTER],
+            validate_spf_closed=True,
+            close_wait_time=3,
+        )
+
+        self.spf_opts += [
+            "--save-file",
+            str(self.env.fs_mgr.abspath(SAVE_OUT)),
+            str(self.env.fs_mgr.abspath(FILE1)),
+        ]
+
+    def end_execution(self) -> None:
+        self.logger.debug("Skipping esc key press for save file overwrite test")
+        time.sleep(self.close_wait_time)
+        self.logger.debug("Finished Execution")
+
+    def validate(self) -> bool:
+        if not super().validate():
+            return False
+
+        try:
+            assert self.env.fs_mgr.check_exists(SAVE_OUT), f"File {SAVE_OUT} does not exists"
+            save_output = self.env.fs_mgr.read_file(SAVE_OUT)
+            expected = str(self.env.fs_mgr.abspath(FILE1))
+            assert save_output == expected, f"Expected '{expected}', got '{save_output}'"
+        except AssertionError as ae:
+            self.logger.debug("Test assertion failed : %s", ae, exc_info=True)
+            return False
+
+        return True

--- a/testsuite/tests/save_file_test.py
+++ b/testsuite/tests/save_file_test.py
@@ -39,7 +39,7 @@ class SaveFileTest(GenericTestImpl):
             return False
 
         try:
-            assert self.env.fs_mgr.check_exists(SAVE_OUT), f"File {SAVE_OUT} does not exists"
+            assert self.env.fs_mgr.check_exists(SAVE_OUT), f"File {SAVE_OUT} does not exist"
             assert self.env.fs_mgr.check_exists(DIR1 / "download.txt"), "download placeholder was not created at target path"
             save_output = self.env.fs_mgr.read_file(SAVE_OUT)
             expected = str(self.env.fs_mgr.abspath(DIR1 / "download.txt"))

--- a/testsuite/tests/save_file_test.py
+++ b/testsuite/tests/save_file_test.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import time
+
+from core.base_test import GenericTestImpl
+from core.environment import Environment
+import core.test_constants as tconst
+import core.keys as keys
+
+TESTROOT = Path("save_file_ops")
+DIR1 = TESTROOT / "dir1"
+SAVE_OUT = TESTROOT / "save_out.txt"
+
+
+class SaveFileTest(GenericTestImpl):
+
+    def __init__(self, test_env: Environment):
+        super().__init__(
+            test_env=test_env,
+            test_root=TESTROOT,
+            start_dir=DIR1,
+            test_dirs=[DIR1],
+            key_inputs=[keys.KEY_CTRL_R, "download.txt", keys.KEY_ENTER, "E"],
+            validate_spf_closed=True,
+            close_wait_time=3,
+        )
+
+        self.spf_opts += [
+            "--save-file",
+            str(self.env.fs_mgr.abspath(SAVE_OUT)),
+            str(self.env.fs_mgr.abspath(DIR1)),
+        ]
+
+    def end_execution(self) -> None:
+        self.logger.debug("Skipping esc key press for save file test")
+        time.sleep(self.close_wait_time)
+        self.logger.debug("Finished Execution")
+
+    def validate(self) -> bool:
+        if not super().validate():
+            return False
+
+        try:
+            assert self.env.fs_mgr.check_exists(SAVE_OUT), f"File {SAVE_OUT} does not exists"
+            assert self.env.fs_mgr.check_exists(DIR1 / "download.txt"), "download placeholder was not created at target path"
+            save_output = self.env.fs_mgr.read_file(SAVE_OUT)
+            expected = str(self.env.fs_mgr.abspath(DIR1 / "download.txt"))
+            assert save_output == expected, f"Expected '{expected}', got '{save_output}'"
+        except AssertionError as ae:
+            self.logger.debug("Test assertion failed : %s", ae, exc_info=True)
+            return False
+
+        return True

--- a/testsuite/tests/save_file_test.py
+++ b/testsuite/tests/save_file_test.py
@@ -3,7 +3,6 @@ import time
 
 from core.base_test import GenericTestImpl
 from core.environment import Environment
-import core.test_constants as tconst
 import core.keys as keys
 
 TESTROOT = Path("save_file_ops")

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -20,3 +20,13 @@ Try these things below:
 - Set your locale to utf-8  
 - chcp 65001 ( If that's an option for your shell )  
 - Set environment variable RUNEWIDTH_EASTASIAN to 0 (`RUNEWIDTH_EASTASIAN=0`)
+
+## superfile chooser/save mode is not working through my portal wrapper
+
+If you launch superfile through `xdg-desktop-portal-termfilechooser` or another wrapper:
+
+- Use `--chooser-file` for open-file selection output.
+- Use `--save-file` for save-target selection output.
+- `--chooser-file` now supports multi-select and writes newline-delimited absolute paths.
+- `--save-file` uses superfile's save flow, where `e` confirms the focused file or ghost and `E` confirms the current directory plus the ghost name.
+- The `xdg-desktop-portal-termfilechooser` superfile wrapper must call `spf --save-file="$out" "$path"` for save requests. Older wrappers that always call `--chooser-file` will not enter save mode.

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -28,5 +28,5 @@ If you launch superfile through `xdg-desktop-portal-termfilechooser` or another 
 - Use `--chooser-file` for open-file selection output.
 - Use `--save-file` for save-target selection output.
 - `--chooser-file` now supports multi-select and writes newline-delimited absolute paths.
-- `--save-file` uses superfile's save flow, where `e` confirms the focused file or ghost and `E` confirms the current directory plus the ghost name.
+- `--save-file` uses superfile's save flow, where `ctrl+r` renames the ghost, `e` confirms the focused file or ghost, and `E` confirms the current directory plus the ghost name.
 - The `xdg-desktop-portal-termfilechooser` superfile wrapper must call `spf --save-file="$out" "$path"` for save requests. Older wrappers that always call `--chooser-file` will not enter save mode.


### PR DESCRIPTION
## Summary

This adds two related chooser improvements :

- `--chooser-file` now supports ordered multi-select output
- `--save-file` adds a dedicated save flow for portal/file-chooser usage

The save flow includes a pinned save target entry in the panel, confirmation via the existing open keys, and overwrite confirmation for real existing files.

## What I changed

- added `--save-file` CLI support
- made `--chooser-file` and `--save-file` mutually exclusive
- reject multiple startup paths in chooser/save mode
- changed chooser output to write newline-delimited absolute paths for multi-select
- preserved selection order for chooser output
- added save-mode panel state with a pinned synthetic save target entry
- made save confirmation work through `e` and `E`
- suppressed normal open/editor side effects while in save mode
- added overwrite confirmation for real existing save targets
- create the real placeholder file at the confirmed save destination when the destination does not already exist
- avoid false overwrite prompts when the selected path is the portal’s own temporary save placeholder
- added tests for chooser ordering and save flow behavior
- added a `contrib/superfile-wrapper.sh` example updated for `--save-file`

## Why the extra save placeholder logic exists

`xdg-desktop-portal-termfilechooser` validates save selections against a real file on disk when `create_help_file=1` is enabled, which is the default.  
That means returning only a synthetic path is not enough for save mode to work correctly when the target is moved to a different directory.

To handle that correctly, I made sure it creates the real empty placeholder file at the confirmed destination before returning the selected path.

## Testing

I Ran:

- `go test ./src/cmd`
- `go test ./src/internal/ui/filepanel`
- `go test ./src/internal -run 'TestChooserFile|TestChooserFileMultiSelectWritesSelectionOrder|TestSaveChooser|TestResolveSaveChooserStartPath'`
- `go test ./... -run '^$'`
- `python3 testsuite/main.py -t ChooserFileTest ChooserFileMultiSelectTest SaveFileTest SaveFileOverwriteTest`

## Notes

- the wrapper update for portal save requests is included as `contrib/superfile-wrapper.sh`
- if a downstream wrapper still always calls `--chooser-file`, save mode will not be used obiously


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal file-chooser: open multi-select via --chooser-file (writes newline-delimited absolute paths in selection order) and dedicated save flow via --save-file with pinned save target, rename/confirm hotkeys, overwrite confirmation, portal-placeholder handling; flags are mutually exclusive and accept at most one startup path.

* **Documentation**
  * README and troubleshooting updated with CLI usage, behavior details, and wrapper instructions for save requests.

* **Tests**
  * Added unit and end-to-end tests for chooser open/save flows, selection order, save initialization, overwrite and placeholder behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->