### PR TITLE
fix: Change FormatFileSize to use configured units

### DIFF
--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -159,10 +159,12 @@ func formatSizeInternal(size int64, power int, unitlist [7]string) string {
 
 func FormatFileSize(size int64) string {
 	units := unitsBin()
+	power := KibibyteSize
 	if Config.FileSizeUseSI {
 		units = unitsDec()
+		power = KilobyteSize
 	}
-	return formatSizeInternal(size, KibibyteSize, units)
+	return formatSizeInternal(size, power, units)
 }
 
 func GetHelpMenuHotkeyString(hotkeys []string) string {


### PR DESCRIPTION
99d2a1e fixed fractional bytes but broke the sizes to always use binary units even with SI symbols.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * File size display formatting has been improved to correctly respect the unit system configuration preference. The system now dynamically selects and applies the appropriate unit system based on user settings, ensuring consistent and accurate file size displays throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->