### PR TITLE
fix: thread safe ioReqCnt

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -94,8 +94,7 @@ func (m *model) IsRenamingConflicting() bool {
 
 // TODO: Remove channel messaging and use tea.Cmd
 func (m *model) warnModalForRenaming() tea.Cmd {
-	reqID := m.ioReqCnt
-	m.ioReqCnt++
+	reqID := m.nextIoReqCnt()
 	slog.Debug("Submitting rename notify model request", "reqID", reqID)
 	res := func() tea.Msg {
 		notifyModel := notify.New(true,
@@ -156,8 +155,7 @@ func (m *model) getDeleteCmd(permDelete bool) tea.Cmd {
 
 	useTrash := m.hasTrash && !isExternalDiskPath(panel.Location) && !permDelete
 
-	reqID := m.ioReqCnt
-	m.ioReqCnt++
+	reqID := m.nextIoReqCnt()
 	slog.Debug("Submitting delete request", "id", reqID, "items cnt", len(items))
 	return func() tea.Msg {
 		return m.deleteOperation(&m.processBarModel, items, useTrash, reqID)
@@ -222,8 +220,7 @@ func (m *model) getDeleteTriggerCmd(deletePermanent bool) tea.Cmd {
 		return nil
 	}
 
-	reqID := m.ioReqCnt
-	m.ioReqCnt++
+	reqID := m.nextIoReqCnt()
 
 	return func() tea.Msg {
 		title := common.TrashWarnTitle
@@ -273,8 +270,7 @@ func (m *model) getPasteItemCmd() tea.Cmd {
 
 	// TODO: Do it via m.getNewReqID()
 	// TODO: Have an IO Req Management, collecting info about pending IO Req too
-	reqID := m.ioReqCnt
-	m.ioReqCnt++
+	reqID := m.nextIoReqCnt()
 	panelLocation := m.getFocusedFilePanel().Location
 
 	slog.Debug("Submitting pasteItems request", "id", reqID, "items cnt", len(copyItems), "dest", panelLocation)
@@ -413,8 +409,7 @@ func (m *model) getExtractFileCmd() tea.Cmd {
 		slog.Error("Error unexpected file", "extension type", ext, "item", item, "error", errors.ErrUnsupported)
 		return nil
 	}
-	reqID := m.ioReqCnt
-	m.ioReqCnt++
+	reqID := m.nextIoReqCnt()
 
 	slog.Debug("Submitting Extract file request", "reqID", reqID, "item", item)
 
@@ -460,8 +455,7 @@ func (m *model) getCompressSelectedFilesCmd() tea.Cmd {
 		filesToCompress = panel.GetSelectedLocations()
 	}
 
-	reqID := m.ioReqCnt
-	m.ioReqCnt++
+	reqID := m.nextIoReqCnt()
 
 	return func() tea.Msg {
 		zipName, err := getZipArchiveName(filepath.Base(firstFile))

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -285,8 +285,7 @@ func (m *model) spfErrorModelOpenKey(msg string) tea.Cmd {
 	if state == nil {
 		return nil
 	}
-	reqID := m.ioReqCnt
-	m.ioReqCnt++
+	reqID := m.nextIoReqCnt()
 	if isSkip {
 		return func() tea.Msg { return state.Skip(m.runFileProcessor, reqID) }
 	}

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/yorukot/superfile/src/config/icon"
@@ -168,8 +169,7 @@ func (m *model) getMetadataCmd() tea.Cmd {
 		m.fileMetaData.SetInfoMsg(icon.InOperation + icon.Space + "Loading metadata...")
 	}
 
-	reqCnt := m.ioReqCnt
-	m.ioReqCnt++
+	reqCnt := m.nextIoReqCnt()
 	// If there are too many metadata fetches, we need to have a cache with path as a key
 	// and timeout based eviction
 	slog.Debug("Submitting metadata fetch request", "id", reqCnt, "path", selectedItem.Location)
@@ -622,4 +622,10 @@ func (m *model) quitSuperfile(cdOnQuit bool) {
 	}
 	m.modelQuitState = quitDone
 	slog.Debug("Quitting superfile", "current dir", currentDir)
+}
+
+// thread safe. returns current ioReqCnt and increments it.
+func (m *model) nextIoReqCnt() int {
+	var res = atomic.AddInt32(&m.ioReqCnt, 1)
+	return int(res)
 }

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -71,8 +71,11 @@ type model struct {
 	// Zoxide client for directory tracking
 	zClient *zoxidelib.Client
 
-	fileMetaData         metadata.Model
-	ioReqCnt             int
+	fileMetaData metadata.Model
+
+	// no use directly for increment, use nextIoReqCnt
+	ioReqCnt int32
+
 	modelQuitState       modelQuitStateType
 	firstTextInput       bool
 	toggleFooter         bool


### PR DESCRIPTION
When we open an error modal window, we can begin do it in different threads.
issue: https://github.com/yorukot/superfile/issues/1360

The counting of ioReqCnt is made thread safe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal request ID generation mechanism to use centralized thread-safe handling across multiple operations, enhancing code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->