### PR TITLE
fix: files processed in deterministic order

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -149,7 +149,7 @@ func (m *model) getDeleteCmd(permDelete bool) tea.Cmd {
 
 	var items []string
 	if panel.PanelMode == filepanel.SelectMode {
-		items = panel.GetSelectedLocations()
+		items = panel.GetSelectedLocationsSortedAsVisible()
 	} else {
 		items = []string{panel.GetFocusedItem().Location}
 	}
@@ -259,9 +259,10 @@ func (m *model) copyMultipleItem(cut bool) {
 	if panel.SelectedCount() == 0 {
 		return
 	}
+	items := panel.GetSelectedLocationsSortedAsVisible()
 	slog.Debug("handle_file_operations.copyMultipleItem", "cut", cut,
-		"panel selected files", panel.GetSelectedLocations())
-	m.clipboard.SetItems(panel.GetSelectedLocations())
+		"panel selected files", items)
+	m.clipboard.SetItems(items)
 }
 
 func (m *model) getPasteItemCmd() tea.Cmd {
@@ -457,7 +458,7 @@ func (m *model) getCompressSelectedFilesCmd() tea.Cmd {
 		filesToCompress = append(filesToCompress, firstFile)
 	} else {
 		firstFile = panel.GetFirstSelectedLocation()
-		filesToCompress = panel.GetSelectedLocations()
+		filesToCompress = panel.GetSelectedLocationsSortedAsVisible()
 	}
 
 	reqID := m.ioReqCnt

--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -24,8 +24,10 @@ func (m *Model) renderFileName(indexElement int, columnWidth int) string {
 
 	// Calculate the actual prefix width for proper alignment
 	prefixWidth := ansi.StringWidth(cursor+" ") + ansi.StringWidth(selectBox)
-
-	isLink := elem.Info.Mode()&os.ModeSymlink != 0
+	isLink := false
+	if elem.Info != nil {
+		isLink = elem.Info.Mode()&os.ModeSymlink != 0
+	}
 	renderedName := common.FilePanelItemRenderWithIcon(
 		elem.Name,
 		columnWidth-prefixWidth,

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -82,6 +82,14 @@ func (m *Model) GetSelectedLocations() []string {
 
 // Returns an ordered list of selected locations. Order like user see in filepanel.
 func (m *Model) GetSelectedLocationsSortedAsVisible() []string {
+	if len(m.selected) == 0 {
+		return []string{}
+	}
+	if len(m.selected) == 1 {
+		for k := range m.selected {
+			return []string{k}
+		}
+	}
 	result := make([]string, 0, len(m.selected))
 	for _, el := range m.element {
 		if _, ok := m.selected[el.Location]; ok {

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -80,6 +80,17 @@ func (m *Model) GetSelectedLocations() []string {
 	return result
 }
 
+// Returns an ordered list of selected locations. Order like user see in filepanel.
+func (m *Model) GetSelectedLocationsSortedAsVisible() []string {
+	result := make([]string, 0, len(m.selected))
+	for _, el := range m.element {
+		if _, ok := m.selected[el.Location]; ok {
+			result = append(result, el.Location)
+		}
+	}
+	return result
+}
+
 func (m *Model) GetFirstSelectedLocation() string {
 	if len(m.selected) == 0 {
 		return ""

--- a/src/internal/ui/filepanel/utils_test.go
+++ b/src/internal/ui/filepanel/utils_test.go
@@ -1,0 +1,70 @@
+package filepanel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorukot/superfile/src/internal/ui/sortmodel"
+)
+
+func TestGetSelectedLocationsSortedAsVisible(t *testing.T) {
+	testdata := []struct {
+		name             string
+		panel            Model
+		toSelect         []string
+		expectedSelected []string
+	}{
+		{
+			name: "no any selected",
+			panel: testModel(0, 0, 12, SelectMode, []Element{
+				{Name: "file1.txt", Location: "/tmp/file1.txt"},
+				{Name: "file2.txt", Location: "/tmp/file2.txt"},
+				{Name: "file3.txt", Location: "/tmp/file3.txt"},
+				{Name: "file4.txt", Location: "/tmp/file4.txt"},
+			}),
+			expectedSelected: []string{},
+		},
+		{
+			name: "1 item selected",
+			panel: testModel(0, 0, 12, SelectMode, []Element{
+				{Name: "file1.txt", Location: "/tmp/file1.txt"},
+				{Name: "file2.txt", Location: "/tmp/file2.txt"},
+				{Name: "file3.txt", Location: "/tmp/file3.txt"},
+				{Name: "file4.txt", Location: "/tmp/file4.txt"},
+			}),
+			toSelect:         []string{"/tmp/file2.txt"},
+			expectedSelected: []string{"/tmp/file2.txt"},
+		},
+		{
+			name: "2 item selects reverse selection order",
+			panel: testModel(-1, 0, 12, SelectMode, []Element{
+				{Name: "file1.txt", Location: "/tmp/file1.txt"},
+				{Name: "file2.txt", Location: "/tmp/file2.txt"},
+				{Name: "file4.txt", Location: "/tmp/file3.txt"},
+				{Name: "file5.txt", Location: "/tmp/file4.txt"},
+			}),
+			toSelect:         []string{"/tmp/file4.txt", "/tmp/file2.txt"},
+			expectedSelected: []string{"/tmp/file2.txt", "/tmp/file4.txt"},
+		},
+		{
+			name: "2 item selects",
+			panel: testModel(-1, 0, 12, SelectMode, []Element{
+				{Name: "file1.txt", Location: "/tmp/file1.txt"},
+				{Name: "file2.txt", Location: "/tmp/file2.txt"},
+				{Name: "file3.txt", Location: "/tmp/file3.txt"},
+				{Name: "file4.txt", Location: "/tmp/file4.txt"},
+			}),
+			toSelect:         []string{"/tmp/file2.txt", "/tmp/file4.txt"},
+			expectedSelected: []string{"/tmp/file2.txt", "/tmp/file4.txt"},
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.panel.SortKind = sortmodel.SortByName
+			tt.panel.SetSelectedAll(tt.toSelect)
+			assert.Equal(t, tt.expectedSelected, tt.panel.GetSelectedLocationsSortedAsVisible())
+		})
+	}
+}


### PR DESCRIPTION
issue: https://github.com/yorukot/superfile/issues/1417

The files are processed in the order they are presented to the user when they are in "select mode".
PS fixed panic in multicolumn rendering ( FYI @yorukot  )
<img width="1060" height="490" alt="image" src="https://github.com/user-attachments/assets/f63cb769-ca42-4720-802a-5b50c6914011" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvement**
  * Multi-item file operations (delete, copy, compress) now act on selections in the same order users see in the file panel.
* **Bug Fix**
  * Prevented a potential crash when rendering file names by safely handling missing file info (fixes nil dereference with symlinks).
* **Tests**
  * Added tests verifying selections are returned in visible/sorted order for none, single, reversed and multi selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->