### PR TITLE
fix: `behviour` -> `behaviour` typo in tmux.md

### DIFF
--- a/testsuite/docs/tmux.md
+++ b/testsuite/docs/tmux.md
@@ -1,5 +1,5 @@
 # Overview
-This is to document the behviour of tmux, and how could we use it in testsuite
+This is to document the behaviour of tmux, and how could we use it in testsuite
 
 # Tmux concepts and working info
 - Tmux creates a main server process, and one new process for each session.


### PR DESCRIPTION
Line 2 of `testsuite/docs/tmux.md` has `behviour` (missing letter).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed spelling correction in the tmux documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->