### PR TITLE
feat: add linux attributes to metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.42.0
 	golang.org/x/text v0.35.0
 )

--- a/src/internal/ui/metadata/const.go
+++ b/src/internal/ui/metadata/const.go
@@ -18,6 +18,7 @@ const keyPermissions = "Permissions"
 const keyMd5Checksum = "MD5Checksum"
 const keyOwner = "Owner"
 const keyGroup = "Group"
+const keyAttributes = "Attributes"
 const keyPath = "Path"
 const keyArchitecture = "Architecture"
 const borderSize = 2

--- a/src/internal/ui/metadata/metadata.go
+++ b/src/internal/ui/metadata/metadata.go
@@ -126,6 +126,11 @@ func getMetaDataUnsorted(filePath string, metadataFocused bool, et *exiftool.Exi
 	}
 	res.data = append(res.data, name, size, modifyDate, permissions, owner, group)
 
+	if attrVal, ok := getFileAttributes(filePath); ok {
+		attrs := [2]string{keyAttributes, attrVal}
+		res.data = append(res.data, attrs)
+	}
+
 	if fileInfo.Mode().IsRegular() {
 		if arch, err := GetBinaryArchitecture(filePath); err == nil {
 			archData := [2]string{keyArchitecture, arch}

--- a/src/internal/ui/metadata/metadata_darwin.go
+++ b/src/internal/ui/metadata/metadata_darwin.go
@@ -1,14 +1,6 @@
-//go:build windows
+//go:build darwin
 
 package metadata
-
-import (
-	"os"
-)
-
-func getOwnerAndGroup(_ os.FileInfo) (string, string) {
-	return "", ""
-}
 
 // returns file attributes
 // TODO: need realisation

--- a/src/internal/ui/metadata/metadata_linux.go
+++ b/src/internal/ui/metadata/metadata_linux.go
@@ -4,7 +4,6 @@ package metadata
 
 import (
 	"os"
-	"strings"
 
 	"golang.org/x/sys/unix"
 )
@@ -69,6 +68,11 @@ const (
 	FS_CASEFOLD_FL = 0x40000000 /* Folder is case insensitive */
 )
 
+type attrEntry struct {
+	flag   uint32
+	letter byte
+}
+
 // returns file attributes
 //
 // Parameters:
@@ -92,82 +96,44 @@ func getFileAttributes(path string) (string, bool) {
 	return decodeChattr(flags), true
 }
 
-// list of letter and output order see in
-// lsattr sources https://github.com/tytso/e2fsprogs/blob/master/lib/e2p/pf.c
-//
-//nolint:gocognit // it's just mapping list of linux flags to lsattr letters
 func decodeChattr(flags uint32) string {
-	var attrs = make([]string, AttrsSupported)
+	// list of letter and output order see in
+	// lsattr sources https://github.com/tytso/e2fsprogs/blob/master/lib/e2p/pf.c
+	var attrOrder = [...]attrEntry{
+		{FS_SECRM_FL, 's'},        // Secure_Deletion
+		{FS_UNRM_FL, 'u'},         // Undelete
+		{FS_SYNC_FL, 'S'},         // Synchronous_Updates
+		{FS_DIRSYNC_FL, 'D'},      // Synchronous_Directory_Updates
+		{FS_IMMUTABLE_FL, 'i'},    // Immutable
+		{FS_APPEND_FL, 'a'},       // Append_Only
+		{FS_NODUMP_FL, 'd'},       // No_Dump
+		{FS_NOATIME_FL, 'A'},      // No_Atime
+		{FS_COMPR_FL, 'c'},        // Compression_Requested
+		{FS_ENCRYPT_FL, 'E'},      // Encrypted
+		{FS_JOURNAL_DATA_FL, 'j'}, // Journaled_Data
+		{FS_INDEX_FL, 'I'},        // Indexed_directory
+		{FS_NOTAIL_FL, 't'},       // No_Tailmerging
+		{FS_TOPDIR_FL, 'T'},       // Top_of_Directory_Hierarchies
+		{FS_EXTENT_FL, 'e'},       // Extents
+		{FS_NOCOW_FL, 'C'},        // No_COW
+		{FS_DAX_FL, 'x'},          // DAX
+		{FS_CASEFOLD_FL, 'F'},     // Casefold
+		{FS_INLINE_DATA_FL, 'N'},  // Inline_Data
+		{FS_PROJINHERIT_FL, 'P'},  // Project_Hierarchy
+		{FS_VERITY_FL, 'V'},       // Verity
+		{FS_NOCOMP_FL, 'm'},       // Dont_Compress
+	}
+
+	attrs := make([]byte, len(attrOrder))
 	for i := range attrs {
-		attrs[i] = "-"
+		attrs[i] = '-'
 	}
 
-	if flags&FS_SECRM_FL != 0 {
-		attrs[0] = "s" // Secure_Deletion
-	}
-	if flags&FS_UNRM_FL != 0 {
-		attrs[1] = "u" // Undelete
-	}
-	if flags&FS_SYNC_FL != 0 {
-		attrs[2] = "S" // Synchronous_Updates
-	}
-	if flags&FS_DIRSYNC_FL != 0 {
-		attrs[3] = "D" // Synchronous_Directory_Updates
-	}
-	if flags&FS_IMMUTABLE_FL != 0 {
-		attrs[4] = "i" // Immutable
-	}
-	if flags&FS_APPEND_FL != 0 {
-		attrs[5] = "a" // Append_Only
-	}
-	if flags&FS_NODUMP_FL != 0 {
-		attrs[6] = "d" // No_Dump
-	}
-	if flags&FS_NOATIME_FL != 0 {
-		attrs[7] = "A" // No_Atime
-	}
-	if flags&FS_COMPR_FL != 0 {
-		attrs[8] = "c" // Compression_Requested
-	}
-	if flags&FS_ENCRYPT_FL != 0 {
-		attrs[9] = "E" // Encrypted
-	}
-	if flags&FS_JOURNAL_DATA_FL != 0 {
-		attrs[10] = "j" // Journaled_Data
-	}
-	if flags&FS_INDEX_FL != 0 {
-		attrs[11] = "I" // Indexed_directory
-	}
-	if flags&FS_NOTAIL_FL != 0 {
-		attrs[12] = "t" // No_Tailmerging
-	}
-	if flags&FS_TOPDIR_FL != 0 {
-		attrs[13] = "T" // Top_of_Directory_Hierarchies
-	}
-	if flags&FS_EXTENT_FL != 0 {
-		attrs[14] = "e" // Extents
-	}
-	if flags&FS_NOCOW_FL != 0 {
-		attrs[15] = "C" // No_COW
-	}
-	if flags&FS_DAX_FL != 0 {
-		attrs[16] = "x" // DAX
-	}
-	if flags&FS_CASEFOLD_FL != 0 {
-		attrs[17] = "F" // Casefold
-	}
-	if flags&FS_INLINE_DATA_FL != 0 {
-		attrs[18] = "N" // Inline_Data
-	}
-	if flags&FS_PROJINHERIT_FL != 0 {
-		attrs[19] = "P" // Project_Hierarchy
-	}
-	if flags&FS_VERITY_FL != 0 {
-		attrs[20] = "V" // Verity
-	}
-	if flags&FS_NOCOMP_FL != 0 {
-		attrs[21] = "m" // Dont_Compress
+	for i, e := range attrOrder {
+		if flags&e.flag != 0 {
+			attrs[i] = e.letter
+		}
 	}
 
-	return strings.Join(attrs, "")
+	return string(attrs)
 }

--- a/src/internal/ui/metadata/metadata_linux.go
+++ b/src/internal/ui/metadata/metadata_linux.go
@@ -12,7 +12,7 @@ import (
 // see https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/fs.h
 // Inode flags (FS_IOC_GETFLAGS / FS_IOC_SETFLAGS)
 const (
-	AttrsSupported = 16
+	AttrsSupported = 22
 	//nolint:staticcheck // reference name
 	FS_SECRM_FL = 0x00000001 /* Secure deletion */
 	//nolint:staticcheck // reference name
@@ -29,7 +29,8 @@ const (
 	FS_NODUMP_FL = 0x00000040 /* do not dump file */
 	//nolint:staticcheck // reference name
 	FS_NOATIME_FL = 0x00000080 /* do not update atime */
-	/* End compression flags --- maybe not all used */
+	//nolint:staticcheck // reference name
+	FS_NOCOMP_FL = 0x00000400 /* Don't compress */
 	//nolint:staticcheck // reference name
 	FS_ENCRYPT_FL = 0x00000800 /* Encrypted file */
 	//nolint:staticcheck // reference name
@@ -56,6 +57,16 @@ const (
 	FS_EA_INODE_FL = 0x00200000 /* Inode used for large EA */
 	//nolint:staticcheck // reference name
 	FS_EOFBLOCKS_FL = 0x00400000 /* Reserved for ext4 */
+	//nolint:staticcheck // reference name
+	FS_NOCOW_FL = 0x00800000 /* Do not cow file */
+	//nolint:staticcheck // reference name
+	FS_DAX_FL = 0x02000000 /* Inode is DAX */
+	//nolint:staticcheck // reference name
+	FS_INLINE_DATA_FL = 0x10000000 /* Reserved for ext4 */
+	//nolint:staticcheck // reference name
+	FS_PROJINHERIT_FL = 0x20000000 /* Create with parents projid */
+	//nolint:staticcheck // reference name
+	FS_CASEFOLD_FL = 0x40000000 /* Folder is case insensitive */
 )
 
 // returns file attributes
@@ -80,55 +91,82 @@ func getFileAttributes(path string) (string, bool) {
 
 	return decodeChattr(flags), true
 }
+
+// list of letter and output order see in
+// lsattr sources https://github.com/tytso/e2fsprogs/blob/master/lib/e2p/pf.c
+//
+//nolint:gocognit // it's just mapping list of linux flags to lsattr letters
 func decodeChattr(flags uint32) string {
 	var attrs = make([]string, AttrsSupported)
 	for i := range attrs {
 		attrs[i] = "-"
 	}
+
 	if flags&FS_SECRM_FL != 0 {
-		attrs[0] = "s"
+		attrs[0] = "s" // Secure_Deletion
 	}
 	if flags&FS_UNRM_FL != 0 {
-		attrs[1] = "u"
-	}
-	if flags&FS_COMPR_FL != 0 {
-		attrs[2] = "c"
+		attrs[1] = "u" // Undelete
 	}
 	if flags&FS_SYNC_FL != 0 {
-		attrs[3] = "S"
-	}
-	if flags&FS_IMMUTABLE_FL != 0 {
-		attrs[4] = "i"
-	}
-	if flags&FS_APPEND_FL != 0 {
-		attrs[5] = "a"
-	}
-	if flags&FS_NODUMP_FL != 0 {
-		attrs[6] = "d"
-	}
-	if flags&FS_NOATIME_FL != 0 {
-		attrs[7] = "A"
-	}
-	if flags&FS_INDEX_FL != 0 {
-		attrs[9] = "I"
-	}
-	if flags&FS_JOURNAL_DATA_FL != 0 {
-		attrs[10] = "j"
-	}
-	if flags&FS_NOTAIL_FL != 0 {
-		attrs[11] = "t"
-	}
-	if flags&FS_TOPDIR_FL != 0 {
-		attrs[12] = "T"
-	}
-	if flags&FS_HUGE_FILE_FL != 0 {
-		attrs[13] = "h"
-	}
-	if flags&FS_EXTENT_FL != 0 {
-		attrs[14] = "e"
+		attrs[2] = "S" // Synchronous_Updates
 	}
 	if flags&FS_DIRSYNC_FL != 0 {
-		attrs[15] = "D"
+		attrs[3] = "D" // Synchronous_Directory_Updates
+	}
+	if flags&FS_IMMUTABLE_FL != 0 {
+		attrs[4] = "i" // Immutable
+	}
+	if flags&FS_APPEND_FL != 0 {
+		attrs[5] = "a" // Append_Only
+	}
+	if flags&FS_NODUMP_FL != 0 {
+		attrs[6] = "d" // No_Dump
+	}
+	if flags&FS_NOATIME_FL != 0 {
+		attrs[7] = "A" // No_Atime
+	}
+	if flags&FS_COMPR_FL != 0 {
+		attrs[8] = "c" // Compression_Requested
+	}
+	if flags&FS_ENCRYPT_FL != 0 {
+		attrs[9] = "E" // Encrypted
+	}
+	if flags&FS_JOURNAL_DATA_FL != 0 {
+		attrs[10] = "j" // Journaled_Data
+	}
+	if flags&FS_INDEX_FL != 0 {
+		attrs[11] = "I" // Indexed_directory
+	}
+	if flags&FS_NOTAIL_FL != 0 {
+		attrs[12] = "t" // No_Tailmerging
+	}
+	if flags&FS_TOPDIR_FL != 0 {
+		attrs[13] = "T" // Top_of_Directory_Hierarchies
+	}
+	if flags&FS_EXTENT_FL != 0 {
+		attrs[14] = "e" // Extents
+	}
+	if flags&FS_NOCOW_FL != 0 {
+		attrs[15] = "C" // No_COW
+	}
+	if flags&FS_DAX_FL != 0 {
+		attrs[16] = "x" // DAX
+	}
+	if flags&FS_CASEFOLD_FL != 0 {
+		attrs[17] = "F" // Casefold
+	}
+	if flags&FS_INLINE_DATA_FL != 0 {
+		attrs[18] = "N" // Inline_Data
+	}
+	if flags&FS_PROJINHERIT_FL != 0 {
+		attrs[19] = "P" // Project_Hierarchy
+	}
+	if flags&FS_VERITY_FL != 0 {
+		attrs[20] = "V" // Verity
+	}
+	if flags&FS_NOCOMP_FL != 0 {
+		attrs[21] = "m" // Dont_Compress
 	}
 
 	return strings.Join(attrs, "")

--- a/src/internal/ui/metadata/metadata_linux.go
+++ b/src/internal/ui/metadata/metadata_linux.go
@@ -1,0 +1,135 @@
+//go:build linux
+
+package metadata
+
+import (
+	"os"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// see https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/fs.h
+// Inode flags (FS_IOC_GETFLAGS / FS_IOC_SETFLAGS)
+const (
+	AttrsSupported = 16
+	//nolint:staticcheck // reference name
+	FS_SECRM_FL = 0x00000001 /* Secure deletion */
+	//nolint:staticcheck // reference name
+	FS_UNRM_FL = 0x00000002 /* Undelete */
+	//nolint:staticcheck // reference name
+	FS_COMPR_FL = 0x00000004 /* Compress file */
+	//nolint:staticcheck // reference name
+	FS_SYNC_FL = 0x00000008 /* Synchronous updates */
+	//nolint:staticcheck // reference name
+	FS_IMMUTABLE_FL = 0x00000010 /* Immutable file */
+	//nolint:staticcheck // reference name
+	FS_APPEND_FL = 0x00000020 /* writes to file may only append */
+	//nolint:staticcheck // reference name
+	FS_NODUMP_FL = 0x00000040 /* do not dump file */
+	//nolint:staticcheck // reference name
+	FS_NOATIME_FL = 0x00000080 /* do not update atime */
+	/* End compression flags --- maybe not all used */
+	//nolint:staticcheck // reference name
+	FS_ENCRYPT_FL = 0x00000800 /* Encrypted file */
+	//nolint:staticcheck // reference name
+	FS_BTREE_FL = 0x00001000 /* btree format dir */
+	//nolint:staticcheck // reference name
+	FS_INDEX_FL = 0x00001000 /* hash-indexed directory */
+	//nolint:staticcheck // reference name
+	FS_IMAGIC_FL = 0x00002000 /* AFS directory */
+	//nolint:staticcheck // reference name
+	FS_JOURNAL_DATA_FL = 0x00004000 /* Reserved for ext3 */
+	//nolint:staticcheck // reference name
+	FS_NOTAIL_FL = 0x00008000 /* file tail should not be merged */
+	//nolint:staticcheck // reference name
+	FS_DIRSYNC_FL = 0x00010000 /* dirsync behaviour (directories only) */
+	//nolint:staticcheck // reference name
+	FS_TOPDIR_FL = 0x00020000 /* Top of directory hierarchies*/
+	//nolint:staticcheck // reference name
+	FS_HUGE_FILE_FL = 0x00040000 /* Reserved for ext4 */
+	//nolint:staticcheck // reference name
+	FS_EXTENT_FL = 0x00080000 /* Extents */
+	//nolint:staticcheck // reference name
+	FS_VERITY_FL = 0x00100000 /* Verity protected inode */
+	//nolint:staticcheck // reference name
+	FS_EA_INODE_FL = 0x00200000 /* Inode used for large EA */
+	//nolint:staticcheck // reference name
+	FS_EOFBLOCKS_FL = 0x00400000 /* Reserved for ext4 */
+)
+
+// returns file attributes
+//
+// Parameters:
+// - path (string): file path
+//
+// Returns:
+// - string: formated attribute string
+// - bool: true in case attribute found
+func getFileAttributes(path string) (string, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	flags, err := unix.IoctlGetUint32(int(f.Fd()), unix.FS_IOC_GETFLAGS)
+	if err != nil {
+		return "", false
+	}
+
+	return decodeChattr(flags), true
+}
+func decodeChattr(flags uint32) string {
+	var attrs = make([]string, AttrsSupported)
+	for i := range attrs {
+		attrs[i] = "-"
+	}
+	if flags&FS_SECRM_FL != 0 {
+		attrs[0] = "s"
+	}
+	if flags&FS_UNRM_FL != 0 {
+		attrs[1] = "u"
+	}
+	if flags&FS_COMPR_FL != 0 {
+		attrs[2] = "c"
+	}
+	if flags&FS_SYNC_FL != 0 {
+		attrs[3] = "S"
+	}
+	if flags&FS_IMMUTABLE_FL != 0 {
+		attrs[4] = "i"
+	}
+	if flags&FS_APPEND_FL != 0 {
+		attrs[5] = "a"
+	}
+	if flags&FS_NODUMP_FL != 0 {
+		attrs[6] = "d"
+	}
+	if flags&FS_NOATIME_FL != 0 {
+		attrs[7] = "A"
+	}
+	if flags&FS_INDEX_FL != 0 {
+		attrs[9] = "I"
+	}
+	if flags&FS_JOURNAL_DATA_FL != 0 {
+		attrs[10] = "j"
+	}
+	if flags&FS_NOTAIL_FL != 0 {
+		attrs[11] = "t"
+	}
+	if flags&FS_TOPDIR_FL != 0 {
+		attrs[12] = "T"
+	}
+	if flags&FS_HUGE_FILE_FL != 0 {
+		attrs[13] = "h"
+	}
+	if flags&FS_EXTENT_FL != 0 {
+		attrs[14] = "e"
+	}
+	if flags&FS_DIRSYNC_FL != 0 {
+		attrs[15] = "D"
+	}
+
+	return strings.Join(attrs, "")
+}


### PR DESCRIPTION
for  linux build added linux attributes to metadata panel
issue #1363
<img width="774" height="586" alt="image" src="https://github.com/user-attachments/assets/b5806b94-3270-463c-bac9-cc1fcedae2ec" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File attributes are now shown in file metadata: Linux exposes decoded inode flags; macOS and Windows include platform-specific stubs to enable attributes when available.

* **Chores**
  * Updated dependency declaration in module metadata (classification change; version unchanged).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorukot/superfile/pull/1432)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->