### PR TITLE
test: some tests for modal error message

### DIFF
--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -453,7 +453,7 @@ func TestRunFileProcessorMutex(t *testing.T) {
 			assert.False(t, m.mutexErrorModal.TryLock())
 		})
 
-	t.Run("The mutex mutexErrorModal must be locked after failed processing, when we haven't todo files",
+	t.Run("The mutex mutexErrorModal must be unlocked after failed processing, when we haven't todo files",
 		func(t *testing.T) {
 			m := prepareLockUnlockTest(t)
 			finalizer := func(state processbar.ProcessState, reqID int) tea.Msg { return NewDeleteOperationMsg(state, reqID) }

--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -407,4 +408,64 @@ func cleanupWithRetry(t *testing.T, path, label string) {
 	if !ok {
 		t.Fatalf("Failed to remove %s %q: %v", label, path, lastErr)
 	}
+}
+
+func TestRunFileProcessorMutex(t *testing.T) {
+	t.Run("The mutex mutexErrorModal must be locked before run processor ", func(t *testing.T) {
+		m := prepareLockUnlockTest(t)
+		finalizer := func(state processbar.ProcessState, reqID int) tea.Msg { return NewDeleteOperationMsg(state, reqID) }
+		processor := func(items []string) (processbar.Process, []string) {
+			assert.False(t, m.mutexErrorModal.TryLock())
+			return processbar.NewProcess("1", "test", processbar.OpCopy, 10), []string{}
+		}
+		_ = m.runFileProcessor(processor, finalizer, []string{"file1", "file2"}, 1)
+	})
+
+	t.Run("The mutex mutexErrorModal must be unlocked after successful processing. We can see new Error modal window",
+		func(t *testing.T) {
+			m := prepareLockUnlockTest(t)
+			finalizer := func(state processbar.ProcessState, reqID int) tea.Msg { return NewDeleteOperationMsg(state, reqID) }
+			processor := func(items []string) (processbar.Process, []string) {
+				assert.False(t, m.mutexErrorModal.TryLock())
+				process := processbar.NewProcess("1", "test", processbar.OpCopy, 10)
+				process.State = processbar.Successful
+				return process, []string{}
+			}
+			result := m.runFileProcessor(processor, finalizer, []string{"file1", "file2"}, 1)
+			_, ok := result.(DeleteOperationMsg)
+			assert.True(t, ok)
+			assert.True(t, m.mutexErrorModal.TryLock())
+		})
+
+	t.Run("Failed processing. we have todo files. mutexErrorModal must be locked. Waits user choice",
+		func(t *testing.T) {
+			m := prepareLockUnlockTest(t)
+			finalizer := func(state processbar.ProcessState, reqID int) tea.Msg { return NewDeleteOperationMsg(state, reqID) }
+			processor := func(items []string) (processbar.Process, []string) {
+				assert.False(t, m.mutexErrorModal.TryLock())
+				process := processbar.NewProcess("1", "test", processbar.OpCopy, 10)
+				process.State = processbar.Failed
+				return process, []string{"test1"}
+			}
+			result := m.runFileProcessor(processor, finalizer, []string{"file1", "file2"}, 1)
+			_, ok := result.(SpfErrorModalUpdateMsg)
+			assert.True(t, ok)
+			assert.False(t, m.mutexErrorModal.TryLock())
+		})
+
+	t.Run("The mutex mutexErrorModal must be locked after failed processing, when we haven't todo files",
+		func(t *testing.T) {
+			m := prepareLockUnlockTest(t)
+			finalizer := func(state processbar.ProcessState, reqID int) tea.Msg { return NewDeleteOperationMsg(state, reqID) }
+			processor := func(items []string) (processbar.Process, []string) {
+				assert.False(t, m.mutexErrorModal.TryLock())
+				process := processbar.NewProcess("1", "test", processbar.OpCopy, 10)
+				process.State = processbar.Failed
+				return process, []string{}
+			}
+			result := m.runFileProcessor(processor, finalizer, []string{"file1", "file2"}, 1)
+			_, ok := result.(DeleteOperationMsg)
+			assert.True(t, ok)
+			assert.True(t, m.mutexErrorModal.TryLock())
+		})
 }

--- a/src/internal/model_test.go
+++ b/src/internal/model_test.go
@@ -18,7 +18,13 @@ import (
 
 	variable "github.com/yorukot/superfile/src/config"
 	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/ui/notify"
 	"github.com/yorukot/superfile/src/internal/ui/processbar"
+	"github.com/yorukot/superfile/src/internal/ui/prompt"
+	"github.com/yorukot/superfile/src/internal/ui/sidebar"
+	"github.com/yorukot/superfile/src/internal/ui/sortmodel"
+	"github.com/yorukot/superfile/src/internal/ui/spferror"
+	zoxideui "github.com/yorukot/superfile/src/internal/ui/zoxide"
 )
 
 /*
@@ -344,4 +350,84 @@ func TestAsyncPreviewPanelSync(t *testing.T) {
 	p.Send(tea.WindowSizeMsg{Width: 6 * DefaultTestModelWidth,
 		Height: 6 * DefaultTestModelHeight})
 	eventuallyEnsurePreviewContent(t, m, content1, "content should update to file1 after resize")
+}
+
+func prepareLockUnlockTest(t *testing.T) *model {
+	curTestDir := t.TempDir()
+
+	originalPreviewWidth := common.Config.FilePreviewWidth
+	common.Config.FilePreviewWidth = 0
+	t.Cleanup(func() {
+		common.Config.FilePreviewWidth = originalPreviewWidth
+	})
+
+	file1, content1 := filepath.Join(curTestDir, "file1.txt"), "File 1 content"
+	file2, content2 := filepath.Join(curTestDir, "file2.txt"), "File 2 content"
+	utils.SetupFilesWithData(t, []byte(content1), file1)
+	utils.SetupFilesWithData(t, []byte(content2), file2)
+
+	m := defaultTestModelWithFilePreview(curTestDir)
+	processor := func(items []string) (processbar.Process, []string) {
+		return processbar.NewProcess("1", "test", processbar.OpCopy, 10), []string{}
+	}
+	finalizer := func(state processbar.ProcessState, reqId int) tea.Msg { return NewPasteOperationMsg(state, reqId) }
+	m.spfError = spferror.New(true,
+		"error",
+		"ERROR TEST", spferror.NewFileListError([]string{file1}, processor, finalizer))
+	m.spfError.Open()
+	return m
+}
+
+func TestUnlockErrorModalMutex(t *testing.T) {
+	t.Run("after handling error mutex must be unlocked", func(t *testing.T) {
+		m := prepareLockUnlockTest(t)
+		m.mutexErrorModal.Lock()
+		assert.False(t, m.mutexErrorModal.TryLock())
+		m.handleKeyInput(tea.KeyPressMsg{Code: tea.KeyEnter})
+		assert.True(t, m.mutexErrorModal.TryLock())
+	})
+
+	t.Run("Error modal must be handled on top", func(t *testing.T) {
+		m := prepareLockUnlockTest(t)
+		m.mutexErrorModal.Lock()
+		m.typingModal = typingModal{open: true}
+		pModel := prompt.DefaultModel(10, 10)
+		pModel.Open(false)
+		m.promptModal = pModel
+		zModel := zoxideui.GenerateModel(nil, 50, 80)
+		zModel.Open()
+		m.zoxideModal = zModel
+		m.notifyModel = notify.New(true, "test", "test", notify.RenameAction)
+		m.sidebarModel = sidebar.New()
+		m.sidebarModel.PinnedItemRename()
+		m.getFocusedFilePanel().SearchBar.Focus()
+		m.sidebarModel.SearchBarFocus()
+		m.sortModal.Open(sortmodel.SortByName)
+		m.helpMenu.Open()
+
+		assert.False(t, m.mutexErrorModal.TryLock())
+		m.handleKeyInput(tea.KeyPressMsg{Code: tea.KeyEnter})
+		assert.True(t, m.mutexErrorModal.TryLock())
+	})
+	t.Run("Error modal must be rendered on top", func(t *testing.T) {
+		m := prepareLockUnlockTest(t)
+		m.mutexErrorModal.Lock()
+		m.typingModal = typingModal{open: true}
+		pModel := prompt.DefaultModel(10, 10)
+		pModel.Open(false)
+		m.promptModal = pModel
+		zModel := zoxideui.GenerateModel(nil, 50, 80)
+		zModel.Open()
+		m.zoxideModal = zModel
+		m.notifyModel = notify.New(true, "test", "test", notify.RenameAction)
+		m.sidebarModel = sidebar.New()
+		m.sidebarModel.PinnedItemRename()
+		m.getFocusedFilePanel().SearchBar.Focus()
+		m.sidebarModel.SearchBarFocus()
+		m.sortModal.Open(sortmodel.SortByName)
+		m.helpMenu.Open()
+
+		actual := m.updateRenderForOverlay("test render")
+		assert.Contains(t, actual, "ERROR TEST")
+	})
 }

--- a/src/internal/model_test.go
+++ b/src/internal/model_test.go
@@ -379,7 +379,7 @@ func prepareLockUnlockTest(t *testing.T) *model {
 }
 
 func TestUnlockErrorModalMutex(t *testing.T) {
-	t.Run("after handling error mutex must be unlocked", func(t *testing.T) {
+	t.Run("After handling error mutex must be unlocked", func(t *testing.T) {
 		m := prepareLockUnlockTest(t)
 		m.mutexErrorModal.Lock()
 		assert.False(t, m.mutexErrorModal.TryLock())


### PR DESCRIPTION
Added some tests for feature "error modal window" introduced in PR https://github.com/yorukot/superfile/pull/1408
issue #1360 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests validating mutex locking/unlocking during file processing and error-modal handling, including success/failure outcomes and returned messages.
  * Added tests ensuring the error modal is handled and rendered on top of other overlays and that interactions (e.g., Enter key) release the mutex as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorukot/superfile/pull/1435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->