### PR TITLE
feat: more informative content of the error text for file text preview

### DIFF
--- a/src/internal/ui/preview/render.go
+++ b/src/internal/ui/preview/render.go
@@ -2,6 +2,7 @@ package preview
 
 import (
 	"errors"
+	"fmt"
 	"image"
 	"io/fs"
 	"log/slog"
@@ -88,6 +89,10 @@ func (m *Model) renderImagePreview(r *rendering.Renderer, itemPath string, previ
 	}).AddLines(imageRender).Render(), rawTransmit
 }
 
+func renderPreviewError(err error) string {
+	return common.FilePreviewError + fmt.Sprintf("\n%s", err)
+}
+
 func (m *Model) renderTextPreview(r *rendering.Renderer, itemPath string,
 	previewWidth, previewHeight int,
 ) string {
@@ -96,7 +101,7 @@ func (m *Model) renderTextPreview(r *rendering.Renderer, itemPath string,
 		isText, err := common.IsTextFile(itemPath)
 		if err != nil {
 			slog.Error("Error while checking text file", "error", err)
-			return r.AddLines(common.FilePreviewError).Render()
+			return r.AddLines(renderPreviewError(err)).Render()
 		} else if !isText {
 			return r.AddLines(common.FilePreviewUnsupportedFormatText).Render()
 		}
@@ -105,7 +110,7 @@ func (m *Model) renderTextPreview(r *rendering.Renderer, itemPath string,
 	fileContent, err := utils.ReadFileContent(itemPath, previewWidth, previewHeight)
 	if err != nil {
 		slog.Error("Error open file", "error", err)
-		return r.AddLines(common.FilePreviewError).Render()
+		return r.AddLines(renderPreviewError(err)).Render()
 	}
 
 	if fileContent == "" {
@@ -128,7 +133,7 @@ func (m *Model) renderTextPreview(r *rendering.Renderer, itemPath string,
 		}
 		if err != nil {
 			slog.Error("Error render code highlight", "error", err)
-			return r.AddLines(common.FilePreviewError).Render()
+			return r.AddLines(renderPreviewError(err)).Render()
 		}
 	}
 


### PR DESCRIPTION
BEFORE:
<img width="1014" height="191" alt="image" src="https://github.com/user-attachments/assets/d79af247-a4e0-4099-bb46-3542563e5fe0" />

AFTER
<img width="1351" height="256" alt="image" src="https://github.com/user-attachments/assets/bfd781e6-5144-45a3-83c9-4737e2ee4d1a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file preview error messages with enhanced formatting and additional context about underlying issues for better error clarity when previews fail to render.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorukot/superfile/pull/1436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->