### PR TITLE
fix(sidebar): respect sidebar_sections and improve aesthetics

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -66,39 +66,39 @@ type ThemeType struct {
 type ConfigType struct {
 	Theme string `toml:"theme" comment:"More details are at https://superfile.dev/configure/superfile-config/\nchange your theme"`
 
-	Editor    string `toml:"editor" comment:"\nThe editor files will be opened with. (Leave blank to use the EDITOR environment variable)."`
+	Editor    string `toml:"editor"     comment:"\nThe editor files will be opened with. (Leave blank to use the EDITOR environment variable)."`
 	DirEditor string `toml:"dir_editor" comment:"\nThe editor directories will be opened with. (Leave blank to use the default editors)."`
 	// The table (map) for editor by file extension
 	OpenWith map[string]string `toml:"open_with" comment:"\nCustom open commands by file extension."`
 
-	AutoCheckUpdate        bool   `toml:"auto_check_update" comment:"\nAuto check for update"`
-	CdOnQuit               bool   `toml:"cd_on_quit" comment:"\nCd on quit (For more details, please check out https://superfile.dev/configure/superfile-config/#cd_on_quit)"`
+	AutoCheckUpdate        bool   `toml:"auto_check_update"         comment:"\nAuto check for update"`
+	CdOnQuit               bool   `toml:"cd_on_quit"                comment:"\nCd on quit (For more details, please check out https://superfile.dev/configure/superfile-config/#cd_on_quit)"`
 	DefaultOpenFilePreview bool   `toml:"default_open_file_preview" comment:"\nWhether to open file preview automatically every time superfile is opened."`
-	ShowImagePreview       bool   `toml:"show_image_preview" comment:"\nWhether to show image preview."`
-	ShowPanelFooterInfo    bool   `toml:"show_panel_footer_info" comment:"\nWhether to show additional footer info for file panel."`
-	DefaultDirectory       string `toml:"default_directory" comment:"\nThe path of the first file panel when superfile is opened."`
-	FileSizeUseSI          bool   `toml:"file_size_use_si" comment:"\nDisplay file sizes using powers of 1000 (kB, MB, GB) instead of powers of 1024 (KiB, MiB, GiB)."`
-	DefaultSortType        int    `toml:"default_sort_type" comment:"\nDefault sort type (0: Name, 1: Size, 2: Date Modified, 3: Type, 4: Natural)."`
-	SortOrderReversed      bool   `toml:"sort_order_reversed" comment:"\nDefault sort order (false: Ascending, true: Descending)."`
-	CaseSensitiveSort      bool   `toml:"case_sensitive_sort" comment:"\nCase sensitive sort by name (capital \"B\" comes before \"a\" if true)."`
-	ShellCloseOnSuccess    bool   `toml:"shell_close_on_success" comment:"\nWhether to close the shell on successful command execution."`
-	Debug                  bool   `toml:"debug" comment:"\nWhether to enable debug mode."`
+	ShowImagePreview       bool   `toml:"show_image_preview"        comment:"\nWhether to show image preview."`
+	ShowPanelFooterInfo    bool   `toml:"show_panel_footer_info"    comment:"\nWhether to show additional footer info for file panel."`
+	DefaultDirectory       string `toml:"default_directory"         comment:"\nThe path of the first file panel when superfile is opened."`
+	FileSizeUseSI          bool   `toml:"file_size_use_si"          comment:"\nDisplay file sizes using powers of 1000 (kB, MB, GB) instead of powers of 1024 (KiB, MiB, GiB)."`
+	DefaultSortType        int    `toml:"default_sort_type"         comment:"\nDefault sort type (0: Name, 1: Size, 2: Date Modified, 3: Type, 4: Natural)."`
+	SortOrderReversed      bool   `toml:"sort_order_reversed"       comment:"\nDefault sort order (false: Ascending, true: Descending)."`
+	CaseSensitiveSort      bool   `toml:"case_sensitive_sort"       comment:"\nCase sensitive sort by name (capital \"B\" comes before \"a\" if true)."`
+	ShellCloseOnSuccess    bool   `toml:"shell_close_on_success"    comment:"\nWhether to close the shell on successful command execution."`
+	Debug                  bool   `toml:"debug"                     comment:"\nWhether to enable debug mode."`
 	// IgnoreMissingFields controls whether warnings about missing TOML fields are suppressed.
-	IgnoreMissingFields   bool `toml:"ignore_missing_fields" comment:"\nWhether to ignore warnings about missing fields in the config file."`
-	PageScrollSize        int  `toml:"page_scroll_size" comment:"\nNumber of lines to scroll for PgUp/PgDown keys (0: full page, default behavior)."`
+	IgnoreMissingFields   bool `toml:"ignore_missing_fields"    comment:"\nWhether to ignore warnings about missing fields in the config file."`
+	PageScrollSize        int  `toml:"page_scroll_size"         comment:"\nNumber of lines to scroll for PgUp/PgDown keys (0: full page, default behavior)."`
 	FilePanelExtraColumns int  `toml:"file_panel_extra_columns" comment:"\nCount of extra columns in file panel in addition to file name. When option equal 0 then feature is disabled."`
-	FilePanelNamePercent  int  `toml:"file_panel_name_percent" comment:"\nPercentage of file panel width allocated to file names (25-100). Higher values give more space to names, less to extra columns."`
+	FilePanelNamePercent  int  `toml:"file_panel_name_percent"  comment:"\nPercentage of file panel width allocated to file names (25-100). Higher values give more space to names, less to extra columns."`
 
-	Nerdfont                bool     `toml:"nerdfont" comment:"\n================   Style =================\n\n If you don't have or don't want Nerdfont installed you can turn this off"`
-	ShowSelectIcons         bool     `toml:"show_select_icons" comment:"\nShow checkbox icons in select mode (requires nerdfont)"`
-	TransparentBackground   bool     `toml:"transparent_background" comment:"\nSet transparent background or not (this only work when your terminal background is transparent)"`
-	FilePreviewWidth        int      `toml:"file_preview_width" comment:"\nFile preview width allow '0' (this mean same as file panel),'x' x must be less than 10 and greater than 1 (This means that the width of the file preview will be one xth of the total width.)"`
+	Nerdfont                bool     `toml:"nerdfont"                   comment:"\n================   Style =================\n\n If you don't have or don't want Nerdfont installed you can turn this off"`
+	ShowSelectIcons         bool     `toml:"show_select_icons"          comment:"\nShow checkbox icons in select mode (requires nerdfont)"`
+	TransparentBackground   bool     `toml:"transparent_background"     comment:"\nSet transparent background or not (this only work when your terminal background is transparent)"`
+	FilePreviewWidth        int      `toml:"file_preview_width"         comment:"\nFile preview width allow '0' (this mean same as file panel),'x' x must be less than 10 and greater than 1 (This means that the width of the file preview will be one xth of the total width.)"`
 	EnableFilePreviewBorder bool     `toml:"enable_file_preview_border" comment:"\nEnable border around the file preview panel (default: false)"`
-	CodePreviewer           string   `toml:"code_previewer" comment:"\nWhether to use the builtin syntax highlighting with chroma or use bat. Values: \"\" for builtin chroma, \"bat\" for bat"`
-	SidebarWidth            int      `toml:"sidebar_width" comment:"\nThe length of the sidebar(excluding borders). If you don't find to display the sidebar, you can input 0 directly. If you want to display the value, please place it in the range of 5-20."`
-	SidebarSections         []string `toml:"sidebar_sections" comment:"\nOrder of sidebar sections (valid values: \"home\", \"pinned\", \"disks\").\nOnly sections included in this list will be displayed."`
+	CodePreviewer           string   `toml:"code_previewer"             comment:"\nWhether to use the builtin syntax highlighting with chroma or use bat. Values: \"\" for builtin chroma, \"bat\" for bat"`
+	SidebarWidth            int      `toml:"sidebar_width"              comment:"\nThe length of the sidebar(excluding borders). If you don't find to display the sidebar, you can input 0 directly. If you want to display the value, please place it in the range of 5-20."`
+	SidebarSections         []string `toml:"sidebar_sections"           comment:"\nOrder of sidebar sections (valid values: \"home\", \"pinned\", \"disks\").\nOnly sections included in this list will be displayed."`
 
-	BorderTop         string `toml:"border_top" comment:"\nBorder style"`
+	BorderTop         string `toml:"border_top"          comment:"\nBorder style"`
 	BorderBottom      string `toml:"border_bottom"`
 	BorderLeft        string `toml:"border_left"`
 	BorderRight       string `toml:"border_right"`
@@ -109,9 +109,9 @@ type ConfigType struct {
 	BorderMiddleLeft  string `toml:"border_middle_left"`
 	BorderMiddleRight string `toml:"border_middle_right"`
 
-	Metadata          bool `toml:"metadata" comment:"\n==========PLUGINS========== #\nPlugins means that you need to install some external dependencies to use them.\n\nShow more detailed metadata, please install exiftool before enabling this plugin!"`
+	Metadata          bool `toml:"metadata"            comment:"\n==========PLUGINS========== #\nPlugins means that you need to install some external dependencies to use them.\n\nShow more detailed metadata, please install exiftool before enabling this plugin!"`
 	EnableMD5Checksum bool `toml:"enable_md5_checksum" comment:"Enable MD5 checksum generation for files"`
-	ZoxideSupport     bool `toml:"zoxide_support" comment:"Zoxide support for the fast navigation"`
+	ZoxideSupport     bool `toml:"zoxide_support"      comment:"Zoxide support for the fast navigation"`
 }
 
 // GetIgnoreMissingFields reports whether warnings about missing TOML fields should be ignored.
@@ -125,12 +125,12 @@ type HotkeysType struct {
 	CdQuit  []string `toml:"cd_quit"`
 
 	// movement
-	ListUp   []string `toml:"list_up" comment:"movement"`
+	ListUp   []string `toml:"list_up"   comment:"movement"`
 	ListDown []string `toml:"list_down"`
 	PageUp   []string `toml:"page_up"`
 	PageDown []string `toml:"page_down"`
 
-	CloseFilePanel         []string `toml:"close_file_panel" comment:"file panel control"`
+	CloseFilePanel         []string `toml:"close_file_panel"          comment:"file panel control"`
 	CreateNewFilePanel     []string `toml:"create_new_file_panel"`
 	SplitFilePanel         []string `toml:"split_file_panel"`
 	NextFilePanel          []string `toml:"next_file_panel"`
@@ -146,19 +146,19 @@ type HotkeysType struct {
 	FilePanelItemCreate []string `toml:"file_panel_item_create" comment:"create file/directory and rename "`
 	FilePanelItemRename []string `toml:"file_panel_item_rename"`
 
-	CopyItems              []string `toml:"copy_items" comment:"file operate"`
+	CopyItems              []string `toml:"copy_items"               comment:"file operate"`
 	PasteItems             []string `toml:"paste_items"`
 	CutItems               []string `toml:"cut_items"`
 	DeleteItems            []string `toml:"delete_items"`
 	PermanentlyDeleteItems []string `toml:"permanently_delete_items"`
 
-	ExtractFile  []string `toml:"extract_file" comment:"compress and extract"`
+	ExtractFile  []string `toml:"extract_file"  comment:"compress and extract"`
 	CompressFile []string `toml:"compress_file"`
 
-	OpenFileWithEditor             []string `toml:"open_file_with_editor" comment:"editor"`
+	OpenFileWithEditor             []string `toml:"open_file_with_editor"              comment:"editor"`
 	OpenCurrentDirectoryWithEditor []string `toml:"open_current_directory_with_editor"`
 
-	PinnedDirectory []string `toml:"pinned_directory" comment:"other"`
+	PinnedDirectory []string `toml:"pinned_directory"  comment:"other"`
 	ToggleDotFile   []string `toml:"toggle_dot_file"`
 	ChangePanelMode []string `toml:"change_panel_mode"`
 	OpenHelpMenu    []string `toml:"open_help_menu"`

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -129,9 +129,9 @@ func wrapFilePreviewErrorMsg(msg string) string {
 func LoadPrerenderedVariables() {
 	divider := " " + strings.Repeat("─", SidebarDividerLength)
 	SideBarSuperfileTitle = SidebarTitleStyle.Render(" " + icon.SuperfileIcon + icon.Space + "superfile")
-	SideBarHomeDivider = SidebarTitleStyle.Render(icon.Browser) + SidebarDividerStyle.Render(divider)
-	SideBarPinnedDivider = SidebarTitleStyle.Render(icon.Pinned) + SidebarDividerStyle.Render(divider)
-	SideBarDisksDivider = SidebarTitleStyle.Render(icon.Disk) + SidebarDividerStyle.Render(divider)
+	SideBarHomeDivider = SidebarTitleStyle.Render(icon.Home+icon.Space+"Home") + SidebarDividerStyle.Render(divider)
+	SideBarPinnedDivider = SidebarTitleStyle.Render(icon.Pinned+icon.Space+"Pinned") + SidebarDividerStyle.Render(divider)
+	SideBarDisksDivider = SidebarTitleStyle.Render(icon.Disk+icon.Space+"Disks") + SidebarDividerStyle.Render(divider)
 
 	SideBarNoneText = SidebarStyle.Render(" " + icon.Error + icon.Space + "None")
 

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"strings"
 	"time"
 
 	"charm.land/lipgloss/v2"
@@ -9,6 +10,8 @@ import (
 )
 
 const (
+	// SidebarDividerLength defines the number of characters used for the horizontal divider in the sidebar.
+	SidebarDividerLength  = 20
 	WheelRunTime          = 5
 	DefaultCommandTimeout = 5000 * time.Millisecond
 	DateModifiedOption    = "Date Modified"
@@ -121,11 +124,14 @@ func wrapFilePreviewErrorMsg(msg string) string {
 // LoadThemeConfig() in style.go should be finished
 // loadConfigFile() in config_types.go should be finished
 // InitIcon() in config package in function.go should be finished
+// LoadPrerenderedVariables populates global UI component variables with their styled versions.
+// This should be called after theme and icons are initialized.
 func LoadPrerenderedVariables() {
+	divider := " " + strings.Repeat("─", SidebarDividerLength)
 	SideBarSuperfileTitle = SidebarTitleStyle.Render(" " + icon.SuperfileIcon + icon.Space + "superfile")
-	SideBarHomeDivider = SidebarTitleStyle.Render(icon.Browser) + SidebarDividerStyle.Render(" ────────────────────")
-	SideBarPinnedDivider = SidebarTitleStyle.Render(icon.Pinned) + SidebarDividerStyle.Render(" ────────────────────")
-	SideBarDisksDivider = SidebarTitleStyle.Render(icon.Disk) + SidebarDividerStyle.Render(" ────────────────────")
+	SideBarHomeDivider = SidebarTitleStyle.Render(icon.Browser) + SidebarDividerStyle.Render(divider)
+	SideBarPinnedDivider = SidebarTitleStyle.Render(icon.Pinned) + SidebarDividerStyle.Render(divider)
+	SideBarDisksDivider = SidebarTitleStyle.Render(icon.Disk) + SidebarDividerStyle.Render(divider)
 
 	SideBarNoneText = SidebarStyle.Render(" " + icon.Error + icon.Space + "None")
 

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -123,14 +123,9 @@ func wrapFilePreviewErrorMsg(msg string) string {
 // InitIcon() in config package in function.go should be finished
 func LoadPrerenderedVariables() {
 	SideBarSuperfileTitle = SidebarTitleStyle.Render(" " + icon.SuperfileIcon + icon.Space + "superfile")
-	SideBarHomeDivider = SidebarTitleStyle.Render(icon.Home+icon.Space+"Home") +
-		SidebarDividerStyle.Render(" ─────────────")
-
-	SideBarPinnedDivider = SidebarTitleStyle.Render(icon.Pinned+icon.Space+"Pinned") +
-		SidebarDividerStyle.Render(" ───────────")
-
-	SideBarDisksDivider = SidebarTitleStyle.Render(icon.Disk+icon.Space+"Disks") +
-		SidebarDividerStyle.Render(" ────────────")
+	SideBarHomeDivider = SidebarTitleStyle.Render(icon.Browser) + SidebarDividerStyle.Render(" ────────────────────")
+	SideBarPinnedDivider = SidebarTitleStyle.Render(icon.Pinned) + SidebarDividerStyle.Render(" ────────────────────")
+	SideBarDisksDivider = SidebarTitleStyle.Render(icon.Disk) + SidebarDividerStyle.Render(" ────────────────────")
 
 	SideBarNoneText = SidebarStyle.Render(" " + icon.Error + icon.Space + "None")
 

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -130,7 +130,11 @@ func LoadPrerenderedVariables() {
 	divider := " " + strings.Repeat("─", SidebarDividerLength)
 	SideBarSuperfileTitle = SidebarTitleStyle.Render(" " + icon.SuperfileIcon + icon.Space + "superfile")
 	SideBarHomeDivider = SidebarTitleStyle.Render(icon.Home+icon.Space+"Home") + SidebarDividerStyle.Render(divider)
-	SideBarPinnedDivider = SidebarTitleStyle.Render(icon.Pinned+icon.Space+"Pinned") + SidebarDividerStyle.Render(divider)
+	SideBarPinnedDivider = SidebarTitleStyle.Render(
+		icon.Pinned+icon.Space+"Pinned",
+	) + SidebarDividerStyle.Render(
+		divider,
+	)
 	SideBarDisksDivider = SidebarTitleStyle.Render(icon.Disk+icon.Space+"Disks") + SidebarDividerStyle.Render(divider)
 
 	SideBarNoneText = SidebarStyle.Render(" " + icon.Error + icon.Space + "None")

--- a/src/internal/ui/sidebar/directory_utils.go
+++ b/src/internal/ui/sidebar/directory_utils.go
@@ -87,7 +87,7 @@ func getPinnedDirectoriesWithIcon(pinnedMgr *PinnedManager) []directory {
 	return dirs
 }
 
-// Get filtered directories using fuzzy search logic with three haystacks.
+// getFilteredDirectories returns a list of directories that match the fuzzy search query across all sections.
 func getFilteredDirectories(query string, pinnedMgr *PinnedManager, sections []string) []directory {
 	return formDirctorySlice(
 		fuzzySearch(query, getWellKnownDirectories()),
@@ -97,6 +97,8 @@ func getFilteredDirectories(query string, pinnedMgr *PinnedManager, sections []s
 	)
 }
 
+// formDirctorySlice assembles the final list of directories for the sidebar based on the configured sections.
+// It ensures that dividers are only added between non-empty sections.
 func formDirctorySlice(homeDirectories []directory, pinnedDirectories []directory,
 	diskDirectories []directory, sections []string) []directory {
 	// Preallocation for efficiency

--- a/src/internal/ui/sidebar/directory_utils.go
+++ b/src/internal/ui/sidebar/directory_utils.go
@@ -106,16 +106,26 @@ func formDirctorySlice(homeDirectories []directory, pinnedDirectories []director
 	for _, section := range sections {
 		switch section {
 		case utils.SidebarSectionHome:
-			if len(directories) > 0 {
-				directories = append(directories, homeDividerDir)
+			if len(homeDirectories) > 0 {
+				if len(directories) > 0 {
+					directories = append(directories, homeDividerDir)
+				}
+				directories = append(directories, homeDirectories...)
 			}
-			directories = append(directories, homeDirectories...)
 		case utils.SidebarSectionPinned:
-			directories = append(directories, pinnedDividerDir)
-			directories = append(directories, pinnedDirectories...)
+			if len(pinnedDirectories) > 0 {
+				if len(directories) > 0 {
+					directories = append(directories, pinnedDividerDir)
+				}
+				directories = append(directories, pinnedDirectories...)
+			}
 		case utils.SidebarSectionDisks:
-			directories = append(directories, diskDividerDir)
-			directories = append(directories, diskDirectories...)
+			if len(diskDirectories) > 0 {
+				if len(directories) > 0 {
+					directories = append(directories, diskDividerDir)
+				}
+				directories = append(directories, diskDirectories...)
+			}
 		}
 	}
 

--- a/src/internal/ui/sidebar/directory_utils.go
+++ b/src/internal/ui/sidebar/directory_utils.go
@@ -101,35 +101,36 @@ func getFilteredDirectories(query string, pinnedMgr *PinnedManager, sections []s
 // It ensures that dividers are only added between non-empty sections.
 func formDirctorySlice(homeDirectories []directory, pinnedDirectories []directory,
 	diskDirectories []directory, sections []string) []directory {
-	// Preallocation for efficiency
 	totalCapacity := len(homeDirectories) + len(pinnedDirectories) + len(diskDirectories) + directoryCapacityForDividers
 	directories := make([]directory, 0, totalCapacity)
 
 	for _, section := range sections {
 		switch section {
 		case utils.SidebarSectionHome:
-			if len(homeDirectories) > 0 {
-				if len(directories) > 0 {
-					directories = append(directories, homeDividerDir)
-				}
-				directories = append(directories, homeDirectories...)
-			}
+			directories = appendSection(directories, utils.SidebarSectionHome, homeDividerDir, homeDirectories)
 		case utils.SidebarSectionPinned:
-			if len(pinnedDirectories) > 0 {
-				if len(directories) > 0 {
-					directories = append(directories, pinnedDividerDir)
-				}
-				directories = append(directories, pinnedDirectories...)
-			}
+			directories = appendSection(directories, utils.SidebarSectionPinned, pinnedDividerDir, pinnedDirectories)
 		case utils.SidebarSectionDisks:
-			if len(diskDirectories) > 0 {
-				if len(directories) > 0 {
-					directories = append(directories, diskDividerDir)
-				}
-				directories = append(directories, diskDirectories...)
-			}
+			directories = appendSection(directories, utils.SidebarSectionDisks, diskDividerDir, diskDirectories)
 		}
 	}
 
 	return directories
+}
+
+func appendSection(dirs []directory, sectionName string, divider directory, items []directory) []directory {
+	if len(items) == 0 {
+		return dirs
+	}
+
+	if len(dirs) > 0 {
+		dirs = append(dirs, divider)
+	}
+
+	for i := range items {
+		items[i].Section = sectionName
+		dirs = append(dirs, items[i])
+	}
+
+	return dirs
 }

--- a/src/internal/ui/sidebar/disk_utils.go
+++ b/src/internal/ui/sidebar/disk_utils.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shirou/gopsutil/v4/disk"
 
+	"github.com/yorukot/superfile/src/config/icon"
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
@@ -72,14 +73,21 @@ func diskName(mountPoint string) string {
 	// In windows we dont want to use filepath.Base as it returns "\" for when
 	// mountPoint is any drive root "C:", "D:", etc. Hence causing same name
 	// for each drive
-	if runtime.GOOS == utils.OsWindows {
-		return mountPoint
+	name := mountPoint
+	iconStr := icon.Disk
+	if runtime.GOOS != utils.OsWindows {
+		if mountPoint == "/" {
+			name = "Root"
+			iconStr = icon.Terminal
+		} else {
+			// This might cause duplicate names in case you mount two devices in
+			// /mnt/usb and /mnt/dir2/usb . Full mountpoint is a more accurate way
+			// but that results in messy UI, hence we do this.
+			name = filepath.Base(mountPoint)
+		}
 	}
 
-	// This might cause duplicate names in case you mount two devices in
-	// /mnt/usb and /mnt/dir2/usb . Full mountpoint is a more accurate way
-	// but that results in messy UI, hence we do this.
-	return filepath.Base(mountPoint)
+	return iconStr + icon.Space + name
 }
 
 func diskLocation(mountPoint string) string {

--- a/src/internal/ui/sidebar/disk_utils.go
+++ b/src/internal/ui/sidebar/disk_utils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
-// Get external media directories
+// getExternalMediaFolders retrieves a list of mounted physical drives and external media.
 func getExternalMediaFolders() []directory {
 	// only get physical drives
 	parts, err := disk.Partitions(false)
@@ -35,6 +35,7 @@ func getExternalMediaFolders() []directory {
 	return disks
 }
 
+// shouldListDisk determines whether a given mount point should be displayed in the sidebar's disks section.
 func shouldListDisk(mountPoint string) bool {
 	if runtime.GOOS == utils.OsWindows {
 		// We need to get C:, D: drive etc in the list
@@ -69,6 +70,7 @@ func shouldListDisk(mountPoint string) bool {
 		strings.HasPrefix(mountPoint, "/Volumes")
 }
 
+// diskName generates a display name for a disk based on its mount point and the operating system.
 func diskName(mountPoint string) string {
 	// In windows we dont want to use filepath.Base as it returns "\" for when
 	// mountPoint is any drive root "C:", "D:", etc. Hence causing same name
@@ -90,6 +92,7 @@ func diskName(mountPoint string) string {
 	return iconStr + icon.Space + name
 }
 
+// diskLocation returns the normalized path for a disk's mount point.
 func diskLocation(mountPoint string) string {
 	// In windows if you are in "C:\some\path", "cd C:" will not cd to root of C: drive
 	// but "cd C:\" will

--- a/src/internal/ui/sidebar/navigation.go
+++ b/src/internal/ui/sidebar/navigation.go
@@ -96,6 +96,10 @@ func (s *Model) firstRenderedIndex(endIndex int) int {
 }
 
 func (s *Model) updateRenderIndex() {
+	if len(s.directories) == 0 {
+		s.renderIndex = 0
+		return
+	}
 	// Case I : New cursor moved above current renderable range
 	if s.cursor < s.renderIndex {
 		// We will start rendering from there

--- a/src/internal/ui/sidebar/navigation_test.go
+++ b/src/internal/ui/sidebar/navigation_test.go
@@ -356,7 +356,7 @@ func Test_listUp(t *testing.T) {
 			mainPanelHeight:     10,
 			expectedCursor:      6, // Should skip all dividers and move to item before dividers
 			expectedRenderIndex: 5, // Should adjust render index accordingly
-			explanation:         "When encountering multiple consecutive dividers, cursor should skip all of them",
+			explanation:         "When moving up across a divider, cursor should skip it and land on the last home directory",
 		},
 		{
 			name:                "No actual directories case",
@@ -433,7 +433,7 @@ func Test_listDown(t *testing.T) {
 			mainPanelHeight:     10,
 			expectedCursor:      6, // Should skip all dividers and move to item after dividers
 			expectedRenderIndex: 2, // Should adjust render index accordingly
-			explanation:         "When encountering multiple consecutive dividers, cursor should skip all of them",
+			explanation:         "When moving down across a divider, cursor should skip it and land on the first disk directory",
 		},
 		{
 			name:                "No actual directories case",

--- a/src/internal/ui/sidebar/navigation_test.go
+++ b/src/internal/ui/sidebar/navigation_test.go
@@ -271,10 +271,10 @@ func Test_updateRenderIndex(t *testing.T) {
 		},
 		{
 			name:                "Edge case: Empty sidebar",
-			sidebar:             defaultTestModel(2, 0, 0, 0, 0, 0),
+			sidebar:             defaultTestModel(0, 0, 0, 0, 0, 0),
 			mainPanelHeight:     10,
-			expectedRenderIndex: 3,
-			explanation:         "With empty sidebar and cursor=2, renderIndex should become 3",
+			expectedRenderIndex: 0,
+			explanation:         "With empty sidebar, renderIndex should remain at 0",
 		},
 		{
 			name:                "Case I and III overlap: Cursor exactly at current renderIndex",

--- a/src/internal/ui/sidebar/navigation_test.go
+++ b/src/internal/ui/sidebar/navigation_test.go
@@ -66,8 +66,8 @@ func Test_lastRenderIndex(t *testing.T) {
 			sidebar:           sidebarB,
 			mainPanelHeight:   12,
 			startIndex:        0,
-			expectedLastIndex: 4,
-			explanation:       "3(initialHeight) + 1 (0-homedir) + 3(1-pinned divider) + 3 (2-diskdivider) + 2 (3-4 diskdirs)",
+			expectedLastIndex: 6,
+			explanation:       "3(initialHeight) + 1 (0-homedir) + 3(1-pinned divider) + 3 (2-diskdivider) + 4 (3-6 diskdirs)",
 		},
 	}
 
@@ -159,17 +159,17 @@ func Test_firstRenderIndex(t *testing.T) {
 			name:               "Only disk directories case",
 			sidebar:            sidebarD,
 			mainPanelHeight:    8,
-			endIndex:           4, // Last disk dir
-			expectedFirstIndex: 2, // Disk divider
-			explanation:        "3(InitialHeight) + 3(2-4 disk dirs)",
+			endIndex:           2, // Last disk dir
+			expectedFirstIndex: 0, // First disk dir
+			explanation:        "3(InitialHeight) + 3(0-2 disk dirs)",
 		},
 		{
 			name:               "Empty sidebar case",
 			sidebar:            sidebarE,
 			mainPanelHeight:    10,
-			endIndex:           1, // Disk divider
-			expectedFirstIndex: 0, // Pinned divider
-			explanation:        "Empty sidebar should show all dividers",
+			endIndex:           2, // Last divider index
+			expectedFirstIndex: 3, //
+			explanation:        "Empty sidebar should show all dividers except first",
 		},
 		{
 			name:               "End index at the start",
@@ -271,10 +271,10 @@ func Test_updateRenderIndex(t *testing.T) {
 		},
 		{
 			name:                "Edge case: Empty sidebar",
-			sidebar:             defaultTestModel(1, 0, 0, 0, 0, 0),
+			sidebar:             defaultTestModel(2, 0, 0, 0, 0, 0),
 			mainPanelHeight:     10,
-			expectedRenderIndex: 0, // No change needed for empty sidebar
-			explanation:         "With empty sidebar, renderIndex should remain at 0",
+			expectedRenderIndex: 3,
+			explanation:         "With empty sidebar, renderIndex should remain at 3",
 		},
 		{
 			name:                "Case I and III overlap: Cursor exactly at current renderIndex",
@@ -354,8 +354,8 @@ func Test_listUp(t *testing.T) {
 			name:                "Skip multiple consecutive dividers",
 			sidebar:             defaultTestModel(7, 5, 0, 5, 0, 5),
 			mainPanelHeight:     10,
-			expectedCursor:      4, // Should skip all dividers and move to item before dividers
-			expectedRenderIndex: 4, // Should adjust render index accordingly
+			expectedCursor:      6, // Should skip all dividers and move to item before dividers
+			expectedRenderIndex: 5, // Should adjust render index accordingly
 			explanation:         "When encountering multiple consecutive dividers, cursor should skip all of them",
 		},
 		{
@@ -431,10 +431,9 @@ func Test_listDown(t *testing.T) {
 			name:                "Skip multiple consecutive dividers",
 			sidebar:             defaultTestModel(4, 0, 0, 5, 0, 5),
 			mainPanelHeight:     10,
-			expectedCursor:      7, // Should skip all dividers and move to item after dividers
-			expectedRenderIndex: 5, // Should adjust render index accordingly
-			// 3 (Initial Height) 6(5,6 - pinned and disk divider), 1 (7-Disk dir)
-			explanation: "When encountering multiple consecutive dividers, cursor should skip all of them",
+			expectedCursor:      6, // Should skip all dividers and move to item after dividers
+			expectedRenderIndex: 2, // Should adjust render index accordingly
+			explanation:         "When encountering multiple consecutive dividers, cursor should skip all of them",
 		},
 		{
 			name:                "No actual directories case",

--- a/src/internal/ui/sidebar/navigation_test.go
+++ b/src/internal/ui/sidebar/navigation_test.go
@@ -67,7 +67,7 @@ func Test_lastRenderIndex(t *testing.T) {
 			mainPanelHeight:   12,
 			startIndex:        0,
 			expectedLastIndex: 6,
-			explanation:       "3(initialHeight) + 1 (0-homedir) + 3(1-diskdivider) + 5 (2-6 diskdirs, partial fit)",
+			explanation:       "3(initialHeight) + 1 (0-homedir) + 3(1-diskdivider) + 5 (2-6 diskdirs)",
 		},
 	}
 
@@ -167,9 +167,9 @@ func Test_firstRenderIndex(t *testing.T) {
 			name:               "Empty sidebar case",
 			sidebar:            sidebarE,
 			mainPanelHeight:    10,
-			endIndex:           2, // Last divider index
-			expectedFirstIndex: 3, //
-			explanation:        "Empty sidebar should show all dividers except first",
+			endIndex:           2,
+			expectedFirstIndex: 3,
+			explanation:        "An entirely empty sidebar produces no dividers (empty directories slice), so firstRenderedIndex(2) treats endIndex=2 as out of bounds and returns endIndex+1",
 		},
 		{
 			name:               "End index at the start",
@@ -271,10 +271,10 @@ func Test_updateRenderIndex(t *testing.T) {
 		},
 		{
 			name:                "Edge case: Empty sidebar",
-			sidebar:             defaultTestModel(0, 0, 0, 0, 0, 0),
+			sidebar:             defaultTestModel(2, 0, 0, 0, 0, 0),
 			mainPanelHeight:     10,
-			expectedRenderIndex: 1,
-			explanation:         "With empty sidebar, renderIndex should be 1 according to current logic",
+			expectedRenderIndex: 3,
+			explanation:         "With empty sidebar and cursor=2, renderIndex should become 3",
 		},
 		{
 			name:                "Case I and III overlap: Cursor exactly at current renderIndex",
@@ -351,12 +351,12 @@ func Test_listUp(t *testing.T) {
 			explanation: "When at the top, cursor should wrap to the bottom",
 		},
 		{
-			name:                "Skip multiple consecutive dividers",
+			name:                "Move up within disk section",
 			sidebar:             defaultTestModel(7, 5, 0, 5, 0, 5),
 			mainPanelHeight:     10,
 			expectedCursor:      6, // Should skip all dividers and move to item before dividers
 			expectedRenderIndex: 5, // Should adjust render index accordingly
-			explanation:         "When moving up from cursor 7 lands on the previous disk directory",
+			explanation:         "When moving up from cursor 7, lands on the previous disk directory (expectedCursor = 6)",
 		},
 		{
 			name:                "No actual directories case",

--- a/src/internal/ui/sidebar/navigation_test.go
+++ b/src/internal/ui/sidebar/navigation_test.go
@@ -67,7 +67,7 @@ func Test_lastRenderIndex(t *testing.T) {
 			mainPanelHeight:   12,
 			startIndex:        0,
 			expectedLastIndex: 6,
-			explanation:       "3(initialHeight) + 1 (0-homedir) + 3(1-pinned divider) + 3 (2-diskdivider) + 4 (3-6 diskdirs)",
+			explanation:       "3(initialHeight) + 1 (0-homedir) + 3(1-diskdivider) + 3 (2-5 diskdirs, partial fit)",
 		},
 	}
 

--- a/src/internal/ui/sidebar/navigation_test.go
+++ b/src/internal/ui/sidebar/navigation_test.go
@@ -67,7 +67,7 @@ func Test_lastRenderIndex(t *testing.T) {
 			mainPanelHeight:   12,
 			startIndex:        0,
 			expectedLastIndex: 6,
-			explanation:       "3(initialHeight) + 1 (0-homedir) + 3(1-diskdivider) + 3 (2-5 diskdirs, partial fit)",
+			explanation:       "3(initialHeight) + 1 (0-homedir) + 3(1-diskdivider) + 5 (2-6 diskdirs, partial fit)",
 		},
 	}
 
@@ -271,10 +271,10 @@ func Test_updateRenderIndex(t *testing.T) {
 		},
 		{
 			name:                "Edge case: Empty sidebar",
-			sidebar:             defaultTestModel(2, 0, 0, 0, 0, 0),
+			sidebar:             defaultTestModel(0, 0, 0, 0, 0, 0),
 			mainPanelHeight:     10,
-			expectedRenderIndex: 3,
-			explanation:         "With empty sidebar, renderIndex should remain at 3",
+			expectedRenderIndex: 1,
+			explanation:         "With empty sidebar, renderIndex should be 1 according to current logic",
 		},
 		{
 			name:                "Case I and III overlap: Cursor exactly at current renderIndex",
@@ -356,7 +356,7 @@ func Test_listUp(t *testing.T) {
 			mainPanelHeight:     10,
 			expectedCursor:      6, // Should skip all dividers and move to item before dividers
 			expectedRenderIndex: 5, // Should adjust render index accordingly
-			explanation:         "When moving up across a divider, cursor should skip it and land on the last home directory",
+			explanation:         "When moving up from cursor 7 lands on the previous disk directory",
 		},
 		{
 			name:                "No actual directories case",

--- a/src/internal/ui/sidebar/type.go
+++ b/src/internal/ui/sidebar/type.go
@@ -5,6 +5,7 @@ import "charm.land/bubbles/v2/textinput"
 type directory struct {
 	Location string `json:"location"`
 	Name     string `json:"name"`
+	Section  string `json:"-"`
 }
 
 type Model struct {

--- a/src/internal/ui/sidebar/utils.go
+++ b/src/internal/ui/sidebar/utils.go
@@ -1,6 +1,10 @@
 package sidebar
 
-import "log/slog"
+import (
+	"log/slog"
+
+	"github.com/yorukot/superfile/src/pkg/utils"
+)
 
 // isDivider returns true if the directory is one of the section dividers.
 func (d directory) isDivider() bool {
@@ -75,37 +79,17 @@ func (s *Model) GetCurrentDirectoryLocation() string {
 // pinnedIndexRange calculates the start and end indices of the pinned directories section.
 // Returns (-1, -1) if the section is missing or empty.
 func (s *Model) pinnedIndexRange() (int, int) {
-	// pinned directories start after well-known directories and the divider
-	// Can't use getPinnedDirectories() here, as if we are in search mode, we would be showing
-	// and having less directories in sideBar.directories slice
-
-	// TODO : This is inefficient to iterate each time for this.
-	// This information can be kept precomputed
-	pinnedDividerIdx := -1
+	begin, end := -1, -1
 	for i, d := range s.directories {
-		if d == pinnedDividerDir {
-			pinnedDividerIdx = i
-			break
+		if d.Section == utils.SidebarSectionPinned {
+			if begin == -1 {
+				begin = i
+			}
+			end = i
 		}
 	}
 
-	if pinnedDividerIdx == -1 {
-		return -1, -1
-	}
-
-	pinnedEndIdx := len(s.directories) - 1
-	for i := pinnedDividerIdx + 1; i < len(s.directories); i++ {
-		if s.directories[i].isDivider() {
-			pinnedEndIdx = i - 1
-			break
-		}
-	}
-
-	if pinnedDividerIdx+1 > pinnedEndIdx {
-		return -1, -1
-	}
-
-	return pinnedDividerIdx + 1, pinnedEndIdx
+	return begin, end
 }
 
 // GetWidth returns the current width of the sidebar.

--- a/src/internal/ui/sidebar/utils_test.go
+++ b/src/internal/ui/sidebar/utils_test.go
@@ -187,15 +187,19 @@ func TestSidebarSectionsVisibility(t *testing.T) {
 				tt.sections,
 			)
 			assert.Len(t, dirs, tt.expectedLen)
-			if tt.expectHomeDiv {
-				foundHomeDiv := false
-				for _, d := range dirs {
-					if d == homeDividerDir {
-						foundHomeDiv = true
-						break
-					}
+
+			foundHomeDiv := false
+			for _, d := range dirs {
+				if d == homeDividerDir {
+					foundHomeDiv = true
+					break
 				}
+			}
+
+			if tt.expectHomeDiv {
 				assert.True(t, foundHomeDiv, "Expected home divider to be present")
+			} else {
+				assert.False(t, foundHomeDiv, "Expected home divider to be absent")
 			}
 		})
 	}

--- a/src/internal/ui/sidebar/utils_test.go
+++ b/src/internal/ui/sidebar/utils_test.go
@@ -112,17 +112,17 @@ func Test_resetCursor(t *testing.T) {
 		{
 			name:              "Only Pinned directories",
 			curSideBar:        defaultTestModel(0, 0, 10, 0, 10, 0),
-			expectedCursorPos: 1, // After pinned divider
+			expectedCursorPos: 0, // First pinned (no divider)
 		},
 		{
 			name:              "All kind of directories",
 			curSideBar:        defaultTestModel(0, 0, 10, 10, 10, 10),
-			expectedCursorPos: 0, // First home
+			expectedCursorPos: 0, // First home (no divider)
 		},
 		{
 			name:              "Only Disk",
 			curSideBar:        defaultTestModel(0, 0, 10, 0, 0, 10),
-			expectedCursorPos: 2, // After pinned and dist divider
+			expectedCursorPos: 0, // First disk (no divider)
 		},
 		{
 			name:              "Empty Sidebar",
@@ -153,7 +153,7 @@ func TestSidebarSectionsVisibility(t *testing.T) {
 			name:        "Only one section (pinned)",
 			sections:    []string{utils.SidebarSectionPinned},
 			pinnedDirs:  5,
-			expectedLen: 6, // divider + 5 dirs
+			expectedLen: 5, // no divider for first section
 		},
 		{
 			name:        "No sections",
@@ -161,11 +161,19 @@ func TestSidebarSectionsVisibility(t *testing.T) {
 			expectedLen: 0,
 		},
 		{
+			name:          "Home section as first item should NOT have divider",
+			sections:      []string{utils.SidebarSectionHome, utils.SidebarSectionPinned},
+			homeDirs:      1,
+			pinnedDirs:    1,
+			expectedLen:   3, // 1 home + pinned div + 1 pinned
+			expectHomeDiv: false,
+		},
+		{
 			name:          "Reordered sections (pinned, home)",
 			sections:      []string{utils.SidebarSectionPinned, utils.SidebarSectionHome},
 			homeDirs:      3,
 			pinnedDirs:    3,
-			expectedLen:   1 + 3 + 1 + 3, // pinned divider + 3 pinned + home divider + 3 home
+			expectedLen:   3 + 1 + 3, // 3 pinned + home divider + 3 home
 			expectHomeDiv: true,
 		},
 	}


### PR DESCRIPTION
This PR fixes a #1440 bug where the 'sidebar_sections' configuration was partially ignored and improves the sidebar's aesthetics.

Key changes:
- Ensured 'home' divider is always shown (or skipped appropriately) based on configuration.
- Improved 'Disks' section by renaming the root partition to 'Root' and adding a Terminal icon.
- Added disk icons to all entries in the 'Disks' section.
- Standardized divider lengths for a more aligned look.
- Refined rendering logic to avoid redundant blank lines and maintain an elegant minimalist layout.

### screenshots

actual default, `sidebar_sections = ["home", "pinned", "disks"]`
<img width="164" height="448" alt="image" src="https://github.com/user-attachments/assets/2e83fabc-49f2-479d-8c93-9043de49e98c" />  <img width="164" height="448" alt="image" src="https://github.com/user-attachments/assets/1bc832ff-08f8-4c72-a385-392b0f1cd20d" />

 
`sidebar_sections = ["pinned","home"]`
<img width="164" height="448" alt="image" src="https://github.com/user-attachments/assets/6c74835b-63a2-4c37-854f-6ae0fa2065b4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Sidebar dividers now use a uniform length and consistent formatting.
  * Section titles simplified to icon-only headings with a shared underline style.
  * Empty sidebar sections no longer show stray dividers.
  * Disk entries now display with icon-prefixed labels for clearer identification.

* **Tests**
  * Updated sidebar navigation and visibility tests to match the revised divider and title behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorukot/superfile/pull/1442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->