### PR TITLE
docs(readme): fix broken demo GIF path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 | Perform common operations  |
 | -------------------------- |
-| ![](website/src/assets/demo.gif) |
+| ![](asset/readme/demo.gif) |
 
 ## Content
 


### PR DESCRIPTION
The demo GIF referenced in the current README.md is broken.

See:
<img width="906" height="232" alt="image" src="https://github.com/user-attachments/assets/c07773f9-9835-43a6-b033-8ddb70b66e13" />


This PR updates the path to the right `demo.gif` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated demo image reference in project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->