### PR TITLE
feat: add uninstall.sh script for linux and macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,19 +200,9 @@ You can turn this off, by setting `auto_check_update` to false in superfile conf
 
 ### macOS and Linux
 
-On macOS and Linux, you can uninstall superfile by simply removing the binary. If you installed superfile with sudo, run:
-
 ```bash
-sudo rm /usr/local/bin/spf
+bash -c "$(curl -sLo- https://superfile.dev/uninstall.sh)"
 ```
-
-If you installed superfile without sudo, run:
-
-```bash
-rm ~/.local/bin/spf
-```
-
-If you don't rember, just try removing both.
 
 ### Window
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ You can turn this off, by setting `auto_check_update` to false in superfile conf
 bash -c "$(curl -sLo- https://superfile.dev/uninstall.sh)"
 ```
 
+If you want to inspect the script, see : [uninstall.sh](./website/public/uninstall.sh)
+
 ### Window
 
 To uninstall superfile on Windows, use this powershell script.

--- a/website/public/uninstall.sh
+++ b/website/public/uninstall.sh
@@ -32,6 +32,7 @@ echo -e '
 '
 
 found=0
+failed=0
 
 # Remove binary from /usr/local/bin
 if [ -f /usr/local/bin/spf ]; then
@@ -39,6 +40,7 @@ if [ -f /usr/local/bin/spf ]; then
     echo -e "${bright_yellow}Removing ${cyan}/usr/local/bin/spf${bright_yellow}...${nc}"
     if ! sudo rm /usr/local/bin/spf; then
         echo -e "${red}❌ Failed to remove ${white}/usr/local/bin/spf${red}. Do you have sudo permissions?${nc}"
+        failed=1
     else
         echo -e "${bright_green}✔ Removed ${white}/usr/local/bin/spf${nc}"
     fi
@@ -50,46 +52,76 @@ if [ -f "$HOME/.local/bin/spf" ]; then
     echo -e "${bright_yellow}Removing ${cyan}~/.local/bin/spf${bright_yellow}...${nc}"
     if ! rm "$HOME/.local/bin/spf"; then
         echo -e "${red}❌ Failed to remove ${white}~/.local/bin/spf${nc}"
+        failed=1
     else
         echo -e "${bright_green}✔ Removed ${white}~/.local/bin/spf${nc}"
     fi
 fi
 
-# Remove config directory
+# Remove config directory (Linux)
 if [ -d "$HOME/.config/superfile" ]; then
     found=1
     echo -e "${bright_yellow}Removing ${cyan}~/.config/superfile${bright_yellow}...${nc}"
     if ! rm -rf "$HOME/.config/superfile"; then
         echo -e "${red}❌ Failed to remove ${white}~/.config/superfile${nc}"
+        failed=1
     else
         echo -e "${bright_green}✔ Removed ${white}~/.config/superfile${nc}"
     fi
 fi
 
-# Remove data directory
+# Remove data directory (Linux)
 if [ -d "$HOME/.local/share/superfile" ]; then
     found=1
     echo -e "${bright_yellow}Removing ${cyan}~/.local/share/superfile${bright_yellow}...${nc}"
     if ! rm -rf "$HOME/.local/share/superfile"; then
         echo -e "${red}❌ Failed to remove ${white}~/.local/share/superfile${nc}"
+        failed=1
     else
         echo -e "${bright_green}✔ Removed ${white}~/.local/share/superfile${nc}"
     fi
 fi
 
-# Remove cache directory
+# Remove cache directory (Linux)
 if [ -d "$HOME/.cache/superfile" ]; then
     found=1
     echo -e "${bright_yellow}Removing ${cyan}~/.cache/superfile${bright_yellow}...${nc}"
     if ! rm -rf "$HOME/.cache/superfile"; then
         echo -e "${red}❌ Failed to remove ${white}~/.cache/superfile${nc}"
+        failed=1
     else
         echo -e "${bright_green}✔ Removed ${white}~/.cache/superfile${nc}"
     fi
 fi
 
+# Remove Application Support directory (macOS)
+if [ -d "$HOME/Library/Application Support/superfile" ]; then
+    found=1
+    echo -e "${bright_yellow}Removing ${cyan}~/Library/Application Support/superfile${bright_yellow}...${nc}"
+    if ! rm -rf "$HOME/Library/Application Support/superfile"; then
+        echo -e "${red}❌ Failed to remove ${white}~/Library/Application Support/superfile${nc}"
+        failed=1
+    else
+        echo -e "${bright_green}✔ Removed ${white}~/Library/Application Support/superfile${nc}"
+    fi
+fi
+
+# Remove cache directory (macOS)
+if [ -d "$HOME/Library/Caches/superfile" ]; then
+    found=1
+    echo -e "${bright_yellow}Removing ${cyan}~/Library/Caches/superfile${bright_yellow}...${nc}"
+    if ! rm -rf "$HOME/Library/Caches/superfile"; then
+        echo -e "${red}❌ Failed to remove ${white}~/Library/Caches/superfile${nc}"
+        failed=1
+    else
+        echo -e "${bright_green}✔ Removed ${white}~/Library/Caches/superfile${nc}"
+    fi
+fi
+
 if [ "$found" -eq 0 ]; then
     echo -e "${yellow}No superfile installation found. Nothing to remove.${nc}"
+elif [ "$failed" -eq 1 ]; then
+    echo -e "\n${red}⚠ Uninstall completed with errors. Please review the messages above.${nc}"
 else
     echo -e "\n👋 ${bright_green}superfile has been uninstalled.${nc}"
 fi

--- a/website/public/uninstall.sh
+++ b/website/public/uninstall.sh
@@ -39,6 +39,12 @@ if [ -z "${HOME:-}" ] || [ "$HOME" = "/" ]; then
     exit 1
 fi
 
+# Resolve XDG dirs, falling back to spec-defined defaults
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
 # Remove binary from /usr/local/bin
 if [ -f /usr/local/bin/spf ]; then
     found=1
@@ -63,39 +69,51 @@ if [ -f "$HOME/.local/bin/spf" ]; then
     fi
 fi
 
-# Remove config directory (Linux)
-if [ -d "$HOME/.config/superfile" ]; then
+# Remove config directory
+if [ -d "$XDG_CONFIG_HOME/superfile" ]; then
     found=1
-    echo -e "${bright_yellow}Removing ${cyan}~/.config/superfile${bright_yellow}...${nc}"
-    if ! rm -rf "$HOME/.config/superfile"; then
-        echo -e "${red}❌ Failed to remove ${white}~/.config/superfile${nc}"
+    echo -e "${bright_yellow}Removing ${cyan}$XDG_CONFIG_HOME/superfile${bright_yellow}...${nc}"
+    if ! rm -rf "$XDG_CONFIG_HOME/superfile"; then
+        echo -e "${red}❌ Failed to remove ${white}$XDG_CONFIG_HOME/superfile${nc}"
         failed=1
     else
-        echo -e "${bright_green}✔ Removed ${white}~/.config/superfile${nc}"
+        echo -e "${bright_green}✔ Removed ${white}$XDG_CONFIG_HOME/superfile${nc}"
     fi
 fi
 
-# Remove data directory (Linux)
-if [ -d "$HOME/.local/share/superfile" ]; then
+# Remove data directory
+if [ -d "$XDG_DATA_HOME/superfile" ]; then
     found=1
-    echo -e "${bright_yellow}Removing ${cyan}~/.local/share/superfile${bright_yellow}...${nc}"
-    if ! rm -rf "$HOME/.local/share/superfile"; then
-        echo -e "${red}❌ Failed to remove ${white}~/.local/share/superfile${nc}"
+    echo -e "${bright_yellow}Removing ${cyan}$XDG_DATA_HOME/superfile${bright_yellow}...${nc}"
+    if ! rm -rf "$XDG_DATA_HOME/superfile"; then
+        echo -e "${red}❌ Failed to remove ${white}$XDG_DATA_HOME/superfile${nc}"
         failed=1
     else
-        echo -e "${bright_green}✔ Removed ${white}~/.local/share/superfile${nc}"
+        echo -e "${bright_green}✔ Removed ${white}$XDG_DATA_HOME/superfile${nc}"
     fi
 fi
 
-# Remove cache directory (Linux)
-if [ -d "$HOME/.cache/superfile" ]; then
+# Remove cache directory
+if [ -d "$XDG_CACHE_HOME/superfile" ]; then
     found=1
-    echo -e "${bright_yellow}Removing ${cyan}~/.cache/superfile${bright_yellow}...${nc}"
-    if ! rm -rf "$HOME/.cache/superfile"; then
-        echo -e "${red}❌ Failed to remove ${white}~/.cache/superfile${nc}"
+    echo -e "${bright_yellow}Removing ${cyan}$XDG_CACHE_HOME/superfile${bright_yellow}...${nc}"
+    if ! rm -rf "$XDG_CACHE_HOME/superfile"; then
+        echo -e "${red}❌ Failed to remove ${white}$XDG_CACHE_HOME/superfile${nc}"
         failed=1
     else
-        echo -e "${bright_green}✔ Removed ${white}~/.cache/superfile${nc}"
+        echo -e "${bright_green}✔ Removed ${white}$XDG_CACHE_HOME/superfile${nc}"
+    fi
+fi
+
+# Remove state directory
+if [ -d "$XDG_STATE_HOME/superfile" ]; then
+    found=1
+    echo -e "${bright_yellow}Removing ${cyan}$XDG_STATE_HOME/superfile${bright_yellow}...${nc}"
+    if ! rm -rf "$XDG_STATE_HOME/superfile"; then
+        echo -e "${red}❌ Failed to remove ${white}$XDG_STATE_HOME/superfile${nc}"
+        failed=1
+    else
+        echo -e "${bright_green}✔ Removed ${white}$XDG_STATE_HOME/superfile${nc}"
     fi
 fi
 
@@ -127,6 +145,7 @@ if [ "$found" -eq 0 ]; then
     echo -e "${yellow}No superfile installation found. Nothing to remove.${nc}"
 elif [ "$failed" -eq 1 ]; then
     echo -e "\n${red}⚠ Uninstall completed with errors. Please review the messages above.${nc}"
+    exit 1
 else
     echo -e "\n👋 ${bright_green}superfile has been uninstalled.${nc}"
 fi

--- a/website/public/uninstall.sh
+++ b/website/public/uninstall.sh
@@ -34,6 +34,11 @@ echo -e '
 found=0
 failed=0
 
+if [ -z "${HOME:-}" ] || [ "$HOME" = "/" ]; then
+    echo -e "${red}❌ Refusing to run uninstall with an unsafe HOME value.${nc}"
+    exit 1
+fi
+
 # Remove binary from /usr/local/bin
 if [ -f /usr/local/bin/spf ]; then
     found=1

--- a/website/public/uninstall.sh
+++ b/website/public/uninstall.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+green='\033[0;32m'
+red='\033[0;31m'
+yellow='\033[0;33m'
+blue='\033[0;34m'
+purple='\033[0;35m'
+cyan='\033[0;36m'
+white='\033[0;37m'
+bright_red='\033[1;31m'
+bright_green='\033[1;32m'
+bright_yellow='\033[1;33m'
+bright_blue='\033[1;34m'
+bright_purple='\033[1;35m'
+bright_cyan='\033[1;36m'
+bright_white='\033[1;37m'
+nc='\033[0m' # No Color
+
+echo -e '
+\033[0;31m                                                    ______   __  __
+\033[1;31m                                                   /      \ /  |/  |
+\033[0;33m  _______  __    __   ______    ______    ______  /$$$$$$  |$$/ $$ |  ______
+\033[1;33m /       |/  |  /  | /      \  /      \  /      \ $$ |_ $$/ /  |$$ | /      \
+\033[0;32m/$$$$$$$/ $$ |  $$ |/$$$$$$  |/$$$$$$  |/$$$$$$  |$$   |    $$ |$$ |/$$$$$$  |
+\033[1;32m$$      \ $$ |  $$ |$$ |  $$ |$$    $$ |$$ |  $$/ $$$$/     $$ |$$ |$$    $$ |
+\033[0;34m $$$$$$  |$$ \__$$ |$$ |__$$ |$$$$$$$$/ $$ |      $$ |      $$ |$$ |$$$$$$$$/
+\033[1;34m/     $$/ $$    $$/ $$    $$/ $$       |$$ |      $$ |      $$ |$$ |$$       |
+\033[0;35m$$$$$$$/   $$$$$$/  $$$$$$$/   $$$$$$$/ $$/       $$/       $$/ $$/  $$$$$$$/
+\033[1;35m                    $$ |
+\033[0;31m                    $$ |
+\033[1;31m                    $$/
+'
+
+found=0
+
+# Remove binary from /usr/local/bin
+if [ -f /usr/local/bin/spf ]; then
+    found=1
+    echo -e "${bright_yellow}Removing ${cyan}/usr/local/bin/spf${bright_yellow}...${nc}"
+    if ! sudo rm /usr/local/bin/spf; then
+        echo -e "${red}❌ Failed to remove ${white}/usr/local/bin/spf${red}. Do you have sudo permissions?${nc}"
+    else
+        echo -e "${bright_green}✔ Removed ${white}/usr/local/bin/spf${nc}"
+    fi
+fi
+
+# Remove binary from ~/.local/bin
+if [ -f "$HOME/.local/bin/spf" ]; then
+    found=1
+    echo -e "${bright_yellow}Removing ${cyan}~/.local/bin/spf${bright_yellow}...${nc}"
+    if ! rm "$HOME/.local/bin/spf"; then
+        echo -e "${red}❌ Failed to remove ${white}~/.local/bin/spf${nc}"
+    else
+        echo -e "${bright_green}✔ Removed ${white}~/.local/bin/spf${nc}"
+    fi
+fi
+
+# Remove config directory
+if [ -d "$HOME/.config/superfile" ]; then
+    found=1
+    echo -e "${bright_yellow}Removing ${cyan}~/.config/superfile${bright_yellow}...${nc}"
+    if ! rm -rf "$HOME/.config/superfile"; then
+        echo -e "${red}❌ Failed to remove ${white}~/.config/superfile${nc}"
+    else
+        echo -e "${bright_green}✔ Removed ${white}~/.config/superfile${nc}"
+    fi
+fi
+
+# Remove data directory
+if [ -d "$HOME/.local/share/superfile" ]; then
+    found=1
+    echo -e "${bright_yellow}Removing ${cyan}~/.local/share/superfile${bright_yellow}...${nc}"
+    if ! rm -rf "$HOME/.local/share/superfile"; then
+        echo -e "${red}❌ Failed to remove ${white}~/.local/share/superfile${nc}"
+    else
+        echo -e "${bright_green}✔ Removed ${white}~/.local/share/superfile${nc}"
+    fi
+fi
+
+# Remove cache directory
+if [ -d "$HOME/.cache/superfile" ]; then
+    found=1
+    echo -e "${bright_yellow}Removing ${cyan}~/.cache/superfile${bright_yellow}...${nc}"
+    if ! rm -rf "$HOME/.cache/superfile"; then
+        echo -e "${red}❌ Failed to remove ${white}~/.cache/superfile${nc}"
+    else
+        echo -e "${bright_green}✔ Removed ${white}~/.cache/superfile${nc}"
+    fi
+fi
+
+if [ "$found" -eq 0 ]; then
+    echo -e "${yellow}No superfile installation found. Nothing to remove.${nc}"
+else
+    echo -e "\n👋 ${bright_green}superfile has been uninstalled.${nc}"
+fi


### PR DESCRIPTION
Closes #1422

Adds `website/public/uninstall.sh` that removes the `spf` binary from
`/usr/local/bin` or `~/.local/bin`, and cleans up `~/.config/superfile`,
`~/.local/share/superfile`, and `~/.cache/superfile`.

Updated README to replace the manual uninstall steps.

<img width="844" height="392" alt="image" src="https://github.com/user-attachments/assets/e1d66308-5387-43cc-812c-33f6b8fe9a07" />

Tested: installed via the official install.sh, ran the uninstall script,
confirmed `which spf` returns nothing and all directories are removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated macOS/Linux “Uninstall” instructions to use a single hosted command for the uninstall script, with a pointer to the script for review.

* **New Features**
  * Added an automated uninstall script with safety checks (aborts when `HOME` is unset/empty or `/`), colored uninstall banner, and step-by-step removal of the app binary plus user/system config, data, cache, and state folders (macOS and Linux), reporting success vs. any failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->