### PR TITLE
ci: add go mod tidy check

### DIFF
--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -1,0 +1,56 @@
+name: Go Mod Tidy Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '*.go'
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '*.go'
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+
+jobs:
+  go-mod-tidy:
+    name: Check go mod tidy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Go modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ${{ runner.temp }}/gomodcache
+          key: ${{ runner.os }}-go-mod-tidy-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-tidy-
+
+      - name: Run go mod tidy
+        run: go mod tidy
+        env:
+          GOMODCACHE: ${{ runner.temp }}/gomodcache
+
+      - name: Check module files
+        run: |
+          git diff --exit-code -- go.mod go.sum || {
+            echo "::error::go.mod or go.sum is out of date. Run 'go mod tidy' and commit the changes."
+            exit 1
+          }


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that checks whether `go mod tidy` has been run.
- Run the check on pull requests to `main` and `develop`, and on pushes to `main`, when Go source or module files change.
- Leave `go.mod` and `go.sum` unchanged in this PR.

## Validation

- Parsed `.github/workflows/go-mod-tidy.yml` locally with Ruby YAML.
- Confirmed the committed diff only adds the new workflow file.

## Notes

The workflow intentionally does not trigger on changes to the workflow file alone, so this CI-only PR does not also require a module tidy update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI check that runs `go mod tidy` on Go-related changes and verifies `go.mod`/`go.sum` remain consistent, failing the build if updates are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->