### PR TITLE
fix(compress): preserve dotfile name when generating zip archive

### DIFF
--- a/src/internal/file_operation_compress_test.go
+++ b/src/internal/file_operation_compress_test.go
@@ -151,3 +151,25 @@ func TestZipSourcesInvalidTarget(t *testing.T) {
 	err = zipSources([]string{testFile}, invalidTarget, &processBar)
 	require.Error(t, err, "zipSources should return error for invalid target")
 }
+
+func TestGetZipArchiveName(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		want string
+	}{
+		{name: "regular file", base: "test.txt", want: "test.zip"},
+		{name: "dotfile", base: ".test", want: ".test.zip"},
+		{name: "no extension", base: "test", want: "test.zip"},
+		{name: "dotfile with extension", base: ".test.txt", want: ".test.zip"},
+		{name: "dot-only path component", base: "..test", want: "..test.zip"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getZipArchiveName(tt.base)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+

--- a/src/internal/file_operations_compress.go
+++ b/src/internal/file_operations_compress.go
@@ -128,7 +128,15 @@ func writeZipFile(path string, relPath string, info os.FileInfo, writer *zip.Wri
 }
 
 func getZipArchiveName(base string) (string, error) {
-	zipName := strings.TrimSuffix(base, filepath.Ext(base)) + ".zip"
+	// filepath.Ext treats dotfiles (e.g. ".test") as their entire name being
+	// the extension, so naively stripping it would produce ".zip" instead of
+	// ".test.zip". If stripping the extension leaves an empty or dot-only
+	// basename, fall back to the original name.
+	stripped := strings.TrimSuffix(base, filepath.Ext(base))
+	if stripped == "" || strings.Trim(stripped, ".") == "" {
+		stripped = base
+	}
+	zipName := stripped + ".zip"
 	zipName, err := renameIfDuplicate(zipName)
 	return zipName, err
 }


### PR DESCRIPTION
`getZipArchiveName` produces `.zip` (no source name) when compressing a dot file or directory such as `.test`. The root cause is that Go's `filepath.Ext` returns the entire leading-dot basename as the extension, so `strings.TrimSuffix` strips everything and we're left with `.zip`.

When stripping the extension yields an empty or dot-only basename, fall back to the original name so the resulting zip preserves the source identifier.

Cases covered by the new unit tests:
- `.test` → `.test.zip` (was `.zip`)
- `..test` → `..test.zip` (was `..zip`)
- `test.txt` → `test.zip` (unchanged)
- `.test.txt` → `.test.zip` (unchanged)
- `test` → `test.zip` (unchanged)

Fixes #1470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced zip archive creation to properly handle dotfiles by implementing intelligent extension trimming logic with fallback behavior for edge cases where trimming would result in empty or dot-only basenames.

* **Tests**
  * Added comprehensive test coverage for archive name derivation, validating behavior across regular filenames, dotfiles, files without extensions, and complex path components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->