### PR TITLE
fix: copy selected paths in select mode

### DIFF
--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -16,6 +17,71 @@ import (
 	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/ui/processbar"
 )
+
+func TestCopyPath(t *testing.T) {
+	curTestDir := t.TempDir()
+	dir1 := filepath.Join(curTestDir, "dir1")
+	file1 := filepath.Join(curTestDir, "file1.txt")
+	file2 := filepath.Join(curTestDir, "file2.txt")
+
+	utils.SetupDirectories(t, curTestDir, dir1)
+	utils.SetupFiles(t, file1, file2)
+
+	var copiedText string
+	originalWriteClipboard := writeClipboard
+	writeClipboard = func(text string) error {
+		copiedText = text
+		return nil
+	}
+	t.Cleanup(func() {
+		writeClipboard = originalWriteClipboard
+	})
+
+	t.Run("Browser Mode Copy Focused Item Path", func(t *testing.T) {
+		copiedText = ""
+		m := defaultTestModel(curTestDir)
+		setFilePanelSelectedItemByLocation(t, m.getFocusedFilePanel(), file1)
+
+		TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.CopyPath[0]))
+
+		assert.Equal(t, file1, copiedText)
+	})
+
+	t.Run("Select Mode Copy Selected Item Paths", func(t *testing.T) {
+		copiedText = ""
+		m := defaultTestModel(curTestDir)
+		panel := m.getFocusedFilePanel()
+		panel.ChangeFilePanelMode()
+		panel.SetSelected(file2)
+		panel.SetSelected(file1)
+		setFilePanelSelectedItemByLocation(t, panel, dir1)
+
+		TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.CopyPath[0]))
+
+		assert.Equal(t, strings.Join([]string{file1, file2}, "\n"), copiedText)
+	})
+
+	t.Run("Select Mode Without Selection Copies Focused Item Path", func(t *testing.T) {
+		copiedText = ""
+		m := defaultTestModel(curTestDir)
+		panel := m.getFocusedFilePanel()
+		panel.ChangeFilePanelMode()
+		setFilePanelSelectedItemByLocation(t, panel, file2)
+
+		TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.CopyPath[0]))
+
+		assert.Equal(t, file2, copiedText)
+	})
+
+	t.Run("Empty Panel Does Not Copy", func(t *testing.T) {
+		copiedText = ""
+		m := defaultTestModel(t.TempDir())
+
+		TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.CopyPath[0]))
+
+		assert.Empty(t, copiedText)
+	})
+}
 
 func TestCompressSelectedFiles(t *testing.T) {
 	curTestDir := t.TempDir()

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -574,18 +574,33 @@ func (m *model) openDirectoryWithEditor() tea.Cmd {
 	})
 }
 
+var writeClipboard = clipboard.WriteAll
+
 // Copy file path
 // TODO: This is also an IO operations, do it via tea.Cmd
 func (m *model) copyPath() {
-	panel := m.getFocusedFilePanel()
-
-	if panel.Empty() {
+	pathText := m.copyPathText()
+	if pathText == "" {
 		return
 	}
 
-	if err := clipboard.WriteAll(panel.GetFocusedItem().Location); err != nil {
+	if err := writeClipboard(pathText); err != nil {
 		slog.Error("Error while copy path", "error", err)
 	}
+}
+
+func (m *model) copyPathText() string {
+	panel := m.getFocusedFilePanel()
+
+	if panel.Empty() {
+		return ""
+	}
+
+	if panel.PanelMode == filepanel.SelectMode && panel.SelectedCount() > 0 {
+		return strings.Join(panel.GetSelectedLocationsSortedAsVisible(), "\n")
+	}
+
+	return panel.GetFocusedItem().Location
 }
 
 // TODO: This is also an IO operations, do it via tea.Cmd

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -179,6 +179,8 @@ func (m *model) normalAndBrowserModeKey(msg string) tea.Cmd {
 			m.copyMultipleItem(false)
 		case slices.Contains(common.Hotkeys.CutItems, msg):
 			m.copyMultipleItem(true)
+		case slices.Contains(common.Hotkeys.CopyPath, msg):
+			m.copyPath()
 		case slices.Contains(common.Hotkeys.FilePanelSelectAllItem, msg):
 			m.getFocusedFilePanel().SelectAllItem()
 		}

--- a/src/internal/ui/helpmenu/data.go
+++ b/src/internal/ui/helpmenu/data.go
@@ -230,7 +230,7 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 		},
 		{
 			hotkey:         common.Hotkeys.CopyPath,
-			description:    "Copy current file or directory path",
+			description:    "Copy current or selected file/directory paths",
 			hotkeyWorkType: globalType,
 		},
 		{

--- a/website/src/content/docs/list/hotkey-list.mdx
+++ b/website/src/content/docs/list/hotkey-list.mdx
@@ -73,7 +73,7 @@ Quit superfile and cd to current folder "cd_quit" require the same scripts as ["
 | Cut file or folder (or both)                         | `ctrl+x`           | `file_panel_select_mode_item_cut`                                                                 |
 | Paste all items in your clipboard                    | `ctrl+v`, `ctrl+w` | `paste_item`                                                                                      |
 | Delete file or folder (or both)                      | `ctrl+d`, `delete` | `delete_item` (normal mode) <br/> `file_panel_select_mode_item_delete` (select mode)              |
-| Copy current file or directory path                  | `ctrl+p`           | `copy_path`                                                                                       |
+| Copy current or selected file/directory paths        | `ctrl+p`           | `copy_path`                                                                                       |
 | Extract zip file                                     | `ctrl+e`           | `extract_file` (normal mode)                                                                      |
 | Zip file or folder to .zip file                      | `ctrl+a`           | `compress_file` (normal mode)                                                                     |
 | Open file with your default editor                   | `e`                | `open_file_with_editor` (normal node)                                                             |

--- a/website/src/content/docs/zh-tw/list/hotkey-list.mdx
+++ b/website/src/content/docs/zh-tw/list/hotkey-list.mdx
@@ -73,7 +73,7 @@ head:
 | 剪下檔案或資料夾（或兩者）                  | `ctrl+x`           | `file_panel_select_mode_item_cut`                                                             |
 | 貼上剪貼簿中的所有項目                      | `ctrl+v`, `ctrl+w` | `paste_item`                                                                                  |
 | 刪除檔案或資料夾（或兩者）                  | `ctrl+d`, `delete` | `delete_item`（一般模式） <br/> `file_panel_select_mode_item_delete`（選取模式）              |
-| 複製目前檔案或目錄路徑                      | `ctrl+p`           | `copy_path`                                                                                   |
+| 複製目前或已選取檔案/目錄路徑               | `ctrl+p`           | `copy_path`                                                                                   |
 | 解壓縮 zip 檔案                             | `ctrl+e`           | `extract_file`（一般模式）                                                                    |
 | 將檔案或資料夾壓縮成 .zip 檔案              | `ctrl+a`           | `compress_file`（一般模式）                                                                   |
 | 使用預設編輯器開啟檔案                      | `e`                | `open_file_with_editor`（一般模式）                                                           |


### PR DESCRIPTION
Fix copy selected paths in select mode.
In the old code, the selection mode only copies the current focus item. But it should copy all selected files and folders and their paths.

Fix Issue: #406 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copy Path hotkey now copies multiple selected file/directory paths simultaneously in select mode, with paths joined by newlines

* **Documentation**
  * Updated help menu and hotkey documentation to clarify that Copy Path supports both single and multi-item selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->