### PR TITLE
feat: add --with-config-override CLI flag

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -80,56 +80,66 @@ func Run(content embed.FS) {
 				},
 			},
 		},
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:    "debug-info",
-				Aliases: []string{"di"},
-				Usage:   "Print debug information",
-				Value:   false,
-			},
-			&cli.BoolFlag{
-				Name:    "fix-hotkeys",
-				Aliases: []string{"fh"},
-				Usage:   "Adds any missing hotkeys to the hotkey config file",
-				Value:   false,
-			},
-			&cli.BoolFlag{
-				Name:    "fix-config-file",
-				Aliases: []string{"fch"},
-				Usage:   "Adds any missing fields to the config file",
-				Value:   false,
-			},
-			&cli.BoolFlag{
-				Name:    "print-last-dir",
-				Aliases: []string{"pld"},
-				Usage:   "Print the last dir to stdout on exit (to use for cd)",
-				Value:   false,
-			},
-			&cli.StringFlag{
-				Name:    "config-file",
-				Aliases: []string{"c"},
-				Usage:   "Specify the path to a different config file",
-				Value:   "", // Default to the blank string indicating non-usage of flag
-			},
-			&cli.StringFlag{
-				Name:    "hotkey-file",
-				Aliases: []string{"hf"},
-				Usage:   "Specify the path to a different hotkey file",
-				Value:   "", // Default to the blank string indicating non-usage of flag
-			},
-			&cli.StringFlag{
-				Name:    "chooser-file",
-				Aliases: []string{"cf"},
-				Usage:   "On trying to open any file, superfile will write to its path to this file, and exit",
-				Value:   "", // Default to the blank string indicating non-usage of flag
-			},
-		},
+		Flags:  appFlags(),
 		Action: spfAppAction,
 	}
 
 	err := app.Run(context.Background(), os.Args)
 	if err != nil {
 		utils.PrintlnAndExit(err)
+	}
+}
+
+// appFlags returns the top-level CLI flags for the superfile command.
+func appFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "debug-info",
+			Aliases: []string{"di"},
+			Usage:   "Print debug information",
+			Value:   false,
+		},
+		&cli.BoolFlag{
+			Name:    "fix-hotkeys",
+			Aliases: []string{"fh"},
+			Usage:   "Adds any missing hotkeys to the hotkey config file",
+			Value:   false,
+		},
+		&cli.BoolFlag{
+			Name:    "fix-config-file",
+			Aliases: []string{"fch"},
+			Usage:   "Adds any missing fields to the config file",
+			Value:   false,
+		},
+		&cli.BoolFlag{
+			Name:    "print-last-dir",
+			Aliases: []string{"pld"},
+			Usage:   "Print the last dir to stdout on exit (to use for cd)",
+			Value:   false,
+		},
+		&cli.StringFlag{
+			Name:    "config-file",
+			Aliases: []string{"c"},
+			Usage:   "Specify the path to a different config file",
+			Value:   "", // Default to the blank string indicating non-usage of flag
+		},
+		&cli.StringFlag{
+			Name:    "hotkey-file",
+			Aliases: []string{"hf"},
+			Usage:   "Specify the path to a different hotkey file",
+			Value:   "", // Default to the blank string indicating non-usage of flag
+		},
+		&cli.StringFlag{
+			Name:    "chooser-file",
+			Aliases: []string{"cf"},
+			Usage:   "On trying to open any file, superfile will write to its path to this file, and exit",
+			Value:   "", // Default to the blank string indicating non-usage of flag
+		},
+		&cli.StringSliceFlag{
+			Name:    "with-config-override",
+			Aliases: []string{"wco"},
+			Usage:   "Override a config value using 'key=value' (e.g. 'debug=true'). Repeatable; key is the config.toml field name",
+		},
 	}
 }
 

--- a/src/config/fixed_variable.go
+++ b/src/config/fixed_variable.go
@@ -75,6 +75,10 @@ var (
 	FixConfigFile = false
 	LastDir       = ""
 	PrintLastDir  = false
+
+	// ConfigOverrides holds `key=value` pairs passed via --with-config-override.
+	// They are applied on top of the loaded config file before validation.
+	ConfigOverrides []string
 )
 
 // Still we are preventing other packages to directly modify them via reassign linter
@@ -114,4 +118,5 @@ func UpdateVarFromCliArgs(c *cli.Command) {
 	FixHotkeys = c.Bool("fix-hotkeys")
 	FixConfigFile = c.Bool("fix-config-file")
 	PrintLastDir = c.Bool("print-last-dir")
+	ConfigOverrides = c.StringSlice("with-config-override")
 }

--- a/src/internal/common/config_override.go
+++ b/src/internal/common/config_override.go
@@ -31,8 +31,12 @@ func ApplyConfigOverrides(c *ConfigType, overrides []string) error {
 		if !found {
 			return fmt.Errorf("invalid config override %q: expected format 'key=value'", override)
 		}
+		// Trim only the key so overrides line up with config.toml keys. The raw
+		// value is passed through verbatim: for string fields whitespace can be
+		// the intended value (e.g. border_top = ' ' for a borderless layout, as
+		// documented in config.toml), so it must survive exactly as written.
+		// Numeric and bool fields trim internally where needed for parsing.
 		key = strings.TrimSpace(key)
-		rawValue = strings.TrimSpace(rawValue)
 
 		fieldIdx, ok := fieldByTomlKey[key]
 		if !ok {
@@ -76,15 +80,18 @@ func setFieldFromString(field reflect.Value, raw string) error {
 	//exhaustive:ignore
 	switch field.Kind() {
 	case reflect.String:
+		// Assign the raw value verbatim. Whitespace can be the intended value
+		// for a string field (e.g. a single space for a borderless border), so
+		// it must be preserved exactly as it would be in config.toml.
 		field.SetString(raw)
 	case reflect.Bool:
-		b, err := strconv.ParseBool(raw)
+		b, err := strconv.ParseBool(strings.TrimSpace(raw))
 		if err != nil {
 			return fmt.Errorf("expected a boolean (true/false), got %q", raw)
 		}
 		field.SetBool(b)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		n, err := strconv.ParseInt(raw, 10, 64)
+		n, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
 		if err != nil {
 			return fmt.Errorf("expected an integer, got %q", raw)
 		}
@@ -94,10 +101,11 @@ func setFieldFromString(field reflect.Value, raw string) error {
 			return fmt.Errorf("unsupported slice element type %s", field.Type().Elem().Kind())
 		}
 		// Comma separated list, mirroring how TOML arrays of strings are written
-		// inline. An empty string yields an empty slice rather than [""].
+		// inline. An empty (or whitespace-only) string yields an empty slice
+		// rather than [""], and each element is trimmed.
 		var parts []string
-		if raw != "" {
-			parts = strings.Split(raw, ",")
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			parts = strings.Split(trimmed, ",")
 			for i := range parts {
 				parts[i] = strings.TrimSpace(parts[i])
 			}

--- a/src/internal/common/config_override.go
+++ b/src/internal/common/config_override.go
@@ -1,0 +1,110 @@
+package common
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// ApplyConfigOverrides applies a list of `key=value` overrides onto an already
+// loaded ConfigType. Each key is the TOML field name (matching the `toml:"..."`
+// struct tag, e.g. "debug"), so overrides line up with what users write in
+// config.toml. The value is parsed into the field's Go type. An unknown key, a
+// malformed `key=value` pair, or a value that cannot be parsed into the field's
+// type returns a clear error naming the offending key.
+//
+// This is meant to be called from LoadConfigFile after the TOML file has been
+// decoded into Config and before ValidateConfig runs, so overrides are
+// validated together with the rest of the config.
+func ApplyConfigOverrides(c *ConfigType, overrides []string) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+
+	// Build a one-time lookup from TOML key -> struct field index.
+	fieldByTomlKey := buildTomlFieldIndex(reflect.TypeOf(*c))
+
+	val := reflect.ValueOf(c).Elem()
+	for _, override := range overrides {
+		key, rawValue, found := strings.Cut(override, "=")
+		if !found {
+			return fmt.Errorf("invalid config override %q: expected format 'key=value'", override)
+		}
+		key = strings.TrimSpace(key)
+		rawValue = strings.TrimSpace(rawValue)
+
+		fieldIdx, ok := fieldByTomlKey[key]
+		if !ok {
+			return fmt.Errorf("unknown config key %q in override %q", key, override)
+		}
+
+		if err := setFieldFromString(val.Field(fieldIdx), rawValue); err != nil {
+			return fmt.Errorf("invalid value for config key %q: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
+// buildTomlFieldIndex maps each field's TOML key (the part before any comma in
+// the `toml` tag) to its index in the struct. Fields without a toml tag are
+// skipped, matching how the TOML decoder ignores them.
+func buildTomlFieldIndex(t reflect.Type) map[string]int {
+	index := make(map[string]int, t.NumField())
+	for i := range t.NumField() {
+		tag := t.Field(i).Tag.Get("toml")
+		if tag == "" {
+			continue
+		}
+		key := strings.Split(tag, ",")[0]
+		if key == "" || key == "-" {
+			continue
+		}
+		index[key] = i
+	}
+	return index
+}
+
+// setFieldFromString parses raw into the type of field and assigns it. Only the
+// kinds actually present in ConfigType are supported (string, bool, int, and
+// []string); anything else is rejected so silent no-ops cannot happen.
+func setFieldFromString(field reflect.Value, raw string) error {
+	// Only the kinds present in ConfigType are handled; the default case rejects
+	// everything else, so the remaining reflect.Kind values are intentionally
+	// not enumerated.
+	//exhaustive:ignore
+	switch field.Kind() {
+	case reflect.String:
+		field.SetString(raw)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return fmt.Errorf("expected a boolean (true/false), got %q", raw)
+		}
+		field.SetBool(b)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return fmt.Errorf("expected an integer, got %q", raw)
+		}
+		field.SetInt(n)
+	case reflect.Slice:
+		if field.Type().Elem().Kind() != reflect.String {
+			return fmt.Errorf("unsupported slice element type %s", field.Type().Elem().Kind())
+		}
+		// Comma separated list, mirroring how TOML arrays of strings are written
+		// inline. An empty string yields an empty slice rather than [""].
+		var parts []string
+		if raw != "" {
+			parts = strings.Split(raw, ",")
+			for i := range parts {
+				parts[i] = strings.TrimSpace(parts[i])
+			}
+		}
+		field.Set(reflect.ValueOf(parts))
+	default:
+		return fmt.Errorf("unsupported config field type %s", field.Kind())
+	}
+	return nil
+}

--- a/src/internal/common/config_override_test.go
+++ b/src/internal/common/config_override_test.go
@@ -71,10 +71,35 @@ func TestApplyConfigOverrides(t *testing.T) {
 			},
 		},
 		{
-			name:      "key and value are trimmed",
+			name:      "key is trimmed and bool value parses despite surrounding whitespace",
 			overrides: []string{" debug = true "},
 			check: func(t *testing.T, c *ConfigType) {
 				assert.True(t, c.Debug)
+			},
+		},
+		{
+			name:      "int value parses despite surrounding whitespace",
+			overrides: []string{"sidebar_width= 12 "},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.Equal(t, 12, c.SidebarWidth)
+			},
+		},
+		{
+			// config.toml documents "Use ' ' for borderless", so a single space
+			// is a valid intended string value. The key must still be trimmed,
+			// but the raw string value must be preserved verbatim (not trimmed to
+			// empty) so CLI overrides can express the same values as config.toml.
+			name:      "string value with intended single space is preserved",
+			overrides: []string{" border_top = "},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.Equal(t, " ", c.BorderTop)
+			},
+		},
+		{
+			name:      "string value surrounding whitespace is preserved verbatim",
+			overrides: []string{"border_bottom=  x  "},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.Equal(t, "  x  ", c.BorderBottom)
 			},
 		},
 		{

--- a/src/internal/common/config_override_test.go
+++ b/src/internal/common/config_override_test.go
@@ -1,0 +1,133 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyConfigOverrides covers key=value parsing, per-kind type coercion
+// (string, bool, int, []string), multiple ordered overrides, values containing
+// '=', whitespace trimming, and the unknown-key / missing-'=' / bad-value errors.
+func TestApplyConfigOverrides(t *testing.T) {
+	testdata := []struct {
+		name      string
+		overrides []string
+		// check inspects the resulting config when no error is expected
+		check func(t *testing.T, c *ConfigType)
+		// errSubstr, when non-empty, asserts the returned error contains it
+		errSubstr string
+	}{
+		{
+			name:      "bool override true",
+			overrides: []string{"debug=true"},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.True(t, c.Debug)
+			},
+		},
+		{
+			name:      "bool override false",
+			overrides: []string{"auto_check_update=false"},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.False(t, c.AutoCheckUpdate)
+			},
+		},
+		{
+			name:      "string override",
+			overrides: []string{"theme=gruvbox"},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.Equal(t, "gruvbox", c.Theme)
+			},
+		},
+		{
+			name:      "int override",
+			overrides: []string{"default_sort_type=2"},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.Equal(t, 2, c.DefaultSortType)
+			},
+		},
+		{
+			name:      "string slice override comma separated",
+			overrides: []string{"sidebar_sections=home,pinned"},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.Equal(t, []string{"home", "pinned"}, c.SidebarSections)
+			},
+		},
+		{
+			name:      "multiple overrides applied in order",
+			overrides: []string{"debug=true", "theme=catppuccin", "sidebar_width=12"},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.True(t, c.Debug)
+				assert.Equal(t, "catppuccin", c.Theme)
+				assert.Equal(t, 12, c.SidebarWidth)
+			},
+		},
+		{
+			name:      "value containing equals sign is preserved",
+			overrides: []string{"default_directory=/tmp/a=b"},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.Equal(t, "/tmp/a=b", c.DefaultDirectory)
+			},
+		},
+		{
+			name:      "key and value are trimmed",
+			overrides: []string{" debug = true "},
+			check: func(t *testing.T, c *ConfigType) {
+				assert.True(t, c.Debug)
+			},
+		},
+		{
+			name:      "unknown key returns clear error",
+			overrides: []string{"not_a_real_key=true"},
+			errSubstr: "not_a_real_key",
+		},
+		{
+			name:      "missing equals returns error",
+			overrides: []string{"debug"},
+			errSubstr: "debug",
+		},
+		{
+			name:      "invalid bool value returns error",
+			overrides: []string{"debug=notabool"},
+			errSubstr: "debug",
+		},
+		{
+			name:      "invalid int value returns error",
+			overrides: []string{"default_sort_type=abc"},
+			errSubstr: "default_sort_type",
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ConfigType{}
+			err := ApplyConfigOverrides(c, tt.overrides)
+			if tt.errSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, c)
+		})
+	}
+}
+
+// TestApplyConfigOverridesEmpty verifies that a nil/empty override list is a
+// no-op and leaves the config untouched.
+func TestApplyConfigOverridesEmpty(t *testing.T) {
+	c := &ConfigType{Theme: "original"}
+	require.NoError(t, ApplyConfigOverrides(c, nil))
+	assert.Equal(t, "original", c.Theme, "no overrides should leave config untouched")
+}
+
+// TestApplyConfigOverridesUnknownKeyMentionsOverride verifies the unknown-key
+// error names both the offending key and the full override string.
+func TestApplyConfigOverridesUnknownKeyMentionsOverride(t *testing.T) {
+	c := &ConfigType{}
+	err := ApplyConfigOverrides(c, []string{"bogus_key=1"})
+	require.Error(t, err)
+	// Error should be understandable: name the offending key.
+	assert.Contains(t, err.Error(), "bogus_key")
+}

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -45,6 +45,13 @@ func LoadConfigFile() {
 		}
 	}
 
+	// Apply CLI overrides on top of the loaded config file, before validation,
+	// so overridden values are validated together with the rest of the config.
+	if err := ApplyConfigOverrides(&Config, variable.ConfigOverrides); err != nil {
+		userMsg := fmt.Sprintf("%s%s", LipglossError, err.Error())
+		utils.PrintfAndExitf("%s\n", userMsg)
+	}
+
 	// Even if there is a missing field, we want to validate fields that are present
 	if err := ValidateConfig(&Config); err != nil {
 		// If config is incorrect we cannot continue. We need to exit


### PR DESCRIPTION
## Description

Adds a repeatable `--with-config-override 'key=value'` flag (alias `--wco`) that overrides individual `config.toml` values from the CLI, as requested in #1272 (modeled on rovr's `--with`/`--without`).

`ApplyConfigOverrides` (new `src/internal/common/config_override.go`) maps each TOML key to its `ConfigType` field via the `toml:"..."` tags — the same reflection approach `LoadTomlFile` uses — splits on the first `=` (so values may contain `=`), and coerces the value by field kind (string / bool / int / []string). It runs after the config file decodes and before `ValidateConfig`, so overrides are validated like the rest of the config. Unknown keys, a missing `=`, and unparseable values each return a clear error naming the key.

Example: `spf --with-config-override 'debug=true'` (repeatable: `--wco 'a=1' --wco 'b=2'`).

## Related Issues

Fixes #1272

## Screenshots

CLI flag + config behavior (no UI change). Verified manually: `--with-config-override 'debug=true'` launched the TUI and produced DEBUG-level log entries (none without the override); error paths exit before the TUI with a clear message; the flag appears in `--help`.

## Checklist

- [x] `go fmt` (gofmt clean)
- [ ] `golangci-lint run` — not available in my environment; `go vet`, `go build`, and `go test ./...` pass (only pre-existing env failures: missing `exiftool`/`zoxide` binaries)
- [x] Tested — 15-case unit test for parsing / type coercion / error paths (red->green) plus a runtime smoke test
- [x] No leftover debug logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable CLI flag `--with-config-override` (alias `--wco`) to override configuration values via `key=value`.
  * Supports overriding `string`, `bool`, `int`, and comma-separated `[]string` values with sensible whitespace trimming.
* **Bug Fixes**
  * Overrides are now applied immediately after loading the config file and before validation.
  * Clear errors are returned for malformed entries, unknown keys, or invalid value formats.
* **Tests**
  * Added unit tests covering parsing, repeated overrides, trimming, edge cases, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->