### PR TITLE
feat: compression permission improvements

### DIFF
--- a/src/internal/file_operations_compress.go
+++ b/src/internal/file_operations_compress.go
@@ -19,11 +19,13 @@ func delEmptyZip(target string) error {
 	if err != nil {
 		return err
 	}
-	defer r.Close()
 	if len(r.File) == 0 {
+		if err := r.Close(); err != nil {
+			return err
+		}
 		return os.Remove(target)
 	}
-	return nil
+	return r.Close()
 }
 
 func zipSources(sources []string, target string, processBar *processbar.Model) error {
@@ -31,12 +33,16 @@ func zipSources(sources []string, target string, processBar *processbar.Model) e
 
 	totalFiles := 0
 	for _, src := range sources {
-		if _, err = os.Stat(src); os.IsNotExist(err) {
-			return fmt.Errorf("source path does not exist: %s", src)
+		if _, err = os.Stat(src); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("source path does not exist: %s", src)
+			}
+			if os.IsPermission(err) {
+				return fmt.Errorf("missing permissions: %s", src)
+			}
+			return fmt.Errorf("cannot access source path %s: %w", src, err)
 		}
-		if _, err = os.Stat(src); os.IsPermission(err) {
-			return fmt.Errorf("missing permissions: %s", src)
-		}
+
 		count, e := countFiles(src)
 		if e != nil {
 			slog.Error("Error while zip file count files ", "error", e)

--- a/src/internal/file_operations_compress.go
+++ b/src/internal/file_operations_compress.go
@@ -14,6 +14,18 @@ import (
 	"github.com/yorukot/superfile/src/internal/ui/processbar"
 )
 
+func delEmptyZip(target string) error {
+	r, err := zip.OpenReader(target)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	if len(r.File) == 0 {
+		return os.Remove(target)
+	}
+	return nil
+}
+
 func zipSources(sources []string, target string, processBar *processbar.Model) error {
 	var err error
 
@@ -21,6 +33,9 @@ func zipSources(sources []string, target string, processBar *processbar.Model) e
 	for _, src := range sources {
 		if _, err = os.Stat(src); os.IsNotExist(err) {
 			return fmt.Errorf("source path does not exist: %s", src)
+		}
+		if _, err = os.Stat(src); os.IsPermission(err) {
+			return fmt.Errorf("missing permissions: %s", src)
 		}
 		count, e := countFiles(src)
 		if e != nil {
@@ -99,6 +114,12 @@ func zipSourcesCore(sources []string, processBar *processbar.Model,
 }
 
 func writeZipFile(path string, relPath string, info os.FileInfo, writer *zip.Writer) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
 	header, err := zip.FileInfoHeader(info)
 	if err != nil {
 		return err
@@ -115,11 +136,7 @@ func writeZipFile(path string, relPath string, info os.FileInfo, writer *zip.Wri
 	if info.IsDir() {
 		return nil
 	}
-	file, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
+
 	_, err = io.Copy(headerWriter, file)
 	if err != nil {
 		return err

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -475,8 +475,12 @@ func (m *model) getCompressSelectedFilesCmd() tea.Cmd {
 			return NewCompressOperationMsg(processbar.Failed, reqID)
 		}
 		zipPath := filepath.Join(panel.Location, zipName)
-		if err := zipSources(filesToCompress, zipPath, &m.processBarModel); err != nil {
+		if err = zipSources(filesToCompress, zipPath, &m.processBarModel); err != nil {
 			slog.Error("Error in zipping files", "error", err)
+			return NewCompressOperationMsg(processbar.Failed, reqID)
+		}
+		if err = delEmptyZip(zipPath); err != nil {
+			slog.Error("Cann't check zip for empty", "error", err)
 			return NewCompressOperationMsg(processbar.Failed, reqID)
 		}
 		return NewCompressOperationMsg(processbar.Successful, reqID)


### PR DESCRIPTION
1) check all permissions before start compression
<img width="498" height="426" alt="image" src="https://github.com/user-attachments/assets/2443f888-2842-4d7d-bb72-be3c1989241b" />

2) if result zip-file is empty - delete it
3) create header in zip-file only if we can open file to compress. it reduce cases if archived file with zero length
<img width="772" height="268" alt="image" src="https://github.com/user-attachments/assets/aedfce65-81b8-4976-b286-8e28ce93e996" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty zip archives created during compression are now detected and automatically deleted.
  * Permission-related failures when accessing source files now produce clearer, explicit error outcomes.
* **Refactor**
  * Improved the internal zip file open/close flow to better manage file resources and reduce the risk of instability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->