### PR TITLE
feat: add theme = auto to pick a light/dark theme from terminal background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ testsuite/.venv/
 
 # Agent configs
 CLAUDE.md
+.claude/settings.local.json

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/disintegration/imaging v1.6.2
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.4.0
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect

--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -64,7 +64,9 @@ type ThemeType struct {
 
 // Configuration settings
 type ConfigType struct {
-	Theme string `toml:"theme" comment:"More details are at https://superfile.dev/configure/superfile-config/\nchange your theme"`
+	Theme      string `toml:"theme"       comment:"More details are at https://superfile.dev/configure/superfile-config/\nchange your theme, or set to \"auto\" to pick theme_light/theme_dark based on terminal background"`
+	ThemeLight string `toml:"theme_light" comment:"\nTheme to use when theme is \"auto\" and the terminal background is light."`
+	ThemeDark  string `toml:"theme_dark"  comment:"\nTheme to use when theme is \"auto\" and the terminal background is dark (also the fallback if detection fails)."`
 
 	Editor    string `toml:"editor"     comment:"\nThe editor files will be opened with. (Leave blank to use the EDITOR environment variable)."`
 	DirEditor string `toml:"dir_editor" comment:"\nThe editor directories will be opened with. (Leave blank to use the default editors)."`

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -21,6 +21,10 @@ import (
 	"github.com/yorukot/superfile/src/config/icon"
 )
 
+// ThemeAuto is the special theme value that resolves to theme_light or
+// theme_dark based on the terminal's detected background color.
+const ThemeAuto = "auto"
+
 // Load configurations from the configuration file. Compares the content
 // with the default values and modify the config file to include default configs
 // if the FixConfigFile flag is on
@@ -88,16 +92,8 @@ func ValidateConfig(c *ConfigType) error {
 		)
 	}
 
-	if c.Theme == "auto" && (c.ThemeLight == "" || c.ThemeDark == "") {
-		return errors.New(
-			LoadConfigError("theme", "theme_light and theme_dark must both be set when theme is \"auto\"."),
-		)
-	}
-
-	if c.Theme == "auto" && (c.ThemeLight == "auto" || c.ThemeDark == "auto") {
-		return errors.New(
-			LoadConfigError("theme", "theme_light and theme_dark cannot be set to \"auto\"; use concrete theme names."),
-		)
+	if err := validateThemeAuto(c); err != nil {
+		return err
 	}
 
 	if ansi.StringWidth(c.BorderTop) != 1 {
@@ -105,6 +101,28 @@ func ValidateConfig(c *ConfigType) error {
 	}
 
 	return validateBorders(c)
+}
+
+// validateThemeAuto checks the theme_light/theme_dark constraints that only
+// apply when theme is set to ThemeAuto.
+func validateThemeAuto(c *ConfigType) error {
+	if c.Theme != ThemeAuto {
+		return nil
+	}
+
+	if c.ThemeLight == "" || c.ThemeDark == "" {
+		return errors.New(
+			LoadConfigError("theme", "theme_light and theme_dark must both be set when theme is \"auto\"."),
+		)
+	}
+
+	if c.ThemeLight == ThemeAuto || c.ThemeDark == ThemeAuto {
+		return errors.New(
+			LoadConfigError("theme", "theme_light and theme_dark cannot be set to \"auto\"; use concrete theme names."),
+		)
+	}
+
+	return nil
 }
 
 func validateBorders(c *ConfigType) error {
@@ -203,7 +221,7 @@ func LoadHotkeysFile(ignoreMissingFields bool) {
 // not "auto" it is returned unchanged. Otherwise themeDark or themeLight is
 // returned based on hasDarkBG.
 func ResolveThemeName(theme, themeLight, themeDark string, hasDarkBG bool) string {
-	if theme != "auto" {
+	if theme != ThemeAuto {
 		return theme
 	}
 	if hasDarkBG {
@@ -220,14 +238,14 @@ func ResolveThemeName(theme, themeLight, themeDark string, hasDarkBG bool) strin
 // (e.g. Mosh, or proxies layered in front of SSH/Mosh) hit this path even
 // though the terminal itself is fine.
 func ShouldWarnAutoDetectFailed(theme string, bg color.Color, err error) bool {
-	return theme == "auto" && (err != nil || bg == nil)
+	return theme == ThemeAuto && (err != nil || bg == nil)
 }
 
 // LoadThemeFile : Load configurations from theme file into &theme
 // set default values if we cant read user's theme file
 func LoadThemeFile() {
 	themeName := Config.Theme
-	if themeName == "auto" {
+	if themeName == ThemeAuto {
 		bg, err := lipgloss.BackgroundColor(os.Stdin, os.Stdout)
 		if ShouldWarnAutoDetectFailed(Config.Theme, bg, err) {
 			fmt.Fprintln(os.Stderr, "Warning: theme = \"auto\" could not detect your terminal's "+

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -94,6 +94,12 @@ func ValidateConfig(c *ConfigType) error {
 		)
 	}
 
+	if c.Theme == "auto" && (c.ThemeLight == "auto" || c.ThemeDark == "auto") {
+		return errors.New(
+			LoadConfigError("theme", "theme_light and theme_dark cannot be set to \"auto\"; use concrete theme names."),
+		)
+	}
+
 	if ansi.StringWidth(c.BorderTop) != 1 {
 		return errors.New(LoadConfigError("border_top", "Border character must be exactly one cell wide."))
 	}

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -185,6 +185,19 @@ func LoadHotkeysFile(ignoreMissingFields bool) {
 	}
 }
 
+// ResolveThemeName returns the name of the theme file to load. If theme is
+// not "auto" it is returned unchanged. Otherwise themeDark or themeLight is
+// returned based on hasDarkBG.
+func ResolveThemeName(theme, themeLight, themeDark string, hasDarkBG bool) string {
+	if theme != "auto" {
+		return theme
+	}
+	if hasDarkBG {
+		return themeDark
+	}
+	return themeLight
+}
+
 // LoadThemeFile : Load configurations from theme file into &theme
 // set default values if we cant read user's theme file
 func LoadThemeFile() {

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"runtime"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/pelletier/go-toml/v2"
 
@@ -207,7 +208,13 @@ func ResolveThemeName(theme, themeLight, themeDark string, hasDarkBG bool) strin
 // LoadThemeFile : Load configurations from theme file into &theme
 // set default values if we cant read user's theme file
 func LoadThemeFile() {
-	themeFile := filepath.Join(variable.ThemeFolder, Config.Theme+".toml")
+	themeName := Config.Theme
+	if themeName == "auto" {
+		hasDarkBG := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+		themeName = ResolveThemeName(Config.Theme, Config.ThemeLight, Config.ThemeDark, hasDarkBG)
+	}
+
+	themeFile := filepath.Join(variable.ThemeFolder, themeName+".toml")
 	if err := LoadUserTheme(themeFile, &Theme); err != nil {
 		slog.Error("Could not read user's theme file. Falling back to default theme", "error", err)
 		err = toml.Unmarshal([]byte(DefaultThemeString), &Theme)

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"image/color"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -205,11 +206,29 @@ func ResolveThemeName(theme, themeLight, themeDark string, hasDarkBG bool) strin
 	return themeLight
 }
 
+// ShouldWarnAutoDetectFailed reports whether the user should be warned that
+// theme = "auto" could not get a conclusive background color reading from
+// the terminal (bg == nil or err != nil), meaning the resolved theme fell
+// back to themeDark without ever knowing the terminal's actual background.
+// Multiplexers, remote-access bridges, and protocols that don't relay OSC 11
+// (e.g. Mosh, or proxies layered in front of SSH/Mosh) hit this path even
+// though the terminal itself is fine.
+func ShouldWarnAutoDetectFailed(theme string, bg color.Color, err error) bool {
+	return theme == "auto" && (err != nil || bg == nil)
+}
+
 // LoadThemeFile : Load configurations from theme file into &theme
 // set default values if we cant read user's theme file
 func LoadThemeFile() {
 	themeName := Config.Theme
 	if themeName == "auto" {
+		bg, err := lipgloss.BackgroundColor(os.Stdin, os.Stdout)
+		if ShouldWarnAutoDetectFailed(Config.Theme, bg, err) {
+			fmt.Fprintln(os.Stderr, "Warning: theme = \"auto\" could not detect your terminal's "+
+				"background color, so superfile is falling back to theme_dark. This can happen over "+
+				"Mosh or behind some SSH/remote-access bridges that don't relay the required terminal "+
+				"query. Set theme to theme_light or theme_dark explicitly to fix this.")
+		}
 		hasDarkBG := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
 		themeName = ResolveThemeName(Config.Theme, Config.ThemeLight, Config.ThemeDark, hasDarkBG)
 	}

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -86,6 +86,12 @@ func ValidateConfig(c *ConfigType) error {
 		)
 	}
 
+	if c.Theme == "auto" && (c.ThemeLight == "" || c.ThemeDark == "") {
+		return errors.New(
+			LoadConfigError("theme", "theme_light and theme_dark must both be set when theme is \"auto\"."),
+		)
+	}
+
 	if ansi.StringWidth(c.BorderTop) != 1 {
 		return errors.New(LoadConfigError("border_top", "Border character must be exactly one cell wide."))
 	}

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -242,30 +242,22 @@ func ShouldWarnAutoDetectFailed(theme string, bg color.Color, err error) bool {
 	return theme == ThemeAuto && (err != nil || bg == nil)
 }
 
-// isDarkColor returns whether c is dark, based on the luminance portion of
-// the color as interpreted as HSL. Mirrors lipgloss's own unexported
-// isDarkColor, which HasDarkBackground uses after it queries the terminal.
-func isDarkColor(c color.Color) bool {
-	col, ok := colorful.MakeColor(c)
+// isDarkColor reports whether bg should be treated as a dark background,
+// given the (bg, err) pair already returned by lipgloss.BackgroundColor.
+// This mirrors lipgloss.HasDarkBackground's own logic (defaulting to dark on
+// a failed or inconclusive query) without re-querying the terminal, since
+// that second query is what caused the delay and inconsistent fallback
+// behavior the reuse-bg-and-err review comment flagged.
+func isDarkColor(bg color.Color, err error) bool {
+	if err != nil || bg == nil {
+		return true
+	}
+	col, ok := colorful.MakeColor(bg)
 	if !ok {
 		return true
 	}
 	_, _, l := col.Hsl()
 	return l < 0.5
-}
-
-// hasDarkBackground reports whether bg should be treated as a dark
-// background, given the (bg, err) pair already returned by
-// lipgloss.BackgroundColor. This mirrors lipgloss.HasDarkBackground's own
-// logic (defaulting to dark on a failed or inconclusive query) without
-// re-querying the terminal, since that second query is what caused the
-// delay and inconsistent fallback behavior the reuse-bg-and-err review
-// comment flagged.
-func hasDarkBackground(bg color.Color, err error) bool {
-	if err != nil || bg == nil {
-		return true
-	}
-	return isDarkColor(bg)
 }
 
 // LoadThemeFile : Load configurations from theme file into &theme
@@ -280,7 +272,7 @@ func LoadThemeFile() {
 				"Mosh or behind some SSH/remote-access bridges that don't relay the required terminal "+
 				"query. Set theme to theme_light or theme_dark explicitly to fix this.")
 		}
-		themeName = ResolveThemeName(Config.Theme, Config.ThemeLight, Config.ThemeDark, hasDarkBackground(bg, err))
+		themeName = ResolveThemeName(Config.Theme, Config.ThemeLight, Config.ThemeDark, isDarkColor(bg, err))
 	}
 
 	themeFile := filepath.Join(variable.ThemeFolder, themeName+".toml")

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -13,6 +13,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/lucasb-eyer/go-colorful"
 	"github.com/pelletier/go-toml/v2"
 
 	"github.com/yorukot/superfile/src/pkg/utils"
@@ -241,6 +242,32 @@ func ShouldWarnAutoDetectFailed(theme string, bg color.Color, err error) bool {
 	return theme == ThemeAuto && (err != nil || bg == nil)
 }
 
+// isDarkColor returns whether c is dark, based on the luminance portion of
+// the color as interpreted as HSL. Mirrors lipgloss's own unexported
+// isDarkColor, which HasDarkBackground uses after it queries the terminal.
+func isDarkColor(c color.Color) bool {
+	col, ok := colorful.MakeColor(c)
+	if !ok {
+		return true
+	}
+	_, _, l := col.Hsl()
+	return l < 0.5
+}
+
+// hasDarkBackground reports whether bg should be treated as a dark
+// background, given the (bg, err) pair already returned by
+// lipgloss.BackgroundColor. This mirrors lipgloss.HasDarkBackground's own
+// logic (defaulting to dark on a failed or inconclusive query) without
+// re-querying the terminal, since that second query is what caused the
+// delay and inconsistent fallback behavior the reuse-bg-and-err review
+// comment flagged.
+func hasDarkBackground(bg color.Color, err error) bool {
+	if err != nil || bg == nil {
+		return true
+	}
+	return isDarkColor(bg)
+}
+
 // LoadThemeFile : Load configurations from theme file into &theme
 // set default values if we cant read user's theme file
 func LoadThemeFile() {
@@ -253,8 +280,7 @@ func LoadThemeFile() {
 				"Mosh or behind some SSH/remote-access bridges that don't relay the required terminal "+
 				"query. Set theme to theme_light or theme_dark explicitly to fix this.")
 		}
-		hasDarkBG := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
-		themeName = ResolveThemeName(Config.Theme, Config.ThemeLight, Config.ThemeDark, hasDarkBG)
+		themeName = ResolveThemeName(Config.Theme, Config.ThemeLight, Config.ThemeDark, hasDarkBackground(bg, err))
 	}
 
 	themeFile := filepath.Join(variable.ThemeFolder, themeName+".toml")

--- a/src/internal/common/load_config_test.go
+++ b/src/internal/common/load_config_test.go
@@ -160,6 +160,24 @@ func TestValidateConfig_AutoTheme(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "Auto theme with theme_light set to auto fails",
+			mutate: func(c *ConfigType) {
+				c.Theme = "auto"
+				c.ThemeLight = "auto"
+				c.ThemeDark = "catppuccin-mocha"
+			},
+			expectErr: true,
+		},
+		{
+			name: "Auto theme with theme_dark set to auto fails",
+			mutate: func(c *ConfigType) {
+				c.Theme = "auto"
+				c.ThemeLight = "catppuccin-latte"
+				c.ThemeDark = "auto"
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/src/internal/common/load_config_test.go
+++ b/src/internal/common/load_config_test.go
@@ -48,3 +48,80 @@ func TestResolveThemeName(t *testing.T) {
 		})
 	}
 }
+
+func validConfigType() ConfigType {
+	return ConfigType{
+		Theme:                "catppuccin-mocha",
+		DefaultSortType:      0,
+		FilePanelNamePercent: 50,
+		BorderTop:            "─",
+		BorderBottom:         "─",
+		BorderLeft:           "│",
+		BorderRight:          "│",
+		BorderTopLeft:        "╭",
+		BorderTopRight:       "╮",
+		BorderBottomLeft:     "╰",
+		BorderBottomRight:    "╯",
+		BorderMiddleLeft:     "├",
+		BorderMiddleRight:    "┤",
+	}
+}
+
+func TestValidateConfig_AutoTheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(c *ConfigType)
+		expectErr bool
+	}{
+		{
+			name:      "Non-auto theme is unaffected by empty theme_light/theme_dark",
+			mutate:    func(_ *ConfigType) {},
+			expectErr: false,
+		},
+		{
+			name: "Auto theme with both theme_light and theme_dark set passes",
+			mutate: func(c *ConfigType) {
+				c.Theme = "auto"
+				c.ThemeLight = "catppuccin-latte"
+				c.ThemeDark = "catppuccin-mocha"
+			},
+			expectErr: false,
+		},
+		{
+			name: "Auto theme with theme_light unset fails",
+			mutate: func(c *ConfigType) {
+				c.Theme = "auto"
+				c.ThemeDark = "catppuccin-mocha"
+			},
+			expectErr: true,
+		},
+		{
+			name: "Auto theme with theme_dark unset fails",
+			mutate: func(c *ConfigType) {
+				c.Theme = "auto"
+				c.ThemeLight = "catppuccin-latte"
+			},
+			expectErr: true,
+		},
+		{
+			name: "Auto theme with both theme_light and theme_dark unset fails",
+			mutate: func(c *ConfigType) {
+				c.Theme = "auto"
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfigType()
+			tt.mutate(&cfg)
+			err := ValidateConfig(&cfg)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/src/internal/common/load_config_test.go
+++ b/src/internal/common/load_config_test.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"errors"
+	"image/color"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,6 +46,54 @@ func TestResolveThemeName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ResolveThemeName(tt.theme, tt.themeLight, tt.themeDark, tt.hasDarkBG)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestShouldWarnAutoDetectFailed(t *testing.T) {
+	someColor := color.RGBA{R: 255, G: 255, B: 255, A: 255}
+
+	tests := []struct {
+		name     string
+		theme    string
+		bg       color.Color
+		err      error
+		expected bool
+	}{
+		{
+			name:     "Non-auto theme never warns, even if detection failed",
+			theme:    "catppuccin-mocha",
+			bg:       nil,
+			err:      errors.New("input/output is not a terminal"),
+			expected: false,
+		},
+		{
+			name:     "Auto theme with detection error warns",
+			theme:    "auto",
+			bg:       nil,
+			err:      errors.New("input/output is not a terminal"),
+			expected: true,
+		},
+		{
+			name:     "Auto theme with nil color and no error warns (inconclusive query)",
+			theme:    "auto",
+			bg:       nil,
+			err:      nil,
+			expected: true,
+		},
+		{
+			name:     "Auto theme with a resolved color does not warn",
+			theme:    "auto",
+			bg:       someColor,
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ShouldWarnAutoDetectFailed(tt.theme, tt.bg, tt.err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/src/internal/common/load_config_test.go
+++ b/src/internal/common/load_config_test.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveThemeName(t *testing.T) {
+	tests := []struct {
+		name       string
+		theme      string
+		themeLight string
+		themeDark  string
+		hasDarkBG  bool
+		expected   string
+	}{
+		{
+			name:       "Non-auto theme is returned unchanged regardless of background",
+			theme:      "catppuccin-mocha",
+			themeLight: "catppuccin-latte",
+			themeDark:  "catppuccin-mocha",
+			hasDarkBG:  false,
+			expected:   "catppuccin-mocha",
+		},
+		{
+			name:       "Auto mode with dark background picks theme_dark",
+			theme:      "auto",
+			themeLight: "catppuccin-latte",
+			themeDark:  "catppuccin-mocha",
+			hasDarkBG:  true,
+			expected:   "catppuccin-mocha",
+		},
+		{
+			name:       "Auto mode with light background picks theme_light",
+			theme:      "auto",
+			themeLight: "catppuccin-latte",
+			themeDark:  "catppuccin-mocha",
+			hasDarkBG:  false,
+			expected:   "catppuccin-latte",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResolveThemeName(tt.theme, tt.themeLight, tt.themeDark, tt.hasDarkBG)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/src/internal/common/load_config_test.go
+++ b/src/internal/common/load_config_test.go
@@ -27,7 +27,7 @@ func TestResolveThemeName(t *testing.T) {
 		},
 		{
 			name:       "Auto mode with dark background picks theme_dark",
-			theme:      "auto",
+			theme:      ThemeAuto,
 			themeLight: "catppuccin-latte",
 			themeDark:  "catppuccin-mocha",
 			hasDarkBG:  true,
@@ -35,7 +35,7 @@ func TestResolveThemeName(t *testing.T) {
 		},
 		{
 			name:       "Auto mode with light background picks theme_light",
-			theme:      "auto",
+			theme:      ThemeAuto,
 			themeLight: "catppuccin-latte",
 			themeDark:  "catppuccin-mocha",
 			hasDarkBG:  false,
@@ -70,21 +70,21 @@ func TestShouldWarnAutoDetectFailed(t *testing.T) {
 		},
 		{
 			name:     "Auto theme with detection error warns",
-			theme:    "auto",
+			theme:    ThemeAuto,
 			bg:       nil,
 			err:      errors.New("input/output is not a terminal"),
 			expected: true,
 		},
 		{
 			name:     "Auto theme with nil color and no error warns (inconclusive query)",
-			theme:    "auto",
+			theme:    ThemeAuto,
 			bg:       nil,
 			err:      nil,
 			expected: true,
 		},
 		{
 			name:     "Auto theme with a resolved color does not warn",
-			theme:    "auto",
+			theme:    ThemeAuto,
 			bg:       someColor,
 			err:      nil,
 			expected: false,
@@ -131,7 +131,7 @@ func TestValidateConfig_AutoTheme(t *testing.T) {
 		{
 			name: "Auto theme with both theme_light and theme_dark set passes",
 			mutate: func(c *ConfigType) {
-				c.Theme = "auto"
+				c.Theme = ThemeAuto
 				c.ThemeLight = "catppuccin-latte"
 				c.ThemeDark = "catppuccin-mocha"
 			},
@@ -140,7 +140,7 @@ func TestValidateConfig_AutoTheme(t *testing.T) {
 		{
 			name: "Auto theme with theme_light unset fails",
 			mutate: func(c *ConfigType) {
-				c.Theme = "auto"
+				c.Theme = ThemeAuto
 				c.ThemeDark = "catppuccin-mocha"
 			},
 			expectErr: true,
@@ -148,7 +148,7 @@ func TestValidateConfig_AutoTheme(t *testing.T) {
 		{
 			name: "Auto theme with theme_dark unset fails",
 			mutate: func(c *ConfigType) {
-				c.Theme = "auto"
+				c.Theme = ThemeAuto
 				c.ThemeLight = "catppuccin-latte"
 			},
 			expectErr: true,
@@ -156,15 +156,15 @@ func TestValidateConfig_AutoTheme(t *testing.T) {
 		{
 			name: "Auto theme with both theme_light and theme_dark unset fails",
 			mutate: func(c *ConfigType) {
-				c.Theme = "auto"
+				c.Theme = ThemeAuto
 			},
 			expectErr: true,
 		},
 		{
 			name: "Auto theme with theme_light set to auto fails",
 			mutate: func(c *ConfigType) {
-				c.Theme = "auto"
-				c.ThemeLight = "auto"
+				c.Theme = ThemeAuto
+				c.ThemeLight = ThemeAuto
 				c.ThemeDark = "catppuccin-mocha"
 			},
 			expectErr: true,
@@ -172,9 +172,9 @@ func TestValidateConfig_AutoTheme(t *testing.T) {
 		{
 			name: "Auto theme with theme_dark set to auto fails",
 			mutate: func(c *ConfigType) {
-				c.Theme = "auto"
+				c.Theme = ThemeAuto
 				c.ThemeLight = "catppuccin-latte"
-				c.ThemeDark = "auto"
+				c.ThemeDark = ThemeAuto
 			},
 			expectErr: true,
 		},

--- a/src/internal/common/load_config_test.go
+++ b/src/internal/common/load_config_test.go
@@ -103,14 +103,6 @@ func TestIsDarkColor(t *testing.T) {
 	white := color.RGBA{R: 255, G: 255, B: 255, A: 255}
 	black := color.RGBA{R: 0, G: 0, B: 0, A: 255}
 
-	assert.True(t, isDarkColor(black))
-	assert.False(t, isDarkColor(white))
-}
-
-func TestHasDarkBackground(t *testing.T) {
-	white := color.RGBA{R: 255, G: 255, B: 255, A: 255}
-	black := color.RGBA{R: 0, G: 0, B: 0, A: 255}
-
 	tests := []struct {
 		name     string
 		bg       color.Color
@@ -145,7 +137,7 @@ func TestHasDarkBackground(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := hasDarkBackground(tt.bg, tt.err)
+			result := isDarkColor(tt.bg, tt.err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/src/internal/common/load_config_test.go
+++ b/src/internal/common/load_config_test.go
@@ -99,6 +99,58 @@ func TestShouldWarnAutoDetectFailed(t *testing.T) {
 	}
 }
 
+func TestIsDarkColor(t *testing.T) {
+	white := color.RGBA{R: 255, G: 255, B: 255, A: 255}
+	black := color.RGBA{R: 0, G: 0, B: 0, A: 255}
+
+	assert.True(t, isDarkColor(black))
+	assert.False(t, isDarkColor(white))
+}
+
+func TestHasDarkBackground(t *testing.T) {
+	white := color.RGBA{R: 255, G: 255, B: 255, A: 255}
+	black := color.RGBA{R: 0, G: 0, B: 0, A: 255}
+
+	tests := []struct {
+		name     string
+		bg       color.Color
+		err      error
+		expected bool
+	}{
+		{
+			name:     "Detection error falls back to dark",
+			bg:       nil,
+			err:      errors.New("input/output is not a terminal"),
+			expected: true,
+		},
+		{
+			name:     "Nil color with no error falls back to dark",
+			bg:       nil,
+			err:      nil,
+			expected: true,
+		},
+		{
+			name:     "Black background is dark",
+			bg:       black,
+			err:      nil,
+			expected: true,
+		},
+		{
+			name:     "White background is not dark",
+			bg:       white,
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasDarkBackground(tt.bg, tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func validConfigType() ConfigType {
 	return ConfigType{
 		Theme:                "catppuccin-mocha",

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -94,8 +94,17 @@ file_panel_name_percent = 50
 ###############################################################################
 
 #-- Theme
-# Put your theme's name here!
+# Put your theme's name here! Or set this to "auto" to automatically pick
+# theme_light or theme_dark below based on your terminal's background color.
 theme = "catppuccin-mocha"
+
+#-- Theme (light) -- only used when theme = "auto"
+theme_light = ""
+
+#-- Theme (dark) -- only used when theme = "auto"
+# If your terminal's background color can't be detected, this is the theme
+# superfile falls back to.
+theme_dark = ""
 
 #-- Code Previewer
 # Whether to use the builtin syntax highlighting with chroma or use bat. Values: "" for builtin chroma, "bat" for bat

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -24,7 +24,20 @@ To see the path locations of your superfile files, use the command `spf pl`.
 
 - ###### theme
 
-[Click here](/configure/custom-theme) for instructions to edit the theme.
+[Click here](/configure/custom-theme) for instructions to edit the theme. Set
+this to `"auto"` to automatically switch between `theme_light` and
+`theme_dark` based on your terminal's background color, detected once at
+startup.
+
+- ###### theme_light
+
+The theme to use when `theme` is `"auto"` and your terminal has a light
+background. Ignored otherwise.
+
+- ###### theme_dark
+
+The theme to use when `theme` is `"auto"` and your terminal has a dark
+background. Ignored otherwise.
 
 - ###### editor
 

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -24,21 +24,15 @@ To see the path locations of your superfile files, use the command `spf pl`.
 
 - ###### theme
 
-[Click here](/configure/custom-theme) for instructions to edit the theme. Set
-this to `"auto"` to automatically switch between `theme_light` and
-`theme_dark` based on your terminal's background color, detected once at
-startup.
+[Click here](/configure/custom-theme) for instructions to edit the theme. Set this to `"auto"` to automatically switch between `theme_light` and `theme_dark` based on your terminal's background color, detected once at startup.
 
 - ###### theme_light
 
-The theme to use when `theme` is `"auto"` and your terminal has a light
-background. Ignored otherwise.
+The theme to use when `theme` is `"auto"` and your terminal has a light background. Ignored otherwise.
 
 - ###### theme_dark
 
-The theme to use when `theme` is `"auto"` and your terminal has a dark
-background. Ignored otherwise. This is also the fallback theme if superfile
-can't detect your terminal's background color.
+The theme to use when `theme` is `"auto"` and your terminal has a dark background. Ignored otherwise. This is also the fallback theme if superfile can't detect your terminal's background color.
 
 - ###### editor
 

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -37,7 +37,8 @@ background. Ignored otherwise.
 - ###### theme_dark
 
 The theme to use when `theme` is `"auto"` and your terminal has a dark
-background. Ignored otherwise.
+background. Ignored otherwise. This is also the fallback theme if superfile
+can't detect your terminal's background color.
 
 - ###### editor
 


### PR DESCRIPTION
## Summary
- Closes #468. Adds `theme_light` / `theme_dark` config fields and a new `theme = "auto"` sentinel value that resolves to one or the other based on the terminal's actual background color (queried once at startup via OSC 11 through lipgloss), instead of requiring users to manually edit `config.toml` and restart when they switch their terminal's color scheme.
- Validates that `theme_light`/`theme_dark` are set when `theme = "auto"` is used.
- Warns on stderr (rather than failing silently) when background detection is inconclusive — e.g. over Mosh or some SSH/remote-access bridges that don't relay the OSC 11 query — and falls back to `theme_dark`.
- Documents the new fields in `superfile-config.mdx` and ships sensible defaults in `config.toml`.

## Test plan
- [x] `go test ./...` passes
- [x] `go build ./...` passes
- [x] Manually verified `theme = "auto"` resolves to `theme_light`/`theme_dark` based on terminal background, and that the stderr warning fires when detection is inconclusive (e.g. over Mosh)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `theme = "auto"` support that selects a theme based on terminal background.
  * Added `theme_light` and `theme_dark` options for explicit light/dark selection and fallback behavior.

* **Bug Fixes**
  * Improved auto-detection handling when terminal background can’t be determined: falls back to the dark theme and shows a warning.

* **Tests**
  * Added unit tests covering theme auto-resolution, warning behavior, and config validation for auto mode.

* **Documentation**
  * Updated superfile config docs with guidance for `auto`, `theme_light`, and `theme_dark`.

* **Chores**
  * Updated `.gitignore` to exclude a local Claude settings file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->