### PR TITLE
fix: Fix incorrect copy behaviour when source-file is symlink.

### DIFF
--- a/src/internal/file_operations.go
+++ b/src/internal/file_operations.go
@@ -125,6 +125,19 @@ func copyDir(src, dst string, srcInfo os.FileInfo) error {
 	return nil
 }
 
+// is an equivalent of "cp -P" command
+func copyLinkFile(src, dst string) error {
+	target, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(target, dst)
+}
+
+func isSymlink(info os.FileInfo) bool {
+	return info.Mode()&os.ModeSymlink != 0
+}
+
 // copyFile copies a single file
 func copyFile(src, dst string, srcInfo os.FileInfo) error {
 	srcFile, err := os.Open(src)
@@ -223,6 +236,9 @@ func actualPasteOperation(info os.FileInfo, path string, newPath string, cut boo
 		}
 		err = os.MkdirAll(newPath, info.Mode())
 		return err
+	}
+	if isSymlink(info) {
+		return copyLinkFile(path, newPath)
 	}
 
 	// File


### PR DESCRIPTION
Fix incorrect copy behaviour when source-file is symlink.
before:
<img width="515" height="172" alt="image" src="https://github.com/user-attachments/assets/fcf3cc3a-1ce4-4f81-8529-fa2321312a1b" />

after:
<img width="1091" height="385" alt="image" src="https://github.com/user-attachments/assets/638db35b-be1a-41ed-a7f8-5eeb75c7214c" />
