### PR TITLE
fix(docs): enable GFM tables in MDX content pages

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -11,6 +11,8 @@ export default defineConfig({
 	integrations: [mdx(), sitemap()],
 
 	markdown: {
+		// Required for GFM tables in MDX content; undefined is treated as false by @astrojs/mdx.
+		gfm: true,
 		shikiConfig: {
 			theme: "catppuccin-mocha",
 			wrap: false


### PR DESCRIPTION
MDX content such as the hotkey list was rendering markdown tables as plain paragraphs because @astrojs/mdx treats an unset gfm option as disabled. Set markdown.gfm explicitly so remark-gfm runs for .mdx files.

## Before
<img width="748" height="728" alt="image" src="https://github.com/user-attachments/assets/b9e61895-ef86-401c-a3eb-96b592a21248" />

## After
<img width="615" height="685" alt="image" src="https://github.com/user-attachments/assets/ed3d9c4f-29b9-4cd1-a479-89e1a9f3d67f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for tables in Markdown/MDX content, making formatted tables render correctly in the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->