### PR TITLE
fix: PageUp/PageDown clamp instead of wrap

### DIFF
--- a/src/internal/ui/filepanel/navigation.go
+++ b/src/internal/ui/filepanel/navigation.go
@@ -31,17 +31,27 @@ func (m *Model) moveCursorBy(delta int) {
 	m.scrollToCursor(cursor)
 }
 
-func (m *Model) moveCursorByClamped(delta int) {
+func (m *Model) pageScrollBy(delta int) {
 	if m.Empty() {
 		return
 	}
-	cursor := m.cursor + delta
-	if cursor < 0 {
-		cursor = 0
-	} else if cursor >= m.ElemCount() {
-		cursor = m.ElemCount() - 1
+	scrollSize := m.getPageScrollSize()
+	last := m.ElemCount() - 1
+
+	if delta < 0 {
+		if m.cursor < scrollSize {
+			m.scrollToCursor(0)
+			return
+		}
+		m.scrollToCursor(m.cursor - scrollSize)
+		return
 	}
-	m.scrollToCursor(cursor)
+
+	if last-m.cursor < scrollSize {
+		m.scrollToCursor(last)
+		return
+	}
+	m.scrollToCursor(m.cursor + scrollSize)
 }
 
 // Control file panel list up
@@ -55,11 +65,11 @@ func (m *Model) ListDown() {
 }
 
 func (m *Model) PgUp() {
-	m.moveCursorByClamped(-m.getPageScrollSize())
+	m.pageScrollBy(-m.getPageScrollSize())
 }
 
 func (m *Model) PgDown() {
-	m.moveCursorByClamped(m.getPageScrollSize())
+	m.pageScrollBy(m.getPageScrollSize())
 }
 
 // Handles the action of selecting an item in the file panel upwards. (only work on select mode)

--- a/src/internal/ui/filepanel/navigation.go
+++ b/src/internal/ui/filepanel/navigation.go
@@ -35,23 +35,13 @@ func (m *Model) pageScrollBy(delta int) {
 	if m.Empty() {
 		return
 	}
-	scrollSize := m.getPageScrollSize()
-	last := m.ElemCount() - 1
-
-	if delta < 0 {
-		if m.cursor < scrollSize {
-			m.scrollToCursor(0)
-			return
-		}
-		m.scrollToCursor(m.cursor - scrollSize)
-		return
+	cursor := m.cursor + delta
+	if cursor < 0 {
+		cursor = 0
+	} else if cursor >= m.ElemCount() {
+		cursor = m.ElemCount() - 1
 	}
-
-	if last-m.cursor < scrollSize {
-		m.scrollToCursor(last)
-		return
-	}
-	m.scrollToCursor(m.cursor + scrollSize)
+	m.scrollToCursor(cursor)
 }
 
 // Control file panel list up

--- a/src/internal/ui/filepanel/navigation.go
+++ b/src/internal/ui/filepanel/navigation.go
@@ -31,6 +31,19 @@ func (m *Model) moveCursorBy(delta int) {
 	m.scrollToCursor(cursor)
 }
 
+func (m *Model) moveCursorByClamped(delta int) {
+	if m.Empty() {
+		return
+	}
+	cursor := m.cursor + delta
+	if cursor < 0 {
+		cursor = 0
+	} else if cursor >= m.ElemCount() {
+		cursor = m.ElemCount() - 1
+	}
+	m.scrollToCursor(cursor)
+}
+
 // Control file panel list up
 func (m *Model) ListUp() {
 	m.moveCursorBy(-1)
@@ -42,11 +55,11 @@ func (m *Model) ListDown() {
 }
 
 func (m *Model) PgUp() {
-	m.moveCursorBy(-m.getPageScrollSize())
+	m.moveCursorByClamped(-m.getPageScrollSize())
 }
 
 func (m *Model) PgDown() {
-	m.moveCursorBy(m.getPageScrollSize())
+	m.moveCursorByClamped(m.getPageScrollSize())
 }
 
 // Handles the action of selecting an item in the file panel upwards. (only work on select mode)

--- a/src/internal/ui/filepanel/navigation_test.go
+++ b/src/internal/ui/filepanel/navigation_test.go
@@ -143,7 +143,7 @@ func TestPgUpDown(t *testing.T) {
 			name:           "Page navigation with small element count",
 			panel:          testModelWithElemCount(0, 0, 12, 5),
 			pageDown:       true,
-			expectedCursor: 4,
+			expectedCursor: 2, // half of 5 items, same as legacy wrap behavior
 			expectedRender: 0,
 		},
 		{
@@ -166,6 +166,13 @@ func TestPgUpDown(t *testing.T) {
 			pageDown:       true,
 			expectedCursor: 19,
 			expectedRender: 13,
+		},
+		{
+			name:           "Short list page down near end snaps to last item",
+			panel:          testModelWithElemCount(3, 0, 12, 5),
+			pageDown:       true,
+			expectedCursor: 4,
+			expectedRender: 0,
 		},
 	}
 

--- a/src/internal/ui/filepanel/navigation_test.go
+++ b/src/internal/ui/filepanel/navigation_test.go
@@ -119,11 +119,11 @@ func TestPgUpDown(t *testing.T) {
 			expectedRender: 1,
 		},
 		{
-			name:           "Page down near end wraps to start",
+			name:           "Page down near end clamps to last item",
 			panel:          testModelWithElemCount(18, 12, 12, 20),
 			pageDown:       true,
-			expectedCursor: 5, // (18 + 7) % 20 = 5
-			expectedRender: 5,
+			expectedCursor: 19,
+			expectedRender: 13,
 		},
 		{
 			name:           "Page up from middle",
@@ -133,17 +133,17 @@ func TestPgUpDown(t *testing.T) {
 			expectedRender: 3,
 		},
 		{
-			name:           "Page up near beginning wraps to end",
+			name:           "Page up near beginning clamps to first item",
 			panel:          testModelWithElemCount(2, 0, 12, 20),
 			pageDown:       false,
-			expectedCursor: 15, // (2 - 7 + 20) % 20 = 15
-			expectedRender: 9,
+			expectedCursor: 0,
+			expectedRender: 0,
 		},
 		{
 			name:           "Page navigation with small element count",
 			panel:          testModelWithElemCount(0, 0, 12, 5),
 			pageDown:       true,
-			expectedCursor: 2, // (0 + 7) % 5 = 2
+			expectedCursor: 4,
 			expectedRender: 0,
 		},
 		{
@@ -152,6 +152,20 @@ func TestPgUpDown(t *testing.T) {
 			pageDown:       true,
 			expectedCursor: 0,
 			expectedRender: 0,
+		},
+		{
+			name:           "Page up at top stays at top",
+			panel:          testModelWithElemCount(0, 0, 12, 20),
+			pageDown:       false,
+			expectedCursor: 0,
+			expectedRender: 0,
+		},
+		{
+			name:           "Page down at bottom stays at bottom",
+			panel:          testModelWithElemCount(19, 13, 12, 20),
+			pageDown:       true,
+			expectedCursor: 19,
+			expectedRender: 13,
 		},
 	}
 

--- a/src/internal/ui/filepanel/navigation_test.go
+++ b/src/internal/ui/filepanel/navigation_test.go
@@ -143,7 +143,7 @@ func TestPgUpDown(t *testing.T) {
 			name:           "Page navigation with small element count",
 			panel:          testModelWithElemCount(0, 0, 12, 5),
 			pageDown:       true,
-			expectedCursor: 2, // half of 5 items, same as legacy wrap behavior
+			expectedCursor: 4, // full-page scroll clamps to last item
 			expectedRender: 0,
 		},
 		{

--- a/src/internal/ui/filepanel/sort.go
+++ b/src/internal/ui/filepanel/sort.go
@@ -148,13 +148,5 @@ func (m *Model) getPageScrollSize() int {
 		// Use default full page behavior
 		scrollSize = m.PanelElementHeight()
 	}
-	// When all items fit on one screen, scroll half the list (matching legacy
-	// wrap behavior without jumping to the opposite end).
-	if m.ElemCount() <= m.PanelElementHeight() {
-		scrollSize = m.ElemCount() / 2
-		if scrollSize < 1 {
-			scrollSize = 1
-		}
-	}
 	return scrollSize
 }

--- a/src/internal/ui/filepanel/sort.go
+++ b/src/internal/ui/filepanel/sort.go
@@ -148,5 +148,13 @@ func (m *Model) getPageScrollSize() int {
 		// Use default full page behavior
 		scrollSize = m.PanelElementHeight()
 	}
+	// When all items fit on one screen, scroll half the list (matching legacy
+	// wrap behavior without jumping to the opposite end).
+	if m.ElemCount() <= m.PanelElementHeight() {
+		scrollSize = m.ElemCount() / 2
+		if scrollSize < 1 {
+			scrollSize = 1
+		}
+	}
 	return scrollSize
 }


### PR DESCRIPTION
I initially thought the wrapping over top/bottom when scrolling the files with pageup/down was a bug, as it was how i expected it to behave, hence this PR. I now understand this is a deliberate design decision, put putting this PR out anyway, maybe people agree that wrapping in this case is unexpected. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Page Up and Page Down now keep the file panel selection within valid bounds instead of wrapping around at the ends.
  * Page navigation on short lists now behaves more consistently, clamping to the first or last item as expected.
  * Updated navigation checks to cover edge cases at the top, bottom, and near the end of the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->