### PR TITLE
docs: Fix cursor/course typos and other documentation errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Before starting, make sure the theme you want to add doesn’t already exist.
     - Make sure that file previewer is non empty, process panel has at least one process, and clipboard has at least one entry
 - Add a screenshot of these individual panel being focused (To make sure border focus color is good)
     - Sidebar
-    - Processbar
+    - Process panel
 - Add a screenshot of help menu (Press ?)
 - Add a screenshot of popup that opens when you create a new file (Ctrl+n)
 - Add a screenshot of image being preview using your theme.
@@ -59,11 +59,11 @@ Before starting, make sure the theme you want to add doesn’t already exist.
 - Add a screenshot of these individual panels being focused (To make sure border focus color is good)
 
   - Sidebar
-  - Processbar
+  - Process panel
 
   ![Sidebar focused](website/src/assets/contributing/theme-example/2.png)
 
-  ![Processbar focused](website/src/assets/contributing/theme-example/3.png)
+  ![Process panel focused](website/src/assets/contributing/theme-example/3.png)
 
 - Add a screenshot of help menu (Press `?`)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 - [Troubleshooting](#troubleshooting)
 - [Uninstalling](#uninstalling)
   - [macOS and Linux](#macos-and-linux-1)
-  - [Window](#window)
+  - [Windows](#windows)
 - [Contributing](#contributing)
 - [Thanks](#thanks)
   - [Support](#support)
@@ -206,7 +206,7 @@ bash -c "$(curl -sLo- https://superfile.dev/uninstall.sh)"
 
 If you want to inspect the script, see : [uninstall.sh](./website/public/uninstall.sh)
 
-### Window
+### Windows
 
 To uninstall superfile on Windows, use this powershell script.
 

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -166,7 +166,7 @@ func LoadPrerenderedVariables() {
 	FilePreviewUnsupportedImageFormatsText = wrapFilePreviewErrorMsg(
 		"Unsupported image formats")
 	FilePreviewImageConversionErrorText = wrapFilePreviewErrorMsg(
-		"Error convert image to ansi")
+		"Error converting image to ANSI")
 	FilePreviewBatNotInstalledText = wrapFilePreviewErrorMsg(
 		"'bat' is not installed or not found")
 	FilePreviewThumbnailGenerationErrorText = wrapFilePreviewErrorMsg(

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -62,7 +62,7 @@ func (m *model) terminalSizeWarnAfterFirstRender() string {
 	fullWidthString = common.TerminalCorrectSize.Render(fullWidthString)
 
 	heightString := common.MainStyle.Render(" Height = ")
-	return common.FullScreenStyle(m.fullHeight, m.fullWidth).Render(`You change your terminal size too small:` + "\n" +
+	return common.FullScreenStyle(m.fullHeight, m.fullWidth).Render(`Your terminal size is too small:` + "\n" +
 		"Width = " + fullWidthString +
 		heightString + fullHeightString + "\n\n" +
 		"Needed for current config:" + "\n" +

--- a/src/internal/ui/helpmenu/data.go
+++ b/src/internal/ui/helpmenu/data.go
@@ -21,7 +21,7 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 		},
 		{
 			hotkey:         common.Hotkeys.Confirm,
-			description:    "Confirm your select or typing",
+			description:    "Confirm your selection or typing",
 			hotkeyWorkType: globalType,
 		},
 		{
@@ -46,7 +46,7 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 		},
 		{
 			hotkey:         common.Hotkeys.OpenHelpMenu,
-			description:    "Open help menu (hotkeylist)",
+			description:    "Open help menu (hotkey list)",
 			hotkeyWorkType: globalType,
 		},
 		{
@@ -162,12 +162,12 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 		},
 		{
 			hotkey:         common.Hotkeys.FilePanelSelectModeItemsSelectUp,
-			description:    "Select up with your course",
+			description:    "Select up from your cursor",
 			hotkeyWorkType: globalType,
 		},
 		{
 			hotkey:         common.Hotkeys.FilePanelSelectModeItemsSelectDown,
-			description:    "Select down with your course",
+			description:    "Select down from your cursor",
 			hotkeyWorkType: globalType,
 		},
 		{
@@ -195,7 +195,7 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 		},
 		{
 			hotkey:         common.Hotkeys.FilePanelItemCreate,
-			description:    "Create file or folder(end with " + string(filepath.Separator) + " to create a folder)",
+			description:    "Create file or folder (end with " + string(filepath.Separator) + " to create a folder)",
 			hotkeyWorkType: globalType,
 		},
 		{

--- a/src/internal/ui/preview/render.go
+++ b/src/internal/ui/preview/render.go
@@ -79,7 +79,7 @@ func (m *Model) renderImagePreview(r *rendering.Renderer, itemPath string, previ
 	}
 
 	if err != nil {
-		slog.Error("Error convert image to ansi", "error", err)
+		slog.Error("Error converting image to ANSI", "error", err)
 		return r.AddLines(common.FilePreviewImageConversionErrorText).Render(), kittyClear
 	}
 

--- a/src/internal/ui/prompt/consts.go
+++ b/src/internal/ui/prompt/consts.go
@@ -69,7 +69,7 @@ func defaultCommandSlice() []promptCommand {
 		{
 			command:     SplitCommand,
 			usage:       SplitCommand,
-			description: "Open a new panel at a current file panel's path",
+			description: "Open a new panel at the current file panel's path",
 		},
 		{
 			command:     CdCommand,

--- a/src/internal/ui/prompt/model_test.go
+++ b/src/internal/ui/prompt/model_test.go
@@ -297,7 +297,7 @@ func TestModel_Render(t *testing.T) {
 			"├──────────────────────────────────────┤\n" +
 			"│ ':' - Get into Shell mode            │\n" +
 			"│ 'open <PATH>' - Open a new panel at a│\n" +
-			"│ 'split' - Open a new panel at a curre│\n" +
+			"│ 'split' - Open a new panel at the cur│\n" +
 			"│ 'cd <PATH>' - Change directory of cur│\n" +
 			"╰──────────────────────────────────────╯"
 		assert.Equal(t, exp, res)

--- a/src/pkg/utils/file_utils.go
+++ b/src/pkg/utils/file_utils.go
@@ -181,7 +181,7 @@ func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) 
 
 	// Fix done
 	// Inform user about backup location
-	resultErr.userMessage = "config file had issues. Its fixed successfully. Original backed up to : " + backupPath
+	resultErr.userMessage = "config file had issues. It's fixed successfully. Original backed up to : " + backupPath
 	resultErr.isFatal = false
 	// Do not remove backup; user may want to restore manually
 	needsBackupFileRemoval = false

--- a/src/pkg/utils/file_utils_test.go
+++ b/src/pkg/utils/file_utils_test.go
@@ -304,7 +304,7 @@ func TestLoadTomlFileIgnorer(t *testing.T) {
 			assert.True(t, tomlErr.missingFields)
 			assert.Equal(t, expectedVal, tomlVal)
 
-			pref := "config file had issues. Its fixed successfully. Original backed up to : "
+			pref := "config file had issues. It's fixed successfully. Original backed up to : "
 
 			assert.True(t, strings.HasPrefix(tomlErr.userMessage, pref), "Unexpectd error : "+tomlErr.Error())
 

--- a/website/src/content/docs/configure/custom-theme.mdx
+++ b/website/src/content/docs/configure/custom-theme.mdx
@@ -1,6 +1,6 @@
 ---
 title: Custom theme
-description: Custom your own superfile theme
+description: Customize your own superfile theme
 head:
   - tag: title
     content: Custom theme | superfile
@@ -31,11 +31,11 @@ Once you find one you like, copy it and paste it into the theme in the config_pa
 
 [Click me to know where is THEME_DIRECTORY](/configure/config-file-path#config)
 
-If you want to customize your own theme, you can go to `THEME_DIRECTORY/YOUR_THEME_NAME.toml` and copy the existing theme's json to your own theme file
+If you want to customize your own theme, you can go to `THEME_DIRECTORY/YOUR_THEME_NAME.toml` and copy the existing theme's TOML to your own theme file
 
 Don't forget to change the `theme` variable in `config.toml` to your theme name.
 
-[If you are satisfied with your theme, you might as well put it into the default theme list!](/how-to-contribute)
+[If you are satisfied with your theme, you might as well put it into the default theme list!](/contribute/how-to-contribute)
 
 ### Theme settings
 

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -28,7 +28,7 @@ To see the path locations of your superfile files, use the command `spf pl`.
 
 - ###### editor
 
-The editor your files will be opened with (Leave blank to use the EDITOR environment variable. If EDITOR environment variable is not set, it will default to `nano` for macOS/Linux, and `notepad` for Windows.
+The editor your files will be opened with (Leave blank to use the EDITOR environment variable. If EDITOR environment variable is not set, it will default to `nano` for macOS/Linux, and `notepad` for Windows).
 
 - ###### dir_editor
 
@@ -230,7 +230,7 @@ Percentage of file panel width allocated to file names (25-100). Higher values g
 
 `true` => Use nerdfont for directories and file icons.
 
-`false` => Dont use nerdfont. If you don't have or don't want Nerdfont installed you can turn this off
+`false` => Don't use nerdfont. If you don't have or don't want Nerdfont installed you can turn this off
 
 - ###### show_select_icons
 

--- a/website/src/content/docs/contribute/how-to-contribute.md
+++ b/website/src/content/docs/contribute/how-to-contribute.md
@@ -49,12 +49,12 @@ Before starting, make sure the theme you want to add doesn’t already exist.
 
 - Full view of superfile (Including sidebar, file previewer, process panel, metadata panel, and clipboard panel )
   - Make sure that file previewer is non empty, process panel has at least one process, and clipboard has at least one entry
-- Add a screenshot of these individual panel being focused (To make sure border focus color is good)
+- Add a screenshot of these individual panels being focused (To make sure border focus color is good)
   - Sidebar
   - Processbar
 - Add a screenshot of help menu (Press ?)
 - Add a screenshot of popup that opens when you create a new file (Ctrl+n)
-- Add a screenshot of image being preview using your theme.
+- Add a screenshot of image being previewed using your theme.
 - Add a screenshot of successful and unsuccessful shell command.
 <details>
 <summary>Example:</summary>

--- a/website/src/content/docs/contribute/how-to-contribute.md
+++ b/website/src/content/docs/contribute/how-to-contribute.md
@@ -51,7 +51,7 @@ Before starting, make sure the theme you want to add doesn’t already exist.
   - Make sure that file previewer is non empty, process panel has at least one process, and clipboard has at least one entry
 - Add a screenshot of these individual panels being focused (To make sure border focus color is good)
   - Sidebar
-  - Processbar
+  - Process panel
 - Add a screenshot of help menu (Press ?)
 - Add a screenshot of popup that opens when you create a new file (Ctrl+n)
 - Add a screenshot of image being previewed using your theme.
@@ -66,11 +66,11 @@ Before starting, make sure the theme you want to add doesn’t already exist.
 
 - Add a screenshot of these individual panels being focused (To make sure border focus color is good)
   - Sidebar
-  - Processbar
+  - Process panel
 
   ![Sidebar focused](../../../assets/contributing/theme-example/2.png)
 
-  ![Processbar focused](../../../assets/contributing/theme-example/3.png)
+  ![Process panel focused](../../../assets/contributing/theme-example/3.png)
 
 - Add a screenshot of help menu (Press `?`)
 

--- a/website/src/content/docs/contribute/implementation-info.md
+++ b/website/src/content/docs/contribute/implementation-info.md
@@ -12,4 +12,4 @@ The purpose of this document is to provide some implementation details to the re
 
 ## How default configuration files are packaged with app
 
-We use Go's `embed.FS` and embed all files in `src/superfile_config/` into our spf binary. In `src/internal/config_function.go`, the function `LoadAllDefaultConfig()` reads these embedded files, and writes them to disk / in memory configuration variables.
+We use Go's `embed.FS` and embed all files in `src/superfile_config/` into our spf binary. In `src/internal/common/load_config.go`, the function `LoadAllDefaultConfig()` reads these embedded files, and writes them to disk / in memory configuration variables.

--- a/website/src/content/docs/contribute/implementation-info.md
+++ b/website/src/content/docs/contribute/implementation-info.md
@@ -12,4 +12,4 @@ The purpose of this document is to provide some implementation details to the re
 
 ## How default configuration files are packaged with app
 
-We use golangs `embed.FS` and embed all files in `src/superfile_config/` into our spf binary. In `src/internal/config_function.go`, the function `LoadAllDefaultConfig()` reads these embedded files, and write them to disk / in memory configuration variables.
+We use Go's `embed.FS` and embed all files in `src/superfile_config/` into our spf binary. In `src/internal/config_function.go`, the function `LoadAllDefaultConfig()` reads these embedded files, and writes them to disk / in memory configuration variables.

--- a/website/src/content/docs/getting-started/image-preview.md
+++ b/website/src/content/docs/getting-started/image-preview.md
@@ -71,7 +71,7 @@ This sequence queries the terminal for the size of each **cell in pixels**. supe
 - Avoid distortions in previews
 - Adapt to terminal resizes
 
-If your terminal does not support `\x1b[16t`, we fallback to default assumptions like `10×20 px per cell`.
+If your terminal does not support `\x1b[16t`, we fall back to default assumptions like `10×20 px per cell`.
 
 ## Graceful Fallback to ANSI
 

--- a/website/src/content/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/getting-started/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install superfile
-description: Let's install superfile to your computer..
+description: Let's install superfile to your computer.
 head:
   - tag: title
     content: Install superfile | superfile
@@ -22,7 +22,7 @@ If you don't install `Nerd font`, superfile will still work, but the UI may look
 
 Copy and paste the following one-line command into your machine's terminal.
 
-### Linux / MacOs
+### Linux / macOS
 
 With `curl`:
 

--- a/website/src/content/docs/getting-started/tutorial.mdx
+++ b/website/src/content/docs/getting-started/tutorial.mdx
@@ -51,7 +51,7 @@ Press `:` to open command execution bar.
 
 To return focus back onto the file panel, press the same hotkey again.
 
-> For command execution bar you need press `esc` or `ctrl+c`
+> For command execution bar you need to press `esc` or `ctrl+c`
 
 You can also press `f` to show or hide the preview window.
 
@@ -79,7 +79,7 @@ superfile provides multiple hotkeys to move through directories. The angle brack
 
 While focused on the file panel, move the cursor up with `up` or `k` and down with `down` or `j`.
 
-After navigating to the your file/folder, press `enter` or `l` to confirm your selection. Files are opened with your default application (if none set, there will be no response) and folders are opened for viewing. Press `h` or `backspace` to return to the parent directory.
+After navigating to your file/folder, press `enter` or `l` to confirm your selection. Files are opened with your default application (if none set, there will be no response) and folders are opened for viewing. Press `h` or `backspace` to return to the parent directory.
 
 ![panel-movement-demo](../../../assets/demo/panel-movement-demo.gif)
 
@@ -169,7 +169,7 @@ To open a file with an editor, press `e`.
 
 To open the current directory with an editor, press `E` (shift+e).
 
-To change the default file editor, you can set the `EDITOR` environment variable in your terminal or you can use the `editor` config option (take priority over `EDITOR` environment variable). To change the default directory editor, you can use the `dir_editor` config option. For example:
+To change the default file editor, you can set the `EDITOR` environment variable in your terminal or you can use the `editor` config option (takes priority over `EDITOR` environment variable). To change the default directory editor, you can use the `dir_editor` config option. For example:
 
 ```bash
 EDITOR=nvim
@@ -210,11 +210,11 @@ Press `>` to open the prompt in SPF mode. ![Prompt-SPF-Mode](../../../assets/tut
 
 In this mode, you can execute these spf commands :
 
-- `split` - Open a new panel at a current file panel's path.
+- `split` - Open a new panel at the current file panel's path.
 - `open <PATH>` - Open a new panel at a specified path.
 - `cd <PATH>` - Change directory of current panel.
 
-In this mode, You can substitute shell environment variables via `${}`, shell commands via `$()` and prefix path with `~` to get substituted to home directory For example
+In this mode, you can substitute shell environment variables via `${}`, shell commands via `$()` and prefix path with `~` to get substituted to home directory. For example
 
 - `cd ${HOME}` or `cd ~/xyz`
 - `open $(dirname $(which bash))`

--- a/website/src/content/docs/list/hotkey-list.mdx
+++ b/website/src/content/docs/list/hotkey-list.mdx
@@ -69,18 +69,18 @@ Quit superfile and cd to current folder "cd_quit" requires the same setup as ["c
 
 ## File operations
 
-| Function                                             | Key                | Variable name                                      |
-| ---------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| Function                                              | Key                | Variable name                                      |
+| ----------------------------------------------------- | ------------------ | -------------------------------------------------- |
 | Create file or folder (end with / to create a folder) | `ctrl+n`           | `file_panel_item_create`                           |
-| Rename file or folder                                | `ctrl+r`           | `file_panel_item_rename`                           |
-| Copy selected items to the clipboard                 | `ctrl+c`           | `copy_items`                                       |
-| Cut selected items to the clipboard                  | `ctrl+x`           | `cut_items`                                        |
-| Paste clipboard items into the current file panel    | `ctrl+v`, `ctrl+w` | `paste_items`                                      |
-| Delete selected items                                | `ctrl+d`, `delete` | `delete_items`                                     |
-| Permanently delete selected items                    | `D` (shift+d)      | `permanently_delete_items`                         |
-| Copy current or selected file/directory paths        | `ctrl+p`           | `copy_path`                                        |
-| Copy current working directory                       | `c`                | `copy_present_working_directory`                   |
-| Extract compressed file                              | `ctrl+e`           | `extract_file` (normal mode)                       |
-| Zip file or folder to .zip file                      | `ctrl+a`           | `compress_file` (normal mode)                      |
-| Open file with your default editor                   | `e`                | `open_file_with_editor` (normal mode)              |
-| Open current directory with default editor           | `E` (shift+e)      | `open_current_directory_with_editor` (normal mode) |
+| Rename file or folder                                 | `ctrl+r`           | `file_panel_item_rename`                           |
+| Copy selected items to the clipboard                  | `ctrl+c`           | `copy_items`                                       |
+| Cut selected items to the clipboard                   | `ctrl+x`           | `cut_items`                                        |
+| Paste clipboard items into the current file panel     | `ctrl+v`, `ctrl+w` | `paste_items`                                      |
+| Delete selected items                                 | `ctrl+d`, `delete` | `delete_items`                                     |
+| Permanently delete selected items                     | `D` (shift+d)      | `permanently_delete_items`                         |
+| Copy current or selected file/directory paths         | `ctrl+p`           | `copy_path`                                        |
+| Copy current working directory                        | `c`                | `copy_present_working_directory`                   |
+| Extract compressed file                               | `ctrl+e`           | `extract_file` (normal mode)                       |
+| Zip file or folder to .zip file                       | `ctrl+a`           | `compress_file` (normal mode)                      |
+| Open file with your default editor                    | `e`                | `open_file_with_editor` (normal mode)              |
+| Open current directory with default editor            | `E` (shift+e)      | `open_current_directory_with_editor` (normal mode) |

--- a/website/src/content/docs/list/hotkey-list.mdx
+++ b/website/src/content/docs/list/hotkey-list.mdx
@@ -22,14 +22,14 @@ These are the default hotkeys and you can [change](/configure/custom-hotkeys) th
 | Quit superfile and cd to current folder | `Q`                   | `cd_quit`           |
 | Confirm typing                          | `enter`               | `confirm_typing`    |
 | Cancel typing                           | `ctrl+c`, `esc`       | `cancel_typing`     |
-| Open help menu(hotkeylist)              | `?`                   | `open_help_menu`    |
+| Open help menu (hotkey list)            | `?`                   | `open_help_menu`    |
 | Open prompt in shell mode               | `:`                   | `open_command_line` |
 | Open prompt in spf mode                 | `>`                   | `open_spf_prompt`   |
 | Open zoxide navigation modal            | `z`                   | `open_zoxide`       |
 
 :::note
 
-Quit superfile and cd to current folder "cd_quit" require the same scripts as ["cd_on_quit"](/configure/superfile-config/#cd_on_quit) setting
+Quit superfile and cd to current folder "cd_quit" requires the same setup as ["cd_on_quit"](/configure/superfile-config/#cd_on_quit) setting
 
 :::
 
@@ -71,7 +71,7 @@ Quit superfile and cd to current folder "cd_quit" require the same scripts as ["
 
 | Function                                             | Key                | Variable name                                      |
 | ---------------------------------------------------- | ------------------ | -------------------------------------------------- |
-| Create file or folder(/ ends with creating a folder) | `ctrl+n`           | `file_panel_item_create`                           |
+| Create file or folder (end with / to create a folder) | `ctrl+n`           | `file_panel_item_create`                           |
 | Rename file or folder                                | `ctrl+r`           | `file_panel_item_rename`                           |
 | Copy selected items to the clipboard                 | `ctrl+c`           | `copy_items`                                       |
 | Cut selected items to the clipboard                  | `ctrl+x`           | `cut_items`                                        |

--- a/website/src/content/docs/overview.md
+++ b/website/src/content/docs/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: An overview of why we built this starter, including its features, the libraries used, and more.
+description: An overview of why we built superfile, including its features, the libraries used, and more.
 head:
   - tag: title
     content: Overview | superfile

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -10,8 +10,8 @@ head:
 
 Try these things below:
 
-- Make sure you already install [nerdfont](https://www.nerdfonts.com/font-downloads) (You can choose whatever font you like!)
-- Apply this font to your terminal,This may require different settings depending on the terminal.You can check how to set it up!
+- Make sure you have already installed [nerdfont](https://www.nerdfonts.com/font-downloads) (You can choose whatever font you like!)
+- Apply this font to your terminal. This may require different settings depending on the terminal. You can check how to set it up!
 
 ## Help! My superfile's rendering is all messed up!
 

--- a/website/src/content/docs/zh-tw/configure/custom-theme.mdx
+++ b/website/src/content/docs/zh-tw/configure/custom-theme.mdx
@@ -35,7 +35,7 @@ $EDITOR CONFIG_PATH
 
 別忘了將 `config.toml` 中的 `theme` 變數改成你的主題名稱。
 
-[如果你對自己的主題很滿意，不妨把它加入預設主題列表！](/zh-tw/how-to-contribute)
+[如果你對自己的主題很滿意，不妨把它加入預設主題列表！](/zh-tw/contribute/how-to-contribute)
 
 ### 主題設定
 

--- a/website/src/content/docs/zh-tw/contribute/implementation-info.md
+++ b/website/src/content/docs/zh-tw/contribute/implementation-info.md
@@ -12,4 +12,4 @@ head:
 
 ## 預設設定檔如何與應用程式一起封裝
 
-我們使用 golangs 的 `embed.FS`，並將 `src/superfile_config/` 中的所有檔案嵌入到 spf binary。於 `src/internal/config_function.go` 中，`LoadAllDefaultConfig()` 函式會讀取這些嵌入檔案，並將它們寫入磁碟或記憶體中的設定變數。
+我們使用 Go 的 `embed.FS`，並將 `src/superfile_config/` 中的所有檔案嵌入到 spf binary。於 `src/internal/config_function.go` 中，`LoadAllDefaultConfig()` 函式會讀取這些嵌入檔案，並將它們寫入磁碟或記憶體中的設定變數。

--- a/website/src/content/docs/zh-tw/contribute/implementation-info.md
+++ b/website/src/content/docs/zh-tw/contribute/implementation-info.md
@@ -12,4 +12,4 @@ head:
 
 ## 預設設定檔如何與應用程式一起封裝
 
-我們使用 Go 的 `embed.FS`，並將 `src/superfile_config/` 中的所有檔案嵌入到 spf binary。於 `src/internal/config_function.go` 中，`LoadAllDefaultConfig()` 函式會讀取這些嵌入檔案，並將它們寫入磁碟或記憶體中的設定變數。
+我們使用 Go 的 `embed.FS`，並將 `src/superfile_config/` 中的所有檔案嵌入到 spf binary。於 `src/internal/common/load_config.go` 中，`LoadAllDefaultConfig()` 函式會讀取這些嵌入檔案，並將它們寫入磁碟或記憶體中的設定變數。


### PR DESCRIPTION
Correct 'course' to 'cursor' in help menu descriptions and align wording with the hotkey list docs. Also fix assorted typos in docs, README, and user-facing UI strings (grammar, broken links, missing punctuation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README Windows section anchors/headings and corrected wording across installation, tutorial, troubleshooting, hotkey lists, and custom theme guides (including TOML guidance and corrected link paths), plus language/formatting fixes.
* **Bug Fixes**
  * Refined user-facing text for the terminal-size warning, preview-related ANSI conversion error messaging, config-repair success output, and several help/prompt hotkey and command descriptions.
* **Tests**
  * Updated a render-output expectation to match the latest displayed suggestion text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->