### PR TITLE
fix(preview): decode UTF-8 runes in IsBufferPrintable text detection

### DIFF
--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -203,7 +203,7 @@ func IsBufferPrintable(buffer []byte) bool {
 			break
 		}
 		r, n := utf8.DecodeRune(buffer[i:])
-		if r == utf8.RuneError {
+		if r == utf8.RuneError && n == 1 {
 			return false
 		}
 		if !unicode.IsPrint(r) && !unicode.IsSpace(r) {

--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -197,11 +197,19 @@ func GetHelpMenuHotkeyString(hotkeys []string) string {
 
 // Separated this out out for easy testing
 func IsBufferPrintable(buffer []byte) bool {
-	for _, b := range buffer {
-		// This will also handle b==0
-		if !unicode.IsPrint(rune(b)) && !unicode.IsSpace(rune(b)) {
+	i := 0
+	for i < len(buffer) {
+		if !utf8.FullRune(buffer[i:]) {
+			break
+		}
+		r, n := utf8.DecodeRune(buffer[i:])
+		if r == utf8.RuneError {
 			return false
 		}
+		if !unicode.IsPrint(r) && !unicode.IsSpace(r) {
+			return false
+		}
+		i += n
 	}
 	return true
 }

--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"image/color"
@@ -195,18 +194,22 @@ func GetHelpMenuHotkeyString(hotkeys []string) string {
 	return hotkey.String()
 }
 
-// Separated this out out for easy testing
-func IsBufferPrintable(buffer []byte) bool {
+// Separated this out out for easy testing.
+// atEOF indicates whether buffer is a complete trailing slice of the input
+// (true EOF). Incomplete UTF-8 at the end is allowed when atEOF is false
+// (fixed-size reads may truncate a multi-byte rune), but rejected at EOF.
+func IsBufferPrintable(buffer []byte, atEOF bool) bool {
 	i := 0
 	for i < len(buffer) {
 		if !utf8.FullRune(buffer[i:]) {
-			break
+			return !atEOF
 		}
 		r, n := utf8.DecodeRune(buffer[i:])
 		if r == utf8.RuneError && n == 1 {
 			return false
 		}
-		if !unicode.IsPrint(r) && !unicode.IsSpace(r) {
+		// Allow UTF-8 BOM (U+FEFF); unicode.IsPrint/IsSpace reject it.
+		if r != '\uFEFF' && !unicode.IsPrint(r) && !unicode.IsSpace(r) {
 			return false
 		}
 		i += n
@@ -240,13 +243,23 @@ func IsTextFile(filename string) (bool, error) {
 	}
 	defer file.Close()
 
-	reader := bufio.NewReader(file)
 	buffer := make([]byte, DefaultBufferSize)
-	cnt, err := reader.Read(buffer)
-	if err != nil && !errors.Is(err, io.EOF) {
+	cnt, err := io.ReadFull(file, buffer)
+	switch {
+	case err == nil:
+		// Full buffer filled; peek one byte to distinguish exact-size EOF
+		// from a mid-file truncation of a multi-byte UTF-8 sequence.
+		var extra [1]byte
+		n, err2 := file.Read(extra[:])
+		if err2 != nil && !errors.Is(err2, io.EOF) {
+			return false, err2
+		}
+		return IsBufferPrintable(buffer, n == 0), nil
+	case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+		return IsBufferPrintable(buffer[:cnt], true), nil
+	default:
 		return false, err
 	}
-	return IsBufferPrintable(buffer[:cnt]), nil
 }
 
 // Although some characters like `\x0b`(vertical tab) are printable,

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -130,8 +130,8 @@ func TestIsBufferPrintable(t *testing.T) {
 		{"\x0f(SI)", false},
 		{"\x1b(ESC)", false},
 		{"\x7f(DEL)", false},
-		{"pure ASCII slurm output", true},
-		{"Julia precompile \xe2\x9c\x93 DRL_Sphere", true},
+		{"plain ASCII log output", true},
+		{"status line \xe2\x9c\x93 example module", true},
 		{"box drawing \xe2\x94\x8c\xe2\x94\x80\xe2\x94\x90", true},
 		{"\xe2\x9c", true}, // truncated UTF-8 at buffer end (fixed-size read)
 	}
@@ -146,12 +146,12 @@ func TestIsBufferPrintable(t *testing.T) {
 }
 
 func TestIsTextFile(t *testing.T) {
-	t.Run("UTF-8 Slurm err log content", func(t *testing.T) {
+	t.Run("UTF-8 log with Unicode early in file", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, "18813962_err")
-		content := "  Activating project at `/path/to/project`\n" +
-			"Precompiling DRL_Sphere...\n" +
-			"    \xe2\x9c\x93 DRL_Sphere\n"
+		path := filepath.Join(dir, "stderr.log")
+		content := "  Loading project at `/path/to/project`\n" +
+			"Building example module...\n" +
+			"    \xe2\x9c\x93 example module\n"
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 		isText, err := IsTextFile(path)

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -133,6 +133,8 @@ func TestIsBufferPrintable(t *testing.T) {
 		{"plain ASCII log output", true},
 		{"status line \xe2\x9c\x93 example module", true},
 		{"box drawing \xe2\x94\x8c\xe2\x94\x80\xe2\x94\x90", true},
+		{"\xef\xbf\xbd(UTF-8 replacement character)", true},
+		{"\xff(invalid UTF-8 byte)", false},
 		{"\xe2\x9c", true}, // truncated UTF-8 at buffer end (fixed-size read)
 	}
 	for _, tt := range inputs {

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -3,9 +3,12 @@ package common
 import (
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringTruncate(t *testing.T) {
@@ -119,7 +122,7 @@ func TestIsBufferPrintable(t *testing.T) {
 		{"hello", true},
 		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", true},
 		{"Horizontal Tab and NewLine\t\t\n\n", true},
-		{"\xa0(NBSP)", true},
+		{"\xc2\xa0(UTF-8 NBSP)", true},
 		{"\x0b(Vertical Tab)", true},
 		{"\x0d(CR)", true},
 		{"ASCII control characters : \x00(NULL)", false},
@@ -127,6 +130,10 @@ func TestIsBufferPrintable(t *testing.T) {
 		{"\x0f(SI)", false},
 		{"\x1b(ESC)", false},
 		{"\x7f(DEL)", false},
+		{"pure ASCII slurm output", true},
+		{"Julia precompile \xe2\x9c\x93 DRL_Sphere", true},
+		{"box drawing \xe2\x94\x8c\xe2\x94\x80\xe2\x94\x90", true},
+		{"\xe2\x9c", true}, // truncated UTF-8 at buffer end (fixed-size read)
 	}
 	for _, tt := range inputs {
 		t.Run(fmt.Sprintf("Testing if buffer %q is printable", tt.input), func(t *testing.T) {
@@ -136,6 +143,31 @@ func TestIsBufferPrintable(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsTextFile(t *testing.T) {
+	t.Run("UTF-8 Slurm err log content", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "18813962_err")
+		content := "  Activating project at `/path/to/project`\n" +
+			"Precompiling DRL_Sphere...\n" +
+			"    \xe2\x9c\x93 DRL_Sphere\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+		isText, err := IsTextFile(path)
+		require.NoError(t, err)
+		assert.True(t, isText)
+	})
+
+	t.Run("binary with NUL", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "binary")
+		require.NoError(t, os.WriteFile(path, []byte("hello\x00world"), 0o644))
+
+		isText, err := IsTextFile(path)
+		require.NoError(t, err)
+		assert.False(t, isText)
+	})
 }
 
 func TestIsExtensionExtractable(t *testing.T) {

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"os"
@@ -116,30 +117,36 @@ func TestHelpHotkeyString(t *testing.T) {
 func TestIsBufferPrintable(t *testing.T) {
 	var inputs = []struct {
 		input    string
+		atEOF    bool
 		expected bool
 	}{
-		{"", true},
-		{"hello", true},
-		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", true},
-		{"Horizontal Tab and NewLine\t\t\n\n", true},
-		{"\xc2\xa0(UTF-8 NBSP)", true},
-		{"\x0b(Vertical Tab)", true},
-		{"\x0d(CR)", true},
-		{"ASCII control characters : \x00(NULL)", false},
-		{"\x05(ENQ)", false},
-		{"\x0f(SI)", false},
-		{"\x1b(ESC)", false},
-		{"\x7f(DEL)", false},
-		{"plain ASCII log output", true},
-		{"status line \xe2\x9c\x93 example module", true},
-		{"box drawing \xe2\x94\x8c\xe2\x94\x80\xe2\x94\x90", true},
-		{"\xef\xbf\xbd(UTF-8 replacement character)", true},
-		{"\xff(invalid UTF-8 byte)", false},
-		{"\xe2\x9c", true}, // truncated UTF-8 at buffer end (fixed-size read)
+		{"", true, true},
+		{"hello", true, true},
+		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", true, true},
+		{"Horizontal Tab and NewLine\t\t\n\n", true, true},
+		{"\xc2\xa0(UTF-8 NBSP)", true, true},
+		{"\x0b(Vertical Tab)", true, true},
+		{"\x0d(CR)", true, true},
+		{"ASCII control characters : \x00(NULL)", true, false},
+		{"\x05(ENQ)", true, false},
+		{"\x0f(SI)", true, false},
+		{"\x1b(ESC)", true, false},
+		{"\x7f(DEL)", true, false},
+		{"plain ASCII log output", true, true},
+		{"status line \xe2\x9c\x93 example module", true, true},
+		{"box drawing \xe2\x94\x8c\xe2\x94\x80\xe2\x94\x90", true, true},
+		{"\xef\xbf\xbd(UTF-8 replacement character)", true, true},
+		{"\xff(invalid UTF-8 byte)", true, false},
+		{"\xef\xbb\xbfBOM-prefixed text", true, true},
+		{"\xef\xbb\xbf", true, true},
+		{"\xe2\x9c", false, true}, // truncated UTF-8 mid-file (fixed-size read)
+		{"\xe2\x9c", true, false}, // incomplete UTF-8 at true EOF
+		{"hello\xe2\x9c", true, false},
+		{"hello\xe2\x9c", false, true},
 	}
 	for _, tt := range inputs {
-		t.Run(fmt.Sprintf("Testing if buffer %q is printable", tt.input), func(t *testing.T) {
-			result := IsBufferPrintable([]byte(tt.input))
+		t.Run(fmt.Sprintf("Testing if buffer %q atEOF=%v is printable", tt.input, tt.atEOF), func(t *testing.T) {
+			result := IsBufferPrintable([]byte(tt.input), tt.atEOF)
 			if result != tt.expected {
 				t.Errorf("Expected %v, got %v", tt.expected, result)
 			}
@@ -169,6 +176,39 @@ func TestIsTextFile(t *testing.T) {
 		isText, err := IsTextFile(path)
 		require.NoError(t, err)
 		assert.False(t, isText)
+	})
+
+	t.Run("BOM-prefixed UTF-8 text", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bom.txt")
+		require.NoError(t, os.WriteFile(path, []byte("\xef\xbb\xbfhello\n"), 0o644))
+
+		isText, err := IsTextFile(path)
+		require.NoError(t, err)
+		assert.True(t, isText)
+	})
+
+	t.Run("incomplete UTF-8 at EOF", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "truncated.log")
+		require.NoError(t, os.WriteFile(path, []byte("hello\xe2\x9c"), 0o644))
+
+		isText, err := IsTextFile(path)
+		require.NoError(t, err)
+		assert.False(t, isText)
+	})
+
+	t.Run("incomplete UTF-8 only at fixed buffer boundary", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "long.log")
+		// Fill DefaultBufferSize-2 bytes, then start a 3-byte rune so the
+		// first read ends mid-sequence, with more valid UTF-8 after.
+		content := append(bytes.Repeat([]byte("a"), DefaultBufferSize-2), []byte("\xe2\x9c\x93more")...)
+		require.NoError(t, os.WriteFile(path, content, 0o644))
+
+		isText, err := IsTextFile(path)
+		require.NoError(t, err)
+		assert.True(t, isText)
 	})
 }
 


### PR DESCRIPTION
Had some issues with some text files with special characters not being able to preview. This fixes it. Hope it can be useful :)
🤖 Written with Cursor. 

# Description

Fix text preview failing on UTF-8 text files without a recognized extension.

`IsTextFile()` reads the first 1024 bytes and calls `IsBufferPrintable()`. The previous implementation checked each byte with `unicode.IsPrint(rune(b))`, which misclassifies UTF-8 continuation bytes (`0x80`–`0xBF`) as C1 control characters. Files containing multi-byte Unicode early in the buffer (e.g. `✓`, box-drawing characters) were incorrectly rejected as non-text and showed "unsupported format" in the preview panel.

`IsBufferPrintable()` now decodes UTF-8 runes with `utf8.DecodeRune` and checks printability per rune. Incomplete UTF-8 at the end of the buffer is allowed via `utf8.FullRune` (relevant for the fixed 1024-byte read in `IsTextFile()`). Binary content with NUL bytes is still rejected.

# Related Issues

---

# ✅ Pre-Submission Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I’m not committing any debug logs or TODOs
- [x] I have checked that the PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text detection by validating UTF-8 content rune-by-rune and treating incomplete trailing UTF-8 sequences more accurately in fixed-size reads.
  * Better handling of malformed/invalid bytes, while still rejecting clear binary indicators like NUL bytes.
  * Improved support for UTF-8 BOM-prefixed text and more consistent results at file end versus mid-file truncation.
* **Tests**
  * Expanded coverage for UTF-8/whitespace/control characters and added a dedicated test suite for overall text-file detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->