### PR TITLE
fix(preview): expand tabs to next tab stop

### DIFF
--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -251,6 +251,8 @@ func IsTextFile(filename string) (bool, error) {
 // This function should better not be broken into multiple functions
 func MakePrintableWithEscCheck(line string, allowEsc bool) string { //nolint: gocognit // See above
 	var sb strings.Builder
+	// where the current line starts in sb, so we can measure the column for tabs
+	lineStart := 0
 	for _, r := range line {
 		if r == utf8.RuneError {
 			continue
@@ -261,11 +263,10 @@ func MakePrintableWithEscCheck(line string, allowEsc bool) string { //nolint: go
 			sb.WriteRune(r)
 			continue
 		}
-		// It needs to be handled separately since considered a space,
-		// Since we are using ansi.StringWidth() for truncation, and \t is
-		// considered zero width
+		// \t is zero-width, expand it to the next tab stop based on current column
 		if r == '\t' {
-			sb.WriteString("    ")
+			col := ansi.StringWidth(sb.String()[lineStart:])
+			sb.WriteString(strings.Repeat(" ", TabWidth-col%TabWidth))
 			continue
 		}
 		if r == EscapeChar {
@@ -286,6 +287,9 @@ func MakePrintableWithEscCheck(line string, allowEsc bool) string { //nolint: go
 		}
 		if unicode.IsGraphic(r) || r == rune('\n') {
 			sb.WriteRune(r)
+			if r == rune('\n') {
+				lineStart = sb.Len() // new line, reset the column
+			}
 		}
 	}
 	return sb.String()

--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -16,13 +16,14 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
 // Size calculation constants
 const (
 	KilobyteSize      = 1000 // SI decimal unit
 	KibibyteSize      = 1024 // Binary unit
-	TabWidth          = 4    // Standard tab expansion width
 	DefaultBufferSize = 1024 // Default buffer size for string operations
 	NonBreakingSpace  = 0xa0 // Unicode non-breaking space
 	EscapeChar        = 0x1b // ANSI escape character
@@ -252,7 +253,9 @@ func IsTextFile(filename string) (bool, error) {
 func MakePrintableWithEscCheck(line string, allowEsc bool) string { //nolint: gocognit // See above
 	var sb strings.Builder
 	// where the current line starts in sb, so we can measure the column for tabs
-	lineStart := 0
+
+	lastSegmentStart := 0
+
 	for _, r := range line {
 		if r == utf8.RuneError {
 			continue
@@ -265,8 +268,9 @@ func MakePrintableWithEscCheck(line string, allowEsc bool) string { //nolint: go
 		}
 		// \t is zero-width, expand it to the next tab stop based on current column
 		if r == '\t' {
-			col := ansi.StringWidth(sb.String()[lineStart:])
-			sb.WriteString(strings.Repeat(" ", TabWidth-col%TabWidth))
+			newSegmentSize := ansi.StringWidth(sb.String()[lastSegmentStart:])
+			sb.WriteString(strings.Repeat(" ", utils.TabWidth-newSegmentSize%utils.TabWidth))
+			lastSegmentStart = sb.Len()
 			continue
 		}
 		if r == EscapeChar {
@@ -285,11 +289,12 @@ func MakePrintableWithEscCheck(line string, allowEsc bool) string { //nolint: go
 			sb.WriteRune(r)
 			continue
 		}
-		if unicode.IsGraphic(r) || r == rune('\n') {
+		if r == rune('\n') {
 			sb.WriteRune(r)
-			if r == rune('\n') {
-				lineStart = sb.Len() // new line, reset the column
-			}
+			lastSegmentStart = sb.Len()
+		}
+		if unicode.IsGraphic(r) {
+			sb.WriteRune(r)
 		}
 	}
 	return sb.String()

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -177,7 +177,13 @@ func TestMakePrintable(t *testing.T) {
 		{"", ""},
 		{"hello", "hello"},
 		{"abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]", "abcdABCD0123~!@#$%^&*()_+-={}|:\"<>?,./;'[]"},
-		{"Horizontal Tab and NewLine\t\t\n\n", "Horizontal Tab and NewLine        \n\n"},
+		// tabs go to the next tab stop, not a fixed width
+		{"Horizontal Tab and NewLine\t\t\n\n", "Horizontal Tab and NewLine      \n\n"},
+		{"\tX", "    X"},
+		{"ab\tX", "ab  X"},
+		{"abcd\tX", "abcd    X"},
+		{"a\tb\tc", "a   b   c"},
+		{"abc\n\tX", "abc\n    X"}, // column resets on newline
 		{"(NBSP)\u00a0\u00a0\u00a0\u00a0;", "(NBSP)\u00a0\u00a0\u00a0\u00a0;"},
 		{"\x0b(Vertical Tab)", "(Vertical Tab)"},
 		{"\x0d(CR)", "(CR)"},

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -183,6 +183,8 @@ func TestMakePrintable(t *testing.T) {
 		{"ab\tX", "ab  X"},
 		{"abcd\tX", "abcd    X"},
 		{"a\tb\tc", "a   b   c"},
+		{"a👩‍💻\tX\tY", "a👩‍💻 X   Y"},
+		{"\x1b[1ma\tX\tY\x1b[0m", "\x1b[1ma   X   Y\x1b[0m"},
 		{"abc\n\tX", "abc\n    X"}, // column resets on newline
 		{"(NBSP)\u00a0\u00a0\u00a0\u00a0;", "(NBSP)\u00a0\u00a0\u00a0\u00a0;"},
 		{"\x0b(Vertical Tab)", "(Vertical Tab)"},

--- a/src/internal/ui/preview/render_test.go
+++ b/src/internal/ui/preview/render_test.go
@@ -61,6 +61,21 @@ func TestFilePreviewRenderWithDimensions(t *testing.T) {
 				"1234",
 		},
 		{
+			// #1290: highlighted files should expand tabs to tab stops too
+			name: "Tab expansion through syntax highlighting",
+			fileContent: "" +
+				"abc\t0123\n" +
+				"a\t0123\n" +
+				"abcd\tX",
+			fileName: "tabs.txt",
+			height:   3,
+			width:    9,
+			expectedPreview: "" +
+				"abc 0123 \n" +
+				"a   0123 \n" +
+				"abcd    X",
+		},
+		{
 			name: "Width and height truncation",
 			fileContent: "" +
 				"abcd\n" +

--- a/src/pkg/utils/consts.go
+++ b/src/pkg/utils/consts.go
@@ -27,4 +27,6 @@ const (
 	SidebarSectionHome   = "home"
 	SidebarSectionPinned = "pinned"
 	SidebarSectionDisks  = "disks"
+
+	TabWidth = 4 // Standard tab expansion width
 )

--- a/src/pkg/utils/file_utils.go
+++ b/src/pkg/utils/file_utils.go
@@ -269,6 +269,9 @@ func ReadFileContent(filepath string, maxLineLength int, previewLine int) (strin
 	lineCount := 0
 	for scanner.Scan() {
 		line := scanner.Text()
+		// do this before truncating, otherwise the highlighter turns tabs into a fixed
+		// number of spaces and columns don't line up
+		line = expandTabs(line)
 		line = ansi.Truncate(line, maxLineLength, "")
 		resultBuilder.WriteString(line)
 		resultBuilder.WriteRune('\n')
@@ -279,6 +282,26 @@ func ReadFileContent(filepath string, maxLineLength int, previewLine int) (strin
 	}
 	// returns the first non-EOF error that was encountered by the [Scanner]
 	return resultBuilder.String(), scanner.Err()
+}
+
+const tabWidth = 4
+
+// expandTabs replaces tabs with spaces up to the next tab stop. line should be a
+// single line without newlines.
+func expandTabs(line string) string {
+	if !strings.Contains(line, "\t") {
+		return line
+	}
+	var sb strings.Builder
+	for _, r := range line {
+		if r == '\t' {
+			col := ansi.StringWidth(sb.String())
+			sb.WriteString(strings.Repeat(" ", tabWidth-col%tabWidth))
+			continue
+		}
+		sb.WriteRune(r)
+	}
+	return sb.String()
 }
 
 func InitJSONFile(path string) error {

--- a/src/pkg/utils/file_utils.go
+++ b/src/pkg/utils/file_utils.go
@@ -284,8 +284,6 @@ func ReadFileContent(filepath string, maxLineLength int, previewLine int) (strin
 	return resultBuilder.String(), scanner.Err()
 }
 
-const tabWidth = 4
-
 // expandTabs replaces tabs with spaces up to the next tab stop. line should be a
 // single line without newlines.
 func expandTabs(line string) string {
@@ -293,10 +291,12 @@ func expandTabs(line string) string {
 		return line
 	}
 	var sb strings.Builder
+	lastSegmentStart := 0
 	for _, r := range line {
 		if r == '\t' {
-			col := ansi.StringWidth(sb.String())
-			sb.WriteString(strings.Repeat(" ", tabWidth-col%tabWidth))
+			newSegmentSize := ansi.StringWidth(sb.String()[lastSegmentStart:])
+			sb.WriteString(strings.Repeat(" ", TabWidth-newSegmentSize%TabWidth))
+			lastSegmentStart = sb.Len()
 			continue
 		}
 		sb.WriteRune(r)

--- a/src/pkg/utils/file_utils_test.go
+++ b/src/pkg/utils/file_utils_test.go
@@ -390,6 +390,31 @@ func TestReadFileContent(t *testing.T) {
 	}
 }
 
+func TestExpandTabs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "multi-tab grapheme cluster",
+			input:    "a👩‍💻\tX\tY",
+			expected: "a👩‍💻 X   Y",
+		},
+		{
+			name:     "multi-tab ANSI sequence",
+			input:    "\x1b[1ma\tX\tY\x1b[0m",
+			expected: "\x1b[1ma   X   Y\x1b[0m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, expandTabs(tt.input))
+		})
+	}
+}
+
 func TestReadFileContentBOMHandling(t *testing.T) {
 	testDir := t.TempDir()
 	curTestDir := filepath.Join(testDir, "TestBOMHandling")

--- a/src/pkg/utils/file_utils_test.go
+++ b/src/pkg/utils/file_utils_test.go
@@ -361,6 +361,21 @@ func TestReadFileContent(t *testing.T) {
 			previewLine:   2,
 			expected:      "line1\nline2\n",
 		},
+		{
+			// tabs line up to tab stops so "0123" starts at the same column
+			name:          "tabs expand to tab stops",
+			content:       []byte("abc\t0123\na\t0123\nabcd\tX"),
+			maxLineLength: 100,
+			previewLine:   5,
+			expected:      "abc 0123\na   0123\nabcd    X\n",
+		},
+		{
+			name:          "tab expanded then truncated",
+			content:       []byte("a\t0123"),
+			maxLineLength: 6,
+			previewLine:   5,
+			expected:      "a   01\n",
+		},
 	}
 
 	for i, tt := range testdata {


### PR DESCRIPTION
## Problem

Fixes #1290.

Tabs in the file preview were always expanded to a fixed 4 spaces regardless of the current column, so files that use tabs to line up columns rendered misaligned. A real terminal (and `bat`) advances each tab to the next tab stop instead.

There were actually two places that flattened tabs:
- `MakePrintableWithEscCheck` replaced every `\t` with a literal `"    "`.
- For files with a recognized extension, the syntax highlighter (lipgloss, via `ansichroma`) collapses tabs to a fixed width *before* the sanitizer even runs — so fixing only the sanitizer wasn't enough.

## Fix

Expand tabs to the next tab stop based on the current column (measured with `ansi.StringWidth`, so wide runes are handled):

- `ReadFileContent` (`pkg/utils`) now expands tabs per line, before truncation and before highlighting. This covers both highlighted and plain file previews.
- `MakePrintableWithEscCheck` (`internal/common`) does the same for the shell-output preview path, which doesn't go through `ReadFileContent`.

## Before / after

File:
```
abc<TAB>0123    5
a<TAB>0123    5
abcd<TAB>X
```

Before (tab = fixed 4 spaces — `0123` misaligned):
```
abc    0123    5
a    0123    5
abcd    X
```

After (tab stops — `0123` lines up, matches `expand -t4`):
```
abc 0123    5
a   0123    5
abcd    X
```

## Testing

- Added unit tests: tab-stop cases in `TestReadFileContent` (incl. expansion-before-truncation), a `.txt` end-to-end case in the preview render test that exercises the syntax-highlighting path, and tab cases in `TestMakePrintable`.
- Verified manually across `.go`, `.py`, `.c`, `.md`, `.tsv`, `.yaml` and plain text — output matches `expand -t4`.

## Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I'm not committing any debug logs or TODOs
- [x] I have filled out the PR template with description, context, and screenshots if needed
- [x] I have checked that the PR title follows the Conventional Commits format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab spacing to expand to the next tab stop based on the current visual column.
  * Fixed tab alignment after newlines for consistent display in previews and rendered text.
  * Expanded tabs before applying line truncation to avoid misaligned output.

* **Tests**
  * Updated and expanded tab/newline expectations, including tab expansion around ANSI-styled content and grapheme scenarios.
  * Added coverage to ensure tab-containing syntax-highlighted previews align correctly under constrained preview dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->