### PR TITLE
feat(filepanel): add directories-only filter toggle

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -160,6 +160,7 @@ type HotkeysType struct {
 
 	PinnedDirectory []string `toml:"pinned_directory"  comment:"other"`
 	ToggleDotFile   []string `toml:"toggle_dot_file"`
+	ToggleDirsOnly  []string `toml:"toggle_dirs_only"`
 	ChangePanelMode []string `toml:"change_panel_mode"`
 	OpenHelpMenu    []string `toml:"open_help_menu"`
 	OpenCommandLine []string `toml:"open_command_line"`

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -133,6 +133,12 @@ func (m *model) toggleDotFileController() {
 	}
 }
 
+// Toggle directories-only display or not. Intentionally not persisted across
+// sessions (unlike ToggleDotFile) — this is meant as a transient navigation filter.
+func (m *model) toggleDirsOnlyController() {
+	m.fileModel.ToggleDirsOnly()
+}
+
 // Toggle dotfile display or not
 func (m *model) toggleFooterController() tea.Cmd {
 	m.toggleFooter = !m.toggleFooter

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -110,6 +110,9 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen //
 	case slices.Contains(common.Hotkeys.ToggleDotFile, msg):
 		m.toggleDotFileController()
 
+	case slices.Contains(common.Hotkeys.ToggleDirsOnly, msg):
+		m.toggleDirsOnlyController()
+
 	case slices.Contains(common.Hotkeys.ToggleFooter, msg):
 		return m.toggleFooterController()
 

--- a/src/internal/ui/filemodel/type.go
+++ b/src/internal/ui/filemodel/type.go
@@ -20,4 +20,5 @@ type Model struct {
 	FocusedPanelIndex    int
 	ioReqCnt             int
 	DisplayDotFiles      bool
+	DisplayDirsOnly      bool
 }

--- a/src/internal/ui/filemodel/update.go
+++ b/src/internal/ui/filemodel/update.go
@@ -133,8 +133,13 @@ func (m *Model) ToggleDotFile() {
 	m.UpdateFilePanelsIfNeeded(true)
 }
 
+func (m *Model) ToggleDirsOnly() {
+	m.DisplayDirsOnly = !m.DisplayDirsOnly
+	m.UpdateFilePanelsIfNeeded(true)
+}
+
 func (m *Model) UpdateFilePanelsIfNeeded(force bool) {
 	for i := range m.FilePanels {
-		m.FilePanels[i].UpdateElementsIfNeeded(force, m.DisplayDotFiles)
+		m.FilePanels[i].UpdateElementsIfNeeded(force, m.DisplayDotFiles, m.DisplayDirsOnly)
 	}
 }

--- a/src/internal/ui/filemodel/update.go
+++ b/src/internal/ui/filemodel/update.go
@@ -140,6 +140,9 @@ func (m *Model) ToggleDirsOnly() {
 
 func (m *Model) UpdateFilePanelsIfNeeded(force bool) {
 	for i := range m.FilePanels {
-		m.FilePanels[i].UpdateElementsIfNeeded(force, m.DisplayDotFiles, m.DisplayDirsOnly)
+		m.FilePanels[i].UpdateElementsIfNeeded(force, filepanel.FilterOptions{
+			DisplayDotFile: m.DisplayDotFiles,
+			DirsOnly:       m.DisplayDirsOnly,
+		})
 	}
 }

--- a/src/internal/ui/filepanel/get_elements.go
+++ b/src/internal/ui/filepanel/get_elements.go
@@ -14,7 +14,7 @@ import (
 // and also consider testing this caseSensitive with both true and false in
 // our unit_test TestReturnDirElement
 // getDirectoryElements returns the directory elements for the panel's current location
-func (m *Model) getDirectoryElements(displayDotFile bool) []Element {
+func (m *Model) getDirectoryElements(displayDotFile bool, dirsOnly bool) []Element {
 	dirEntries, err := os.ReadDir(m.Location)
 	if err != nil {
 		slog.Error("Error while returning folder elements", "error", err)
@@ -24,7 +24,8 @@ func (m *Model) getDirectoryElements(displayDotFile bool) []Element {
 	dirEntries = slices.DeleteFunc(dirEntries, func(e os.DirEntry) bool {
 		// Entries not needed to be considered
 		_, err := e.Info()
-		return err != nil || (strings.HasPrefix(e.Name(), ".") && !displayDotFile)
+		return err != nil || (strings.HasPrefix(e.Name(), ".") && !displayDotFile) ||
+			(dirsOnly && !e.IsDir())
 	})
 
 	// No files/directories to process
@@ -35,7 +36,7 @@ func (m *Model) getDirectoryElements(displayDotFile bool) []Element {
 }
 
 // getDirectoryElementsBySearch returns filtered directory elements based on search string
-func (m *Model) getDirectoryElementsBySearch(displayDotFile bool) []Element {
+func (m *Model) getDirectoryElementsBySearch(displayDotFile bool, dirsOnly bool) []Element {
 	searchString := m.SearchBar.Value()
 	items, err := os.ReadDir(m.Location)
 	if err != nil {
@@ -56,6 +57,9 @@ func (m *Model) getDirectoryElementsBySearch(displayDotFile bool) []Element {
 			continue
 		}
 		if !displayDotFile && strings.HasPrefix(fileInfo.Name(), ".") {
+			continue
+		}
+		if dirsOnly && !item.IsDir() {
 			continue
 		}
 
@@ -86,11 +90,11 @@ func (m *Model) shouldSkipPanelUpdate(nowTime time.Time) bool {
 		nowTime.Sub(m.LastTimeGetElement) < time.Duration(reRenderTime)*time.Second
 }
 
-func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) {
+func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool, dirsOnly bool) {
 	nowTime := time.Now()
 	if force || !m.shouldSkipPanelUpdate(nowTime) {
 		// Load elements for this panel (with/without search filter)
-		m.element = m.getElements(displayDotFile)
+		m.element = m.getElements(displayDotFile, dirsOnly)
 		// Update file panel list
 		m.LastTimeGetElement = nowTime
 
@@ -107,9 +111,9 @@ func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) {
 }
 
 // Retrieves elements for a panel based on search bar value and sort options.
-func (m *Model) getElements(displayDotFile bool) []Element {
+func (m *Model) getElements(displayDotFile bool, dirsOnly bool) []Element {
 	if m.SearchBar.Value() != "" {
-		return m.getDirectoryElementsBySearch(displayDotFile)
+		return m.getDirectoryElementsBySearch(displayDotFile, dirsOnly)
 	}
-	return m.getDirectoryElements(displayDotFile)
+	return m.getDirectoryElements(displayDotFile, dirsOnly)
 }

--- a/src/internal/ui/filepanel/get_elements.go
+++ b/src/internal/ui/filepanel/get_elements.go
@@ -10,11 +10,28 @@ import (
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
+// FilterOptions controls which directory entries are included when listing a panel.
+type FilterOptions struct {
+	DisplayDotFile bool
+	DirsOnly       bool
+}
+
+// shouldIncludeEntry reports whether an entry should be included given the active filters.
+func shouldIncludeEntry(name string, isDir bool, opts FilterOptions) bool {
+	if strings.HasPrefix(name, ".") && !opts.DisplayDotFile {
+		return false
+	}
+	if opts.DirsOnly && !isDir {
+		return false
+	}
+	return true
+}
+
 // TODO : Take common.Config.CaseSensitiveSort as a function parameter
 // and also consider testing this caseSensitive with both true and false in
 // our unit_test TestReturnDirElement
 // getDirectoryElements returns the directory elements for the panel's current location
-func (m *Model) getDirectoryElements(displayDotFile bool, dirsOnly bool) []Element {
+func (m *Model) getDirectoryElements(opts FilterOptions) []Element {
 	dirEntries, err := os.ReadDir(m.Location)
 	if err != nil {
 		slog.Error("Error while returning folder elements", "error", err)
@@ -24,8 +41,7 @@ func (m *Model) getDirectoryElements(displayDotFile bool, dirsOnly bool) []Eleme
 	dirEntries = slices.DeleteFunc(dirEntries, func(e os.DirEntry) bool {
 		// Entries not needed to be considered
 		_, err := e.Info()
-		return err != nil || (strings.HasPrefix(e.Name(), ".") && !displayDotFile) ||
-			(dirsOnly && !e.IsDir())
+		return err != nil || !shouldIncludeEntry(e.Name(), e.IsDir(), opts)
 	})
 
 	// No files/directories to process
@@ -36,7 +52,7 @@ func (m *Model) getDirectoryElements(displayDotFile bool, dirsOnly bool) []Eleme
 }
 
 // getDirectoryElementsBySearch returns filtered directory elements based on search string
-func (m *Model) getDirectoryElementsBySearch(displayDotFile bool, dirsOnly bool) []Element {
+func (m *Model) getDirectoryElementsBySearch(opts FilterOptions) []Element {
 	searchString := m.SearchBar.Value()
 	items, err := os.ReadDir(m.Location)
 	if err != nil {
@@ -56,10 +72,7 @@ func (m *Model) getDirectoryElementsBySearch(displayDotFile bool, dirsOnly bool)
 		if err != nil {
 			continue
 		}
-		if !displayDotFile && strings.HasPrefix(fileInfo.Name(), ".") {
-			continue
-		}
-		if dirsOnly && !item.IsDir() {
+		if !shouldIncludeEntry(fileInfo.Name(), item.IsDir(), opts) {
 			continue
 		}
 
@@ -90,11 +103,11 @@ func (m *Model) shouldSkipPanelUpdate(nowTime time.Time) bool {
 		nowTime.Sub(m.LastTimeGetElement) < time.Duration(reRenderTime)*time.Second
 }
 
-func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool, dirsOnly bool) {
+func (m *Model) UpdateElementsIfNeeded(force bool, opts FilterOptions) {
 	nowTime := time.Now()
 	if force || !m.shouldSkipPanelUpdate(nowTime) {
 		// Load elements for this panel (with/without search filter)
-		m.element = m.getElements(displayDotFile, dirsOnly)
+		m.element = m.getElements(opts)
 		// Update file panel list
 		m.LastTimeGetElement = nowTime
 
@@ -111,9 +124,9 @@ func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool, dirsOnly
 }
 
 // Retrieves elements for a panel based on search bar value and sort options.
-func (m *Model) getElements(displayDotFile bool, dirsOnly bool) []Element {
+func (m *Model) getElements(opts FilterOptions) []Element {
 	if m.SearchBar.Value() != "" {
-		return m.getDirectoryElementsBySearch(displayDotFile, dirsOnly)
+		return m.getDirectoryElementsBySearch(opts)
 	}
-	return m.getDirectoryElements(displayDotFile, dirsOnly)
+	return m.getDirectoryElements(opts)
 }

--- a/src/internal/ui/filepanel/get_elements_test.go
+++ b/src/internal/ui/filepanel/get_elements_test.go
@@ -13,6 +13,36 @@ import (
 	"github.com/yorukot/superfile/src/internal/ui/sortmodel"
 )
 
+// setupSymlinkTestDir creates an isolated directory containing a real directory,
+// a file, and a symlink pointing at the real directory. It returns the directory
+// and any error encountered while creating the symlink, since some CI
+// environments (notably Windows without elevated privileges) cannot create
+// symlinks.
+func setupSymlinkTestDir(t *testing.T) (string, error) {
+	t.Helper()
+	symlinkTestDir := t.TempDir()
+	realDir := filepath.Join(symlinkTestDir, "realDir")
+	utils.SetupDirectories(t, realDir)
+	utils.SetupFilesWithData(t, []byte("0123456789"), filepath.Join(symlinkTestDir, "file.txt"))
+	linkToRealDir := filepath.Join(symlinkTestDir, "linkToRealDir")
+	err := os.Symlink(realDir, linkToRealDir)
+	return symlinkTestDir, err
+}
+
+// setupHiddenDirTestDir creates an isolated directory containing a hidden
+// directory, a visible directory, and a file, for exercising the dirsOnly +
+// dotfiles filter combination without recomputing expected order for the
+// shared curTestDir fixture.
+func setupHiddenDirTestDir(t *testing.T) string {
+	t.Helper()
+	hiddenDirTestDir := t.TempDir()
+	hiddenDir := filepath.Join(hiddenDirTestDir, ".hiddenDir")
+	visibleDir := filepath.Join(hiddenDirTestDir, "visibleDir")
+	utils.SetupDirectories(t, hiddenDir, visibleDir)
+	utils.SetupFilesWithData(t, []byte("0123456789"), filepath.Join(hiddenDirTestDir, "file.txt"))
+	return hiddenDirTestDir
+}
+
 func TestReturnDirElement(t *testing.T) {
 	curTestDir := t.TempDir()
 	dir1 := filepath.Join(curTestDir, "dir1")
@@ -62,14 +92,11 @@ func TestReturnDirElement(t *testing.T) {
 
 	// Isolated directory for the dirsOnly + symlink case, kept separate from curTestDir
 	// so it doesn't affect the exact-listing assertions used by the other test cases above.
-	symlinkTestDir := t.TempDir()
-	realDir := filepath.Join(symlinkTestDir, "realDir")
-	utils.SetupDirectories(t, realDir)
-	utils.SetupFilesWithData(t, []byte("0123456789"), filepath.Join(symlinkTestDir, "file.txt"))
-	linkToRealDir := filepath.Join(symlinkTestDir, "linkToRealDir")
-	if err := os.Symlink(realDir, linkToRealDir); err != nil {
-		t.Fatalf("failed to create symlink to directory: %v", err)
-	}
+	symlinkTestDir, symlinkErr := setupSymlinkTestDir(t)
+
+	// Isolated directory for the dirsOnly + hidden-directory case, so it doesn't
+	// require recomputing expected order for the shared curTestDir fixture.
+	hiddenDirTestDir := setupHiddenDirTestDir(t)
 
 	testdata := []struct {
 		name              string
@@ -217,12 +244,12 @@ func TestReturnDirElement(t *testing.T) {
 		},
 		{
 			name:              "Directories only with dotfiles enabled",
-			location:          curTestDir,
+			location:          hiddenDirTestDir,
 			dotFiles:          true,
 			dirsOnly:          true,
 			sortKind:          sortmodel.SortByName,
 			reversed:          false,
-			expectedElemNames: []string{"dir1", "dir2", "dirNatural"},
+			expectedElemNames: []string{".hiddenDir", "visibleDir"},
 		},
 		{
 			name:              "Directories only with search",
@@ -246,16 +273,20 @@ func TestReturnDirElement(t *testing.T) {
 
 	for _, tt := range testdata {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "Directories only excludes symlinks to directories" && symlinkErr != nil {
+				t.Skipf("skipping: unable to create symlink to directory: %v", symlinkErr)
+			}
 			panel := testModel(0, 0, 0, BrowserMode, nil)
 			panel.Location = tt.location
 			panel.SortKind = tt.sortKind
 			panel.SortReversed = tt.reversed
 			panel.SearchBar.SetValue(tt.searchString)
 			var res []Element
+			opts := FilterOptions{DisplayDotFile: tt.dotFiles, DirsOnly: tt.dirsOnly}
 			if tt.searchString == "" {
-				res = panel.getDirectoryElements(tt.dotFiles, tt.dirsOnly)
+				res = panel.getDirectoryElements(opts)
 			} else {
-				res = panel.getDirectoryElementsBySearch(tt.dotFiles, tt.dirsOnly)
+				res = panel.getDirectoryElementsBySearch(opts)
 			}
 
 			assert.Len(t, res, len(tt.expectedElemNames))

--- a/src/internal/ui/filepanel/get_elements_test.go
+++ b/src/internal/ui/filepanel/get_elements_test.go
@@ -1,6 +1,7 @@
 package filepanel
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -59,10 +60,22 @@ func TestReturnDirElement(t *testing.T) {
 		time.Sleep(creationDelay)
 	}
 
+	// Isolated directory for the dirsOnly + symlink case, kept separate from curTestDir
+	// so it doesn't affect the exact-listing assertions used by the other test cases above.
+	symlinkTestDir := t.TempDir()
+	realDir := filepath.Join(symlinkTestDir, "realDir")
+	utils.SetupDirectories(t, realDir)
+	utils.SetupFilesWithData(t, []byte("0123456789"), filepath.Join(symlinkTestDir, "file.txt"))
+	linkToRealDir := filepath.Join(symlinkTestDir, "linkToRealDir")
+	if err := os.Symlink(realDir, linkToRealDir); err != nil {
+		t.Fatalf("failed to create symlink to directory: %v", err)
+	}
+
 	testdata := []struct {
 		name              string
 		location          string
 		dotFiles          bool
+		dirsOnly          bool
 		sortKind          sortmodel.SortKind
 		reversed          bool
 		searchString      string
@@ -193,6 +206,42 @@ func TestReturnDirElement(t *testing.T) {
 			reversed:          true,
 			expectedElemNames: []string{"file20.txt", "file10.txt", "file2.txt", "file1.txt"},
 		},
+		{
+			name:              "Directories only",
+			location:          curTestDir,
+			dotFiles:          false,
+			dirsOnly:          true,
+			sortKind:          sortmodel.SortByName,
+			reversed:          false,
+			expectedElemNames: []string{"dir1", "dir2", "dirNatural"},
+		},
+		{
+			name:              "Directories only with dotfiles enabled",
+			location:          curTestDir,
+			dotFiles:          true,
+			dirsOnly:          true,
+			sortKind:          sortmodel.SortByName,
+			reversed:          false,
+			expectedElemNames: []string{"dir1", "dir2", "dirNatural"},
+		},
+		{
+			name:              "Directories only with search",
+			location:          curTestDir,
+			dotFiles:          false,
+			dirsOnly:          true,
+			sortKind:          sortmodel.SortByName,
+			searchString:      "dir",
+			expectedElemNames: []string{"dir1", "dir2", "dirNatural"},
+		},
+		{
+			name:              "Directories only excludes symlinks to directories",
+			location:          symlinkTestDir,
+			dotFiles:          false,
+			dirsOnly:          true,
+			sortKind:          sortmodel.SortByName,
+			reversed:          false,
+			expectedElemNames: []string{"realDir"},
+		},
 	}
 
 	for _, tt := range testdata {
@@ -204,9 +253,9 @@ func TestReturnDirElement(t *testing.T) {
 			panel.SearchBar.SetValue(tt.searchString)
 			var res []Element
 			if tt.searchString == "" {
-				res = panel.getDirectoryElements(tt.dotFiles)
+				res = panel.getDirectoryElements(tt.dotFiles, tt.dirsOnly)
 			} else {
-				res = panel.getDirectoryElementsBySearch(tt.dotFiles)
+				res = panel.getDirectoryElementsBySearch(tt.dotFiles, tt.dirsOnly)
 			}
 
 			assert.Len(t, res, len(tt.expectedElemNames))

--- a/src/internal/ui/helpmenu/data.go
+++ b/src/internal/ui/helpmenu/data.go
@@ -176,6 +176,11 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 			hotkeyWorkType: globalType,
 		},
 		{
+			hotkey:         common.Hotkeys.ToggleDirsOnly,
+			description:    "Toggle directories only display",
+			hotkeyWorkType: globalType,
+		},
+		{
 			hotkey:         common.Hotkeys.SearchBar,
 			description:    "Toggle active search bar",
 			hotkeyWorkType: globalType,

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -68,6 +68,7 @@ open_help_menu = ['?', '']
 open_spf_prompt = ['>', '']
 open_zoxide = ['z', '']
 toggle_dot_file = ['.', '']
+toggle_dirs_only = ['alt+d', '']
 toggle_footer = ['F', '']
 
 ###############################################################################

--- a/src/superfile_config/vimHotkeys.toml
+++ b/src/superfile_config/vimHotkeys.toml
@@ -64,6 +64,7 @@ open_current_directory_with_editor = ['E', '']
 #-- Other Actions
 pinned_directory = ['P', '']
 toggle_dot_file = ['.', '']
+toggle_dirs_only = ['alt+d', '']
 change_panel_mode = ['m', '']
 open_help_menu = ['?', '']
 open_spf_prompt = ['>', '']


### PR DESCRIPTION
I've been looking for a good open source project to start contributing to, and this one seemed
like a friendly place to try — plenty of `good first issue` / `difficulty:easy` labels and PRs
from outside contributors get merged pretty often.

Picked up #433. The "hide side/bottom panels" half of that issue is already covered by existing
config (sidebar_width, file_preview_width, f/shift+f), so this PR only does the "show only
directories" part. Turned out to be a small change: a new alt+d toggle on the file panel that
mirrors the existing dotfile toggle pretty closely.

Two things I decided on my own, happy to change if you'd rather: it doesn't persist across
restarts (felt more like a transient filter than a saved preference), and symlinks to directories
get excluded for now, since `os.DirEntry.IsDir()` uses Lstat semantics. Left a test pinning that
down so it's a choice, not an accident.

A couple of things I noticed while in there but didn't want to fold into a first PR: the
dotfile/dirs-only filters are just two bools threaded through a few functions right now, which is
fine with one call site, but something like

```go
type FilterOptions struct {
    ShowDotFiles bool
    DirsOnly     bool
}
```

would probably age better if a third filter shows up. And the symlink exclusion above could flip
to following symlinks with an extra `os.Stat` per entry instead of relying on Lstat. Didn't want
to guess which you'd prefer, so left both alone for now.

Tested manually in the TUI (toggle, search bar, restart, help menu) and go test/vet/golangci-lint
all pass clean.

Related to #433 (directories-only half only).

If this is welcome I'd like to keep contributing here — I like TUIs a lot and this seemed like a
genuinely nice codebase to poke around in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new hotkey and configuration option to toggle a “directories only” view.
  * Updated the help menu and both default keybinding sets to include the new shortcut.

* **Bug Fixes**
  * Directory listings now respect the “directories only” mode consistently, including during search.

* **Tests**
  * Expanded tests to cover directory-only filtering across dotfile settings, search mode, and symlinked directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->