### PR TITLE
fix: keep focus on the new panel instead of the sidebar

### DIFF
--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -76,7 +76,7 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen //
 		}
 		return cmd
 	case slices.Contains(common.Hotkeys.CreateNewFilePanel, msg):
-		cmd, err := m.fileModel.CreateNewFilePanel(variable.HomeDir)
+		cmd, err := m.createNewFilePanel(variable.HomeDir)
 		if err != nil && !errors.Is(err, filemodel.ErrMaximumPanelCount) {
 			slog.Error("unexpected error while creating new panel", "error", err)
 		}

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -443,13 +443,25 @@ func (m *model) applyShellCommandAction(shellCommand string) {
 	}
 }
 
+// Create a new file panel and move focus onto it. All panel-creation goes
+// through here, otherwise the sidebar (or processbar/metadata) can stay focused
+// next to the new panel and both react to keys. See #1497.
+func (m *model) createNewFilePanel(location string) (tea.Cmd, error) {
+	cmd, err := m.fileModel.CreateNewFilePanel(location)
+	if err != nil {
+		return cmd, err
+	}
+	m.focusPanel = nonePanelFocus
+	return cmd, nil
+}
+
 func (m *model) splitPanel() (tea.Cmd, error) {
-	return m.fileModel.CreateNewFilePanel(m.getFocusedFilePanel().Location)
+	return m.createNewFilePanel(m.getFocusedFilePanel().Location)
 }
 
 func (m *model) createNewFilePanelRelativeToCurrent(path string) (tea.Cmd, error) {
 	currentDir := m.getFocusedFilePanel().Location
-	return m.fileModel.CreateNewFilePanel(utils.ResolveAbsPath(currentDir, path))
+	return m.createNewFilePanel(utils.ResolveAbsPath(currentDir, path))
 }
 
 // simulates a 'cd' action

--- a/src/internal/model_panel_focus_test.go
+++ b/src/internal/model_panel_focus_test.go
@@ -1,0 +1,79 @@
+package internal
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	variable "github.com/yorukot/superfile/src/config"
+	"github.com/yorukot/superfile/src/pkg/utils"
+)
+
+// #1497: opening a new panel while the sidebar (or process bar / metadata) was
+// focused left both focused at once. Focus should end up on the new panel only.
+func TestNewPanelClearsNonFilePanelFocus(t *testing.T) {
+	curTestDir := t.TempDir()
+	subDir := filepath.Join(curTestDir, "sub")
+	utils.SetupDirectories(t, subDir)
+
+	// Every way of opening a panel should land focus on it.
+	createPaths := []struct {
+		name   string
+		create func(m *model) error
+	}{
+		{
+			name: "split panel hotkey",
+			create: func(m *model) error {
+				_, err := m.splitPanel()
+				return err
+			},
+		},
+		{
+			name: "create new file panel at home",
+			create: func(m *model) error {
+				_, err := m.createNewFilePanel(variable.HomeDir)
+				return err
+			},
+		},
+		{
+			name: "open panel relative to current",
+			create: func(m *model) error {
+				_, err := m.createNewFilePanelRelativeToCurrent("sub")
+				return err
+			},
+		},
+	}
+
+	for _, cp := range createPaths {
+		t.Run("sidebar focused / "+cp.name, func(t *testing.T) {
+			m := defaultTestModel(curTestDir)
+			m.focusOnSideBar()
+			require.Equal(t, sidebarFocus, m.focusPanel, "precondition: sidebar focused")
+			require.False(t, m.getFocusedFilePanel().IsFocused, "precondition: file panel not focused")
+
+			require.NoError(t, cp.create(m))
+
+			assert.Equal(t, nonePanelFocus, m.focusPanel,
+				"sidebar must lose focus after a new file panel is created")
+			assert.True(t, m.getFocusedFilePanel().IsFocused,
+				"the newly created file panel must be focused")
+		})
+	}
+
+	// Same deal for the process bar (only focusable when the footer is on).
+	t.Run("process bar focused / split panel", func(t *testing.T) {
+		m := defaultTestModelWithFooterAndFilePreview(curTestDir)
+		m.focusOnProcessBar()
+		require.Equal(t, processBarFocus, m.focusPanel, "precondition: process bar focused")
+
+		_, err := m.splitPanel()
+		require.NoError(t, err)
+
+		assert.Equal(t, nonePanelFocus, m.focusPanel,
+			"process bar must lose focus after a new file panel is created")
+		assert.True(t, m.getFocusedFilePanel().IsFocused,
+			"the newly created file panel must be focused")
+	})
+}


### PR DESCRIPTION
# Description

Opening a new file panel while the sidebar (or the process bar / metadata)
was focused left both focused at the same time — the sidebar still moved
up/down while the new panel took left/right, so two panels reacted to keys
at once.

The outer `focusPanel` was never reset when a panel was created. This routes
every panel-creation path (split, new-panel-at-home, open-relative) through a
single `createNewFilePanel` helper that resets `focusPanel` to
`nonePanelFocus` on success, so focus lands on the newly created panel. As a
side effect this also covers the same glitch when the process bar or metadata
panel is focused, not just the sidebar.

Added `TestNewPanelClearsNonFilePanelFocus`, which covers all three creation
paths under sidebar focus plus the process-bar case.

# Related Issues

Fixes #1497

# ✅ Pre-Submission Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues (0 issues)
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I'm not committing any debug logs or TODOs
- [x] I have checked that the PR title follows the Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a new file panel now reliably shifts focus to the new panel.
  * Fixed cases where focus could remain on the sidebar or process bar after opening a panel from different actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->