### PR TITLE
fix: make page up/down aware of the focused panel

### DIFF
--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -22,7 +22,7 @@ import (
 // check the state of model m and handle properly.
 // TODO: This function has grown too big. It needs to be fixed, via major
 // updates and fixes in key handling code
-func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen // See above
+func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,gocognit // See above
 	switch {
 	// If move up Key is pressed, check the current state and executes
 	case slices.Contains(common.Hotkeys.ListUp, msg):
@@ -51,10 +51,24 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen //
 		}
 
 	case slices.Contains(common.Hotkeys.PageUp, msg):
-		m.getFocusedFilePanel().PgUp()
+		switch m.focusPanel {
+		case metadataFocus:
+			m.fileMetaData.PgUp()
+		case nonePanelFocus:
+			m.getFocusedFilePanel().PgUp()
+		case processBarFocus, sidebarFocus:
+			// These panels have no page scrolling, so page keys do nothing.
+		}
 
 	case slices.Contains(common.Hotkeys.PageDown, msg):
-		m.getFocusedFilePanel().PgDown()
+		switch m.focusPanel {
+		case metadataFocus:
+			m.fileMetaData.PgDown()
+		case nonePanelFocus:
+			m.getFocusedFilePanel().PgDown()
+		case processBarFocus, sidebarFocus:
+			// These panels have no page scrolling, so page keys do nothing.
+		}
 
 	case slices.Contains(common.Hotkeys.ChangePanelMode, msg):
 		m.getFocusedFilePanel().ChangeFilePanelMode()

--- a/src/internal/model_page_navigation_test.go
+++ b/src/internal/model_page_navigation_test.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/pkg/utils"
+)
+
+// Regression test for #966 : page up/down keys must be context aware. When a
+// non-file panel (e.g. metadata) is focused, page keys must not scroll the file
+// browser panel.
+func TestPageKeysAreContextAware(t *testing.T) {
+	dir := t.TempDir()
+	files := make([]string, 10)
+	for i := range files {
+		files[i] = filepath.Join(dir, fmt.Sprintf("file%02d.txt", i))
+	}
+	utils.SetupFiles(t, files...)
+
+	// Fix the page size so PgDown deterministically moves the file panel cursor.
+	origPageScrollSize := common.Config.PageScrollSize
+	common.Config.PageScrollSize = 3
+	t.Cleanup(func() { common.Config.PageScrollSize = origPageScrollSize })
+
+	pageDownKey := common.Hotkeys.PageDown[0]
+
+	t.Run("pages the file panel when a file panel is focused", func(t *testing.T) {
+		m := defaultTestModel(dir)
+		require.Equal(t, nonePanelFocus, m.focusPanel)
+		require.Equal(t, 0, m.getFocusedFilePanel().GetCursor())
+
+		m.mainKey(pageDownKey)
+
+		assert.Equal(t, 3, m.getFocusedFilePanel().GetCursor(),
+			"file panel should page down when it is focused")
+	})
+
+	t.Run("does not page the file panel when metadata is focused", func(t *testing.T) {
+		m := defaultTestModel(dir)
+		m.focusPanel = metadataFocus
+		m.getFocusedFilePanel().IsFocused = false
+		require.Equal(t, 0, m.getFocusedFilePanel().GetCursor())
+
+		m.mainKey(pageDownKey)
+
+		assert.Equal(t, 0, m.getFocusedFilePanel().GetCursor(),
+			"file panel must not move when the metadata panel is focused")
+	})
+}

--- a/src/internal/ui/metadata/model.go
+++ b/src/internal/ui/metadata/model.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"fmt"
 
+	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/internal/ui"
 	"github.com/yorukot/superfile/src/pkg/cache"
 )
@@ -59,25 +60,46 @@ func (m *Model) MetadataLen() int {
 	return len(m.metadata.data)
 }
 
-// Control metadata panel up
-func (m *Model) ListUp() {
-	if m.MetadataLen() == 0 {
+// Move renderIndex by delta rows, wrapping at both ends.
+func (m *Model) moveRenderIndexBy(delta int) {
+	l := m.MetadataLen()
+	if l == 0 {
 		return
 	}
-	if m.renderIndex > 0 {
-		m.renderIndex--
-	} else {
-		m.renderIndex = m.MetadataLen() - 1
+	m.renderIndex = ((m.renderIndex+delta)%l + l) % l
+}
+
+func (m *Model) getPageScrollSize() int {
+	scrollSize := common.Config.PageScrollSize
+	if scrollSize <= 0 {
+		// Use default full page behavior
+		scrollSize = m.height - borderSize
 	}
+	// height can be tiny on small terminals, so keep moving at least one row
+	if scrollSize < 1 {
+		scrollSize = 1
+	}
+	return scrollSize
+}
+
+// Control metadata panel up
+func (m *Model) ListUp() {
+	m.moveRenderIndexBy(-1)
 }
 
 // Control metadata panel down
 func (m *Model) ListDown() {
-	if m.renderIndex < m.MetadataLen()-1 {
-		m.renderIndex++
-	} else {
-		m.renderIndex = 0
-	}
+	m.moveRenderIndexBy(1)
+}
+
+// Control metadata panel page up
+func (m *Model) PgUp() {
+	m.moveRenderIndexBy(-m.getPageScrollSize())
+}
+
+// Control metadata panel page down
+func (m *Model) PgDown() {
+	m.moveRenderIndexBy(m.getPageScrollSize())
 }
 
 func (m *Model) SetBlank() {

--- a/src/internal/ui/metadata/navigation_test.go
+++ b/src/internal/ui/metadata/navigation_test.go
@@ -1,0 +1,80 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorukot/superfile/src/internal/common"
+)
+
+func TestPgUpDown(t *testing.T) {
+	tenItems := Metadata{
+		data: make([][2]string, 10),
+	}
+	testdata := []struct {
+		name                string
+		m                   Model
+		pageScrollSize      int // value forced into common.Config.PageScrollSize
+		pageDown            bool
+		expectedRenderIndex int
+	}{
+		{
+			name:                "Page down from top",
+			m:                   Model{metadata: tenItems, renderIndex: 0},
+			pageScrollSize:      3,
+			pageDown:            true,
+			expectedRenderIndex: 3,
+		},
+		{
+			name:                "Page down near end wraps around",
+			m:                   Model{metadata: tenItems, renderIndex: 8},
+			pageScrollSize:      3,
+			pageDown:            true,
+			expectedRenderIndex: 1, // (8 + 3) % 10
+		},
+		{
+			name:                "Page up from middle",
+			m:                   Model{metadata: tenItems, renderIndex: 5},
+			pageScrollSize:      3,
+			pageDown:            false,
+			expectedRenderIndex: 2,
+		},
+		{
+			name:                "Page up near beginning wraps around",
+			m:                   Model{metadata: tenItems, renderIndex: 1},
+			pageScrollSize:      3,
+			pageDown:            false,
+			expectedRenderIndex: 8, // (1 - 3 + 10) % 10
+		},
+		{
+			name:                "Page down on empty panel stays put",
+			m:                   Model{metadata: Metadata{data: nil}, renderIndex: 0},
+			pageScrollSize:      3,
+			pageDown:            true,
+			expectedRenderIndex: 0,
+		},
+		{
+			name:                "Falls back to visible height when config unset",
+			m:                   Model{metadata: tenItems, renderIndex: 0, height: 5},
+			pageScrollSize:      0, // borderSize is 2 -> page size becomes 5 - 2 = 3
+			pageDown:            true,
+			expectedRenderIndex: 3,
+		},
+	}
+
+	origPageScrollSize := common.Config.PageScrollSize
+	t.Cleanup(func() { common.Config.PageScrollSize = origPageScrollSize })
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			common.Config.PageScrollSize = tt.pageScrollSize
+			if tt.pageDown {
+				tt.m.PgDown()
+			} else {
+				tt.m.PgUp()
+			}
+			assert.Equal(t, tt.expectedRenderIndex, tt.m.renderIndex)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Focus the metadata panel and the arrow keys scroll it fine, but page up
and page down still scroll the file browser behind it. The page-key
handlers were always going to the focused file panel, while list up/down
already branch on which panel has focus.

So I routed the page keys through that same switch:

- metadata focused -> pages the metadata panel
- file panel focused -> pages the file panel (unchanged)
- sidebar / process bar focused -> nothing, since they don't page

The metadata panel only had list up/down, so I gave it page up/down as
well. Both share a small wrap helper now, and the page size follows the
page_scroll_size setting with a full-page fallback, same as the file panel.

# Related Issues

Fixes #966
---

# ✅ Pre-Submission Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I’m not committing any debug logs or TODOs
- [x] I have checked that the PR title follows the Conventional Commits format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Page Up/Down now behave based on the active panel, so metadata navigation no longer affects the file list and inactive panels ignore paging keys.
  * Metadata paging now handles edge cases more smoothly, including wrap-around and empty views.
  * Paging step size now falls back to the visible panel height when no custom page size is set, with a minimum of one row.

* **Tests**
  * Added regression coverage for context-aware page key handling and metadata navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->