### PR TITLE
feat: Add config and allow file preview to take up more space

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -93,6 +93,7 @@ type ConfigType struct {
 	ShowSelectIcons         bool     `toml:"show_select_icons"          comment:"\nShow checkbox icons in select mode (requires nerdfont)"`
 	TransparentBackground   bool     `toml:"transparent_background"     comment:"\nSet transparent background or not (this only work when your terminal background is transparent)"`
 	FilePreviewWidth        int      `toml:"file_preview_width"         comment:"\nFile preview width allow '0' (this mean same as file panel),'x' x must be less than 10 and greater than 1 (This means that the width of the file preview will be one xth of the total width.)"`
+	FilePreviewWidthPercent int      `toml:"file_preview_width_percent" comment:"\nDirect percentage (10-90) of total width for the file preview panel. Overrides file_preview_width when non-zero."`
 	EnableFilePreviewBorder bool     `toml:"enable_file_preview_border" comment:"\nEnable border around the file preview panel (default: false)"`
 	CodePreviewer           string   `toml:"code_previewer"             comment:"\nWhether to use the builtin syntax highlighting with chroma or use bat. Values: \"\" for builtin chroma, \"bat\" for bat"`
 	SidebarWidth            int      `toml:"sidebar_width"              comment:"\nThe length of the sidebar(excluding borders). If you don't find to display the sidebar, you can input 0 directly. If you want to display the value, please place it in the range of 5-20."`

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -60,6 +60,12 @@ func ValidateConfig(c *ConfigType) error {
 		)
 	}
 
+	if c.FilePreviewWidthPercent != 0 && (c.FilePreviewWidthPercent < 10 || c.FilePreviewWidthPercent > 90) {
+		return errors.New(
+			LoadConfigError("file_preview_width_percent", "File preview width percent must be 10-90, or 0 to disable."),
+		)
+	}
+
 	if c.SidebarWidth != 0 && (c.SidebarWidth < 5 || c.SidebarWidth > 20) {
 		return errors.New(LoadConfigError("sidebar_width", "Sidebar width must be 5–20, or 0 to hide the sidebar."))
 	}

--- a/src/internal/ui/filemodel/consts.go
+++ b/src/internal/ui/filemodel/consts.go
@@ -14,6 +14,7 @@ const (
 	FileModelMinWidth       = filepanel.MinWidth
 	FilePreviewResizingText = "Resizing..."
 	FilePreviewLoadingText  = "Loading..."
+	PercentDivisor          = 100
 )
 
 var ErrMaximumPanelCount = errors.New("maximum panel count reached")

--- a/src/internal/ui/filemodel/dimensions.go
+++ b/src/internal/ui/filemodel/dimensions.go
@@ -51,10 +51,13 @@ func (m *Model) updateChildComponentWidth() {
 
 	if m.FilePreview.IsOpen() {
 		// Need to give some width to preview
-		if common.Config.FilePreviewWidth == 0 {
+		switch {
+		case common.Config.FilePreviewWidthPercent != 0:
+			m.ExpectedPreviewWidth = m.Width * common.Config.FilePreviewWidthPercent / PercentDivisor
+		case common.Config.FilePreviewWidth == 0:
 			// FileModel will be split among `panelCount+1`
 			m.ExpectedPreviewWidth = m.Width / (panelCount + 1)
-		} else {
+		default:
 			m.ExpectedPreviewWidth = m.Width / common.Config.FilePreviewWidth
 		}
 		widthForPanels -= m.ExpectedPreviewWidth

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -121,6 +121,11 @@ transparent_background = false
 # Default (0): Use the same width as file picker panel.
 file_preview_width = 0
 
+#-- File Preview Panel Width (percent)
+# Direct percentage (10-90) of total width for the file preview panel.
+# Overrides file_preview_width when non-zero.
+file_preview_width_percent = 0
+
 #-- File Preview Border
 # Enable border around the file preview panel for better visual separation.
 # Default: false (no border)


### PR DESCRIPTION
# Description




`file_preview_width` only supports 1/n divisors (n=2-10), which caps the file preview panel at 50% of total width — there's no way to make it wider than the file panel.

Adds a new optional `file_preview_width_percent` config field (10-90) that, when non-zero, directly sets the preview panel's share of total width and overrides `file_preview_width`. Old behavior is unchanged when the new field is left at 0.

Example: `file_preview_width_percent = 67` gives a 2/3 preview / 1/3 file panel split.

# Related Issues

https://github.com/yorukot/superfile/issues/1520

# Screenshots

<img width="1619" height="1008" alt="Screenshot 2026-07-09 at 20 31 55" src="https://github.com/user-attachments/assets/fca76abb-4a78-4112-9689-5cbe3f026d18" />


<img width="1604" height="994" alt="Screenshot 2026-07-09 at 20 32 11" src="https://github.com/user-attachments/assets/ca3b515a-099b-49a8-98d7-c90383a1cc8a" />

<img width="1622" height="1002" alt="Screenshot 2026-07-09 at 20 34 43" src="https://github.com/user-attachments/assets/948e1265-2461-4d26-a6f0-ca75ce8b7e2f" />


---

# ✅ Pre-Submission Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I'm not committing any debug logs or TODOs
- [x] I have checked that the PR title follows the Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to set the file preview panel width as a percentage of the window.
  * The preview panel now supports percentage-based sizing, with the new setting taking priority over the existing width-based option when enabled.

* **Bug Fixes**
  * Added validation to ensure the percentage value stays within the supported 10–90 range.
  * Improved width calculation so the preview layout follows the selected sizing mode more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->