### PR TITLE
fix: Detailed information about create operation errors for the user

### DIFF
--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -18,20 +18,14 @@ func (m *model) cancelTypingModal() {
 	m.typingModal.textInput.Blur()
 	m.typingModal.open = false
 }
-func (m *model) closeTypingModal(process processbar.Process,
-	processBarModel *processbar.Model) {
-	m.typingModal.errorMesssage = ""
-	markProcessDone(process, processBarModel)
-}
 
 // Confirm to create file or directory
-func (m *model) createItem(item string) error {
+func createItem(location, item string) error {
 	if err := checkFileNameValidity(item); err != nil {
-		m.typingModal.errorMesssage = err.Error()
 		slog.Error("Errow while createItem during item creation", "error", err)
 		return err
 	}
-	path := filepath.Join(m.typingModal.location, item)
+	path := filepath.Join(location, item)
 	if !strings.HasSuffix(item, string(filepath.Separator)) {
 		path, _ = renameIfDuplicate(path)
 		if err := os.MkdirAll(filepath.Dir(path), utils.UserDirPerm); err != nil {
@@ -60,16 +54,22 @@ func (m *model) getCreateCmd() tea.Cmd {
 	}
 
 	items := []string{m.typingModal.textInput.Value()}
+	location := m.typingModal.location
 
 	reqID := m.nextIoReqCnt()
 	slog.Debug("Submitting create request", "id", reqID, "items cnt", len(items))
 	m.cancelTypingModal()
 	return func() tea.Msg {
-		return m.createOperation(&m.processBarModel, items, reqID)
+		return m.createOperation(&m.processBarModel, location, items, reqID)
 	}
 }
 
-func (m *model) createOperation(processBarModel *processbar.Model, items []string, reqID int) tea.Msg {
+func (m *model) createOperation(
+	processBarModel *processbar.Model,
+	location string,
+	items []string,
+	reqID int,
+) tea.Msg {
 	if len(items) == 0 {
 		return NewCreateOperationMsg(processbar.Cancelled, reqID)
 	}
@@ -81,23 +81,23 @@ func (m *model) createOperation(processBarModel *processbar.Model, items []strin
 	finalizer := func(state processbar.ProcessState, reqID int) tea.Msg {
 		return NewCreateOperationMsg(state, reqID)
 	}
-	processor := makeCreateProcessor(m, p, processBarModel)
+	processor := makeCreateProcessor(location, p, processBarModel)
 	msg := m.runFileProcessor(processor, finalizer, items, reqID)
 	return msg
 }
 
-func makeCreateProcessor(model *model,
+func makeCreateProcessor(location string,
 	process processbar.Process,
 	processBarModel *processbar.Model) processbar.FileListProcessor {
 	processorFunction := func(items []string) (processbar.Process, []string) {
 		notProcessed := make([]string, 0)
 		if len(items) == 0 {
-			model.closeTypingModal(process, processBarModel)
+			markProcessDone(process, processBarModel)
 			return process, notProcessed
 		}
 
 		for i, item := range items {
-			err := model.createItem(item)
+			err := createItem(location, item)
 			if err != nil {
 				process.State = processbar.Failed
 				slog.Error("Error in create operation", "item", item, "error", err)
@@ -112,7 +112,7 @@ func makeCreateProcessor(model *model,
 
 		if process.State != processbar.Failed {
 			process.State = processbar.Successful
-			model.closeTypingModal(process, processBarModel)
+			markProcessDone(process, processBarModel)
 		}
 		return process, notProcessed
 	}

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -21,7 +21,6 @@ func (m *model) cancelTypingModal() {
 func (m *model) closeTypingModal(process processbar.Process,
 	processBarModel *processbar.Model) {
 	m.typingModal.errorMesssage = ""
-	m.cancelTypingModal()
 	markProcessDone(process, processBarModel)
 }
 
@@ -64,6 +63,7 @@ func (m *model) getCreateCmd() tea.Cmd {
 
 	reqID := m.nextIoReqCnt()
 	slog.Debug("Submitting create request", "id", reqID, "items cnt", len(items))
+	m.cancelTypingModal()
 	return func() tea.Msg {
 		return m.createOperation(&m.processBarModel, items, reqID)
 	}

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -6,7 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/yorukot/superfile/src/internal/ui/filepanel"
+	"github.com/yorukot/superfile/src/internal/ui/processbar"
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
@@ -15,42 +18,105 @@ func (m *model) cancelTypingModal() {
 	m.typingModal.textInput.Blur()
 	m.typingModal.open = false
 }
+func (m *model) closeTypingModal(process processbar.Process,
+	processBarModel *processbar.Model) {
+	m.typingModal.errorMesssage = ""
+	m.cancelTypingModal()
+	markProcessDone(process, processBarModel)
+}
 
 // Confirm to create file or directory
-func (m *model) createItem() {
-	if err := checkFileNameValidity(m.typingModal.textInput.Value()); err != nil {
+func (m *model) createItem(item string) error {
+	if err := checkFileNameValidity(item); err != nil {
 		m.typingModal.errorMesssage = err.Error()
 		slog.Error("Errow while createItem during item creation", "error", err)
-
-		return
+		return err
 	}
-
-	defer func() {
-		m.typingModal.errorMesssage = ""
-		m.typingModal.open = false
-		m.typingModal.textInput.Blur()
-	}()
-
-	path := filepath.Join(m.typingModal.location, m.typingModal.textInput.Value())
-	if !strings.HasSuffix(m.typingModal.textInput.Value(), string(filepath.Separator)) {
+	path := filepath.Join(m.typingModal.location, item)
+	if !strings.HasSuffix(item, string(filepath.Separator)) {
 		path, _ = renameIfDuplicate(path)
 		if err := os.MkdirAll(filepath.Dir(path), utils.UserDirPerm); err != nil {
 			slog.Error("Error while createItem during directory creation", "error", err)
-			return
+			return err
 		}
 		f, err := os.Create(path)
 		if err != nil {
 			slog.Error("Error while createItem during file creation", "error", err)
-			return
+			return err
 		}
 		defer f.Close()
 	} else {
 		err := os.MkdirAll(path, utils.UserDirPerm)
 		if err != nil {
 			slog.Error("Error while createItem during directory creation", "error", err)
-			return
+			return err
 		}
 	}
+	return nil
+}
+
+func (m *model) getCreateCmd() tea.Cmd {
+	if !m.typingModal.open {
+		return nil
+	}
+
+	items := []string{m.typingModal.textInput.Value()}
+
+	reqID := m.nextIoReqCnt()
+	slog.Debug("Submitting delete request", "id", reqID, "items cnt", len(items))
+	return func() tea.Msg {
+		return m.createOperation(&m.processBarModel, items, reqID)
+	}
+}
+
+func (m *model) createOperation(processBarModel *processbar.Model, items []string, reqID int) tea.Msg {
+	if len(items) == 0 {
+		return NewCreateOperationMsg(processbar.Cancelled, reqID)
+	}
+	p, err := processBarModel.SendAddProcessMsg(filepath.Base(items[0]), processbar.OpCreate, len(items), true)
+	if err != nil {
+		slog.Error("Cannot spawn a new process", "error", err)
+		return NewDeleteOperationMsg(processbar.Failed, reqID)
+	}
+	finalizer := func(state processbar.ProcessState, reqID int) tea.Msg {
+		return NewCreateOperationMsg(state, reqID)
+	}
+	processor := makeCreateProcessor(m, p, processBarModel)
+	msg := m.runFileProcessor(processor, finalizer, items, reqID)
+	return msg
+}
+
+func makeCreateProcessor(model *model,
+	process processbar.Process,
+	processBarModel *processbar.Model) processbar.FileListProcessor {
+	processorFunction := func(items []string) (processbar.Process, []string) {
+		notProcessed := make([]string, 0)
+		if len(items) == 0 {
+			model.closeTypingModal(process, processBarModel)
+			return process, notProcessed
+		}
+
+		for i, item := range items {
+			err := model.createItem(item)
+			if err != nil {
+				process.State = processbar.Failed
+				slog.Error("Error in create operation", "item", item, "error", err)
+				process.ErrorMsg = formatFileError(item, err)
+				notProcessed = items[i:]
+				break
+			}
+			process.CurrentFile = filepath.Base(item)
+			process.Done++
+			processBarModel.TrySendingUpdateProcessMsg(process)
+		}
+
+		if process.State != processbar.Failed {
+			process.State = processbar.Successful
+			model.closeTypingModal(process, processBarModel)
+		}
+		return process, notProcessed
+	}
+	return processorFunction
 }
 
 // Cancel rename file or directory

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -63,7 +63,7 @@ func (m *model) getCreateCmd() tea.Cmd {
 	items := []string{m.typingModal.textInput.Value()}
 
 	reqID := m.nextIoReqCnt()
-	slog.Debug("Submitting delete request", "id", reqID, "items cnt", len(items))
+	slog.Debug("Submitting create request", "id", reqID, "items cnt", len(items))
 	return func() tea.Msg {
 		return m.createOperation(&m.processBarModel, items, reqID)
 	}
@@ -76,7 +76,7 @@ func (m *model) createOperation(processBarModel *processbar.Model, items []strin
 	p, err := processBarModel.SendAddProcessMsg(filepath.Base(items[0]), processbar.OpCreate, len(items), true)
 	if err != nil {
 		slog.Error("Cannot spawn a new process", "error", err)
-		return NewDeleteOperationMsg(processbar.Failed, reqID)
+		return NewCreateOperationMsg(processbar.Failed, reqID)
 	}
 	finalizer := func(state processbar.ProcessState, reqID int) tea.Msg {
 		return NewCreateOperationMsg(state, reqID)

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -231,14 +231,15 @@ func (m *model) filePanelNormalModeKey(msg string) tea.Cmd {
 }
 
 // Check the hotkey to cancel operation or create file
-func (m *model) typingModalOpenKey(msg string) {
+func (m *model) typingModalOpenKey(msg string) tea.Cmd {
 	switch {
 	case slices.Contains(common.Hotkeys.CancelTyping, msg):
 		m.typingModal.errorMesssage = ""
 		m.cancelTypingModal()
 	case slices.Contains(common.Hotkeys.ConfirmTyping, msg):
-		m.createItem()
+		return m.getCreateCmd()
 	}
+	return nil
 }
 
 func (m *model) notifyModelOpenKey(msg string) tea.Cmd {

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -234,7 +234,6 @@ func (m *model) filePanelNormalModeKey(msg string) tea.Cmd {
 func (m *model) typingModalOpenKey(msg string) tea.Cmd {
 	switch {
 	case slices.Contains(common.Hotkeys.CancelTyping, msg):
-		m.typingModal.errorMesssage = ""
 		m.cancelTypingModal()
 	case slices.Contains(common.Hotkeys.ConfirmTyping, msg):
 		return m.getCreateCmd()

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -297,7 +297,7 @@ func (m *model) handleKeyInput(msg tea.KeyPressMsg) tea.Cmd {
 	case m.spfError.IsOpen():
 		cmd = m.spfErrorModelOpenKey(msg.String())
 	case m.typingModal.open:
-		m.typingModalOpenKey(msg.String())
+		cmd = m.typingModalOpenKey(msg.String())
 	case m.promptModal.IsOpen():
 		// Ignore keypress. It will be handled in Update call via
 		// updateFilePanelState

--- a/src/internal/model_file_operations_test.go
+++ b/src/internal/model_file_operations_test.go
@@ -107,7 +107,6 @@ func TestFileCreation(t *testing.T) {
 			assert.Eventually(t, func() bool {
 				return m.typingModal.errorMesssage != ""
 			}, DefaultTestTimeout, DefaultTestTick, "expected an error for input: %q", tt.fileName)
-
 		} else {
 			targetFile := filepath.Join(testChildDir, tt.fileName)
 			assert.Eventually(t, func() bool {

--- a/src/internal/model_file_operations_test.go
+++ b/src/internal/model_file_operations_test.go
@@ -91,31 +91,63 @@ func TestFileCreation(t *testing.T) {
 	}
 
 	for _, tt := range testdata {
-		m := defaultTestModel(testChildDir)
-		p := NewTestTeaProgWithEventLoop(t, m)
-		TeaUpdate(m, nil)
-		p.SendKey(common.Hotkeys.FilePanelItemCreate[0])
+		t.Run(tt.name, func(t *testing.T) {
+			m := defaultTestModel(testChildDir)
+			p := NewTestTeaProgWithEventLoop(t, m)
+			p.SendKey(common.Hotkeys.FilePanelItemCreate[0])
 
-		require.Eventually(t, func() bool {
-			return m.typingModal.open
-		}, DefaultTestTimeout, DefaultTestTick, "Typing modal never opened")
+			require.Eventually(t, func() bool {
+				return m.typingModal.open
+			}, DefaultTestTimeout, DefaultTestTick, "Typing modal never opened")
 
-		p.SendKey(tt.fileName)
-		p.SendKey(common.Hotkeys.ConfirmTyping[0])
+			p.SendKey(tt.fileName)
+			p.SendKey(common.Hotkeys.ConfirmTyping[0])
 
-		if tt.expectedError {
-			assert.Eventually(t, func() bool {
-				return m.typingModal.errorMesssage != ""
-			}, DefaultTestTimeout, DefaultTestTick, "expected an error for input: %q", tt.fileName)
-		} else {
+			require.Eventually(t, func() bool {
+				return !m.typingModal.open
+			}, DefaultTestTimeout, DefaultTestTick, "Typing modal never closed")
+
+			if tt.expectedError {
+				require.Eventually(t, func() bool {
+					return m.spfError.IsOpen()
+				}, DefaultTestTimeout, DefaultTestTick, "SPF error modal never opened for input: %q", tt.fileName)
+
+				p.SendKey(common.Hotkeys.Quit[0])
+				require.Eventually(t, func() bool {
+					return !m.spfError.IsOpen()
+				}, DefaultTestTimeout, DefaultTestTick, "SPF error modal never closed")
+				return
+			}
+
 			targetFile := filepath.Join(testChildDir, tt.fileName)
 			assert.Eventually(t, func() bool {
 				_, err := os.Lstat(targetFile)
 				return err == nil
 			}, DefaultTestTimeout, DefaultTestTick, "Target file did not get created : %q", targetFile)
-			assert.Empty(t, m.typingModal.errorMesssage, "Empty error expected for input: %q", tt.fileName)
-		}
+			assert.False(t, m.spfError.IsOpen(), "Unexpected SPF error for input: %q", tt.fileName)
+		})
 	}
+
+	// This is to verify that even if m.typingModal.location is changed while the command is being executed
+	// the create still works for older location set in typingModal
+	t.Run("create request snapshots destination", func(t *testing.T) {
+		originalLocation := t.TempDir()
+		changedLocation := t.TempDir()
+		m := defaultTestModel(originalLocation)
+		m.panelCreateNewFile()
+		m.typingModal.textInput.SetValue("captured.txt")
+
+		cmd := m.getCreateCmd()
+		require.NotNil(t, cmd)
+		assert.False(t, m.typingModal.open)
+
+		m.typingModal.location = changedLocation
+		msg := cmd()
+		require.IsType(t, CreateOperationMsg{}, msg)
+
+		assert.FileExists(t, filepath.Join(originalLocation, "captured.txt"))
+		assert.NoFileExists(t, filepath.Join(changedLocation, "captured.txt"))
+	})
 }
 
 func TestFileRename(t *testing.T) {

--- a/src/internal/model_file_operations_test.go
+++ b/src/internal/model_file_operations_test.go
@@ -92,31 +92,29 @@ func TestFileCreation(t *testing.T) {
 
 	for _, tt := range testdata {
 		m := defaultTestModel(testChildDir)
-
+		p := NewTestTeaProgWithEventLoop(t, m)
 		TeaUpdate(m, nil)
-		TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.FilePanelItemCreate[0]))
+		p.SendKey(common.Hotkeys.FilePanelItemCreate[0])
 
-		assert.Empty(t, m.typingModal.errorMesssage)
+		require.Eventually(t, func() bool {
+			return m.typingModal.open
+		}, DefaultTestTimeout, DefaultTestTick, "Typing modal never opened")
 
-		m.typingModal.textInput.SetValue(tt.fileName)
-
-		cmd := TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.ConfirmTyping[0]))
-		if v, ok := cmd().(tea.BatchMsg); ok {
-			for _, cmdExec := range v {
-				cmdExec()
-			}
-		}
+		p.SendKey(tt.fileName)
+		p.SendKey(common.Hotkeys.ConfirmTyping[0])
 
 		if tt.expectedError {
-			assert.NotEmpty(t, m.typingModal.errorMesssage, "expected an error for input: %q", tt.fileName)
+			assert.Eventually(t, func() bool {
+				return m.typingModal.errorMesssage != ""
+			}, DefaultTestTimeout, DefaultTestTick, "expected an error for input: %q", tt.fileName)
+
 		} else {
-			assert.Empty(t, m.typingModal.errorMesssage, "expected an error for input: %q", tt.fileName)
-			assert.FileExists(
-				t,
-				filepath.Join(testChildDir, tt.fileName),
-				"expected file to be created: %q",
-				tt.fileName,
-			)
+			targetFile := filepath.Join(testChildDir, tt.fileName)
+			assert.Eventually(t, func() bool {
+				_, err := os.Lstat(targetFile)
+				return err == nil
+			}, DefaultTestTimeout, DefaultTestTick, "Target file did not get created : %q", targetFile)
+			assert.Empty(t, m.typingModal.errorMesssage, "Empty error expected for input: %q", tt.fileName)
 		}
 	}
 }

--- a/src/internal/model_file_operations_test.go
+++ b/src/internal/model_file_operations_test.go
@@ -100,7 +100,12 @@ func TestFileCreation(t *testing.T) {
 
 		m.typingModal.textInput.SetValue(tt.fileName)
 
-		TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.ConfirmTyping[0]))
+		cmd := TeaUpdate(m, utils.TeaRuneKeyMsg(common.Hotkeys.ConfirmTyping[0]))
+		if v, ok := cmd().(tea.BatchMsg); ok {
+			for _, cmdExec := range v {
+				cmdExec()
+			}
+		}
 
 		if tt.expectedError {
 			assert.NotEmpty(t, m.typingModal.errorMesssage, "expected an error for input: %q", tt.fileName)

--- a/src/internal/model_msg.go
+++ b/src/internal/model_msg.go
@@ -46,6 +46,25 @@ func (msg PasteOperationMsg) ApplyToModel(m *model) tea.Cmd {
 	return nil
 }
 
+type CreateOperationMsg struct {
+	BaseMessage
+
+	state processbar.ProcessState
+}
+
+func NewCreateOperationMsg(state processbar.ProcessState, reqID int) CreateOperationMsg {
+	return CreateOperationMsg{
+		state: state,
+		BaseMessage: BaseMessage{
+			reqID: reqID,
+		},
+	}
+}
+
+func (msg CreateOperationMsg) ApplyToModel(m *model) tea.Cmd {
+	return nil
+}
+
 type DeleteOperationMsg struct {
 	BaseMessage
 

--- a/src/internal/model_render.go
+++ b/src/internal/model_render.go
@@ -85,13 +85,9 @@ func (m *model) typineModalRender() string {
 		lipgloss.NewStyle().Background(common.ModalBGColor).Render("           ") +
 		cancel
 
-	var err string
-	if m.typingModal.errorMesssage != "" {
-		err = "\n\n" + common.ModalErrorStyle.Render(m.typingModal.errorMesssage)
-	}
 	// TODO : Move this all to rendering package to avoid specifying newlines manually
 	return common.ModalBorderStyle(common.ModalHeight, common.ModalWidth).
-		Render(fileLocation + "\n" + m.typingModal.textInput.View() + "\n\n" + tip + err)
+		Render(fileLocation + "\n" + m.typingModal.textInput.View() + "\n\n" + tip)
 }
 
 func (m *model) introduceModalRender() string {

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -101,10 +101,9 @@ type model struct {
 }
 
 type typingModal struct {
-	location      string
-	open          bool
-	textInput     textinput.Model
-	errorMesssage string
+	location  string
+	open      bool
+	textInput textinput.Model
 }
 
 type editorFinishedMsg struct{ err error }

--- a/src/internal/ui/processbar/operation.go
+++ b/src/internal/ui/processbar/operation.go
@@ -10,6 +10,7 @@ const (
 	OpDelete
 	OpCompress
 	OpExtract
+	OpCreate
 )
 
 // GetIcon returns the appropriate icon for the operation type
@@ -25,6 +26,8 @@ func (op OperationType) GetIcon() string {
 		return icon.CompressFile
 	case OpExtract:
 		return icon.ExtractFile
+	case OpCreate:
+		return icon.InOperation
 	default:
 		return icon.InOperation
 	}
@@ -43,6 +46,8 @@ func (op OperationType) GetVerb() string {
 		return "Compressing"
 	case OpExtract:
 		return "Extracting"
+	case OpCreate:
+		return "Creating"
 	default:
 		return "Processing"
 	}
@@ -61,6 +66,8 @@ func (op OperationType) GetPastVerb() string {
 		return "Compressed"
 	case OpExtract:
 		return "Extracted"
+	case OpCreate:
+		return "Created"
 	default:
 		return "Processed"
 	}


### PR DESCRIPTION
continuation of https://github.com/yorukot/superfile/pull/1408
issues: https://github.com/yorukot/superfile/issues/1360 , https://github.com/yorukot/superfile/issues/1152

Problem: User don't get an error message in case of error creation file/dir.
Added error message for create operation. The existing modal error flow is used.

NOTE: I used  here the standard error modal window. It might be worth adding the functionality to hide the buttons and leave one of the two in the next PR.

Happy path works:
<img width="425" height="528" alt="image" src="https://github.com/user-attachments/assets/857c0361-56ca-4348-87c6-b4334fdd2ae9" />

Error case:
got an error window
<img width="824" height="364" alt="image" src="https://github.com/user-attachments/assets/765a682c-6276-4588-b0b8-711f727c81f7" />
after key press
<img width="464" height="204" alt="image" src="https://github.com/user-attachments/assets/d7f2f83a-a4a8-4fd9-8cb3-927b08986647" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a dedicated “Creating / Created” progress workflow for creating files and directories.

* **Bug Fixes**
  * Improved typing modal confirmation so creation runs through the app’s command pipeline.
  * Ensured modal error messaging is cleared when the creation workflow completes successfully.

* **Tests**
  * Updated the file-creation test to interact with the UI via key events and verify asynchronous behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->