### PR TITLE
fix: prevent TOML repair from leaving stale file tail

### DIFF
--- a/src/pkg/utils/file_utils.go
+++ b/src/pkg/utils/file_utils.go
@@ -173,6 +173,13 @@ func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) 
 		resultErr.UpdateMessageAndError("failed to marshal config to TOML", err)
 		return resultErr
 	}
+
+	// Truncate the file
+	if err = origFile.Truncate(0); err != nil {
+		resultErr.UpdateMessageAndError("failed to truncate TOML file", err)
+		return resultErr
+	}
+	// Write updated TOML to file
 	_, err = origFile.WriteAt(tomlData, 0)
 	if err != nil {
 		resultErr.UpdateMessageAndError("failed to write TOML data to original file", err)

--- a/src/pkg/utils/file_utils_test.go
+++ b/src/pkg/utils/file_utils_test.go
@@ -146,6 +146,70 @@ func TestLoadTomlFile(t *testing.T) {
 	}
 }
 
+func TestLoadTomlFileFixOverwritesStaleTail(t *testing.T) {
+	// The defaults are what LoadTomlFile should use to fill any fields missing
+	// from the user's TOML file.
+	defaultData := strings.Join([]string{
+		"sample_bool = true",
+		"sample_int = 2",
+		"sample_str = \"hello\"",
+		"sample_slice = ['a', 'b']",
+		"",
+	}, "\n")
+
+	// The user file below overrides three fields and omits sample_str. After
+	// fixing, those custom values should remain and only sample_str should come
+	// from the defaults.
+	expectedVal := TestTOMLType{
+		SampleBool:  false,
+		SampleInt:   -1,
+		SampleStr:   "hello",
+		SampleSlice: []string{"custom"},
+	}
+	// The fixed file should be exactly the marshaled target. If old bytes remain
+	// after the write, this equality check will fail.
+	fixedToml, err := toml.Marshal(expectedVal)
+	require.NoError(t, err)
+
+	// Put stale padding after the meaningful TOML so it represents the old file
+	// tail. Before the overwrite/truncate fix, WriteAt would write the shorter
+	// fixed TOML at byte 0 and leave bytes from this tail behind.
+	userToml := strings.Join([]string{
+		"sample_bool = false",
+		"sample_int = -1",
+		"sample_slice = ['custom']",
+		"",
+	}, "\n")
+	originalContent := userToml + strings.Repeat("# stale tail padding\n", 50)
+
+	// Write the intentionally incomplete user TOML to a temp file so the fixer
+	// can safely modify it.
+	testFile := filepath.Join(t.TempDir(), "missing-field.toml")
+	require.NoError(t, os.WriteFile(testFile, []byte(originalContent), ConfigFilePerm))
+
+	// Run the repair path. LoadTomlFile returns a non-fatal TomlLoadError when
+	// it fixes missing fields, so the test expects that error shape.
+	var tomlVal TestTOMLType
+	err = LoadTomlFile(testFile, defaultData, &tomlVal, true, false)
+	var tomlErr *TomlLoadError
+	require.ErrorAs(t, err, &tomlErr)
+	require.True(t, tomlErr.missingFields)
+	require.Equal(t, expectedVal, tomlVal)
+
+	// Confirm the repaired file was fully replaced. If the old tail survived
+	// after writing the shorter TOML, this marker would still be present after
+	// the repaired TOML content.
+	repairedContent, err := os.ReadFile(testFile)
+	require.NoError(t, err)
+	assert.Equal(t, fixedToml, repairedContent)
+	assert.NotContains(t, string(repairedContent), "stale tail padding")
+
+	// Finally, reload the repaired file without fixing.
+	err = LoadTomlFile(testFile, defaultData, &tomlVal, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, expectedVal, tomlVal)
+}
+
 func TestLoadTomlFileIgnorer(t *testing.T) {
 	_, curFilename, _, ok := runtime.Caller(0)
 	require.True(t, ok)


### PR DESCRIPTION
# Description

This PR fixes TOML repair writing for missing config/hotkey fields.

 Previously, the shared TOML repair path wrote the repaired TOML at byte offset `0` without clearing the previous file contents first. If the repaired TOML was shorter than the original file, stale bytes from the old file could remain at the end. On the next load, those stale bytes could produce duplicate TOML keys, such as:

`toml: key confirm_typing is already defined`

The fix truncates the existing file before writing the repaired TOML, ensuring the repaired file contains only the newly generated TOML content.

Repaired:
```
spf --fix-hotkeys
spf --fix-config-file
```

# Related Issues

Fixes #1508

# Issue Investigation
This issue existed before v1.6.0 but was likely noticed because `split_file_panel` hotkey was added. A user that uses a custom configuration might not have added this new key configuration to their TOML file so they were notified when running the program to add the value via `--fix-hotkeys`. The default TOML file has multiple lines of comments prior to the actual key value configurations. When `--fix-hotkeys` attempts to fix the configuration it does not do a line by line fix. Instead, it loads a TOML configuration into memory and then writes it all to the file starting at the 0th byte. No comments included in this new write. So, what happens is that this new write is shorter than the existing one so some of the old configuration is left over at the end. Causing potential duplicate keys and a corrupt TOML file.

**Example:**

Current TOML (missing split_file_panel):
```
########################
# Description about file purpose
# Description about file layout
########################
confirm = ['enter', 'right', 'l']
quit = ['q', 'esc']
```

After run --fix-hotkeys:
```
split_file_panel = ['N', '']
confirm = ['enter', 'right', 'l']
quit = ['q', 'esc']
########################
confirm = ['enter', 'right', 'l']
quit = ['q', 'esc']
```

Result: Left over tail bytes remain because file was not truncated before OR after to the correct byte length.

# Screenshots (Optional)

Add screenshots if this helps reviewers understand the change.

---

# ✅ Pre-Submission Checklist

Please go through the following steps **before** submitting this PR.  
You can delete this section after confirming everything is done.

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I’m not committing any debug logs or TODOs
- [x] I have checked that the PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TOML file repairs so outdated trailing content is removed when missing fields are automatically restored.
  * Repaired configuration files can now be reloaded cleanly without retaining stale data.

* **Tests**
  * Added coverage to verify repaired TOML files exactly match the expected configuration and contain no leftover content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->