### PR TITLE
fix(preview): make kitty image previews work inside tmux

### DIFF
--- a/src/pkg/file_preview/kitty.go
+++ b/src/pkg/file_preview/kitty.go
@@ -12,13 +12,19 @@ import (
 	"github.com/charmbracelet/x/ansi/kitty"
 )
 
-// isKittyCapable checks if the terminal supports Kitty graphics protocol
-func isKittyCapable() bool {
-	termProgram := os.Getenv("TERM_PROGRAM")
-	term := os.Getenv("TERM")
+// IsKittyCapable reports whether the terminal supports the Kitty graphics
+// protocol. The result is cached because detection inside tmux has to query
+// the tmux server.
+func (tc *TerminalCapabilities) IsKittyCapable() bool {
+	tc.kittyInit.Do(func() {
+		tc.kittyCapable = detectKittyCapable()
+	})
+	return tc.kittyCapable
+}
 
+// detectKittyCapable performs the actual Kitty graphics capability detection.
+func detectKittyCapable() bool {
 	// TODO: Replace this allowlist with a real Kitty graphics capability check.
-	// tmux masks the underlying terminal through TERM/TERM_PROGRAM.
 	knownTerminals := []string{
 		"ghostty",
 		"WezTerm",
@@ -29,9 +35,24 @@ func isKittyCapable() bool {
 		"WarpTerminal",
 	}
 
-	for _, knownTerm := range knownTerminals {
-		if strings.EqualFold(termProgram, knownTerm) || strings.EqualFold(term, knownTerm) {
-			return true
+	candidates := []string{os.Getenv("TERM_PROGRAM"), os.Getenv("TERM")}
+	if insideTmux() {
+		// tmux masks the underlying terminal through TERM/TERM_PROGRAM, and
+		// discards the image data unless passthrough is enabled.
+		if !tmuxAllowsPassthrough() {
+			return false
+		}
+		candidates = tmuxOuterTerminals()
+	}
+
+	for _, candidate := range candidates {
+		for _, knownTerm := range knownTerminals {
+			// Substring match so terminfo names ("xterm-ghostty") and version
+			// strings ("ghostty 1.3.1") are recognised as well.
+			if candidate != "" &&
+				strings.Contains(strings.ToLower(candidate), strings.ToLower(knownTerm)) {
+				return true
+			}
 		}
 	}
 
@@ -44,7 +65,7 @@ func (p *ImagePreviewer) GetKittyClearRaw() string {
 	if !p.IsKittyCapable() {
 		return ""
 	}
-	return ansi.KittyGraphics(nil, "a=d")
+	return rawForTerminal(ansi.KittyGraphics(nil, "a=d"))
 }
 
 // generatePlacementID generates a unique placement ID based on file path
@@ -134,7 +155,7 @@ func (p *ImagePreviewer) renderWithKittyUsingTermCap(img image.Image, path strin
 
 	return &KittyImageResult{
 		Placeholders: placeholders,
-		RawTransmit:  transmitBuf.String(),
+		RawTransmit:  rawForTerminal(transmitBuf.String()),
 	}, nil
 }
 
@@ -175,5 +196,5 @@ func buildKittyPlaceholders(imgID int, cols, rows int) string {
 
 // IsKittyCapable checks if the terminal supports Kitty graphics protocol
 func (p *ImagePreviewer) IsKittyCapable() bool {
-	return isKittyCapable()
+	return p.terminalCap.IsKittyCapable()
 }

--- a/src/pkg/file_preview/kitty_test.go
+++ b/src/pkg/file_preview/kitty_test.go
@@ -1,0 +1,53 @@
+package filepreview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Only the non-tmux paths are asserted here, since the tmux paths depend on a
+// running tmux server being reachable from the test environment.
+func TestDetectKittyCapableOutsideTmux(t *testing.T) {
+	testcases := []struct {
+		name        string
+		termProgram string
+		term        string
+		expected    bool
+	}{
+		{
+			name:        "known terminal via TERM_PROGRAM",
+			termProgram: "ghostty",
+			term:        "xterm-256color",
+			expected:    true,
+		},
+		{
+			name:     "known terminal via TERM",
+			term:     "xterm-kitty",
+			expected: true,
+		},
+		{
+			name:     "terminfo name containing a known terminal",
+			term:     "xterm-ghostty",
+			expected: true,
+		},
+		{
+			name:     "unknown terminal",
+			term:     "xterm-256color",
+			expected: false,
+		},
+		{
+			name:     "empty environment",
+			expected: false,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TMUX", "")
+			t.Setenv("TERM_PROGRAM", tt.termProgram)
+			t.Setenv("TERM", tt.term)
+			assert.Equal(t, tt.expected, detectKittyCapable())
+		})
+	}
+}

--- a/src/pkg/file_preview/tmux.go
+++ b/src/pkg/file_preview/tmux.go
@@ -1,0 +1,79 @@
+package filepreview
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// tmux hides the outer terminal behind its own TERM/TERM_PROGRAM and consumes
+// bare APC sequences, so Kitty graphics only work inside tmux when the payload
+// is tunnelled through tmux's DCS passthrough and the terminal tmux is drawing
+// to is itself Kitty capable. These helpers ask the running server for both.
+
+const (
+	escByte           = "\x1b"
+	stringTerminator  = "\x1b\\"
+	tmuxPassthroughIn = "\x1bPtmux;"
+)
+
+// insideTmux reports whether superfile is running inside a tmux pane.
+func insideTmux() bool {
+	return os.Getenv("TMUX") != ""
+}
+
+// tmuxQuery runs a tmux command and returns its trimmed output, or "" on error.
+func tmuxQuery(args ...string) string {
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// tmuxOuterTerminals returns the terminal name and type reported by the tmux
+// client, which identify the terminal emulator tmux is actually drawing to.
+func tmuxOuterTerminals() []string {
+	return strings.Split(tmuxQuery("display-message", "-p",
+		"#{client_termname}\n#{client_termtype}"), "\n")
+}
+
+// tmuxAllowsPassthrough reports whether the server forwards DCS passthrough
+// sequences to the outer terminal. Without it the image data is discarded and
+// only the Unicode placeholder cells would be drawn.
+func tmuxAllowsPassthrough() bool {
+	switch tmuxQuery("show-options", "-gv", "allow-passthrough") {
+	case "on", "all":
+		return true
+	}
+	return false
+}
+
+// tmuxPassthrough wraps every escape sequence in s in tmux's DCS passthrough,
+// doubling inner ESC bytes as tmux requires. Sequences are wrapped one at a
+// time so that a large chunked image transmission never forms a single DCS
+// string big enough to hit tmux's input buffer limit.
+func tmuxPassthrough(s string) string {
+	var b strings.Builder
+	for s != "" {
+		seq := s
+		if i := strings.Index(s, stringTerminator); i >= 0 {
+			seq, s = s[:i+len(stringTerminator)], s[i+len(stringTerminator):]
+		} else {
+			s = ""
+		}
+		b.WriteString(tmuxPassthroughIn)
+		b.WriteString(strings.ReplaceAll(seq, escByte, escByte+escByte))
+		b.WriteString(stringTerminator)
+	}
+	return b.String()
+}
+
+// rawForTerminal prepares raw terminal output for the transport in use. Inside
+// tmux the sequences must be tunnelled so they reach the outer terminal.
+func rawForTerminal(s string) string {
+	if s == "" || !insideTmux() {
+		return s
+	}
+	return tmuxPassthrough(s)
+}

--- a/src/pkg/file_preview/tmux_test.go
+++ b/src/pkg/file_preview/tmux_test.go
@@ -1,0 +1,55 @@
+package filepreview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTmuxPassthrough(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single APC sequence is wrapped with doubled escapes",
+			input:    "\x1b_Ga=d\x1b\\",
+			expected: "\x1bPtmux;\x1b\x1b_Ga=d\x1b\x1b\\\x1b\\",
+		},
+		{
+			name:  "each sequence is wrapped separately",
+			input: "\x1b_Ga=d\x1b\\\x1b_Gm=1;AAAA\x1b\\",
+			expected: "\x1bPtmux;\x1b\x1b_Ga=d\x1b\x1b\\\x1b\\" +
+				"\x1bPtmux;\x1b\x1b_Gm=1;AAAA\x1b\x1b\\\x1b\\",
+		},
+		{
+			name:     "unterminated trailing data is still wrapped",
+			input:    "\x1b_Gm=0",
+			expected: "\x1bPtmux;\x1b\x1b_Gm=0\x1b\\",
+		},
+		{
+			name:     "empty input produces no wrapper",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tmuxPassthrough(tt.input))
+		})
+	}
+}
+
+func TestRawForTerminalOutsideTmux(t *testing.T) {
+	t.Setenv("TMUX", "")
+	raw := "\x1b_Ga=d\x1b\\"
+	assert.Equal(t, raw, rawForTerminal(raw))
+}
+
+func TestRawForTerminalInsideTmux(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-1000/default,1,0")
+	assert.Equal(t, tmuxPassthrough("\x1b_Ga=d\x1b\\"), rawForTerminal("\x1b_Ga=d\x1b\\"))
+	assert.Empty(t, rawForTerminal(""))
+}

--- a/src/pkg/file_preview/utils.go
+++ b/src/pkg/file_preview/utils.go
@@ -30,6 +30,8 @@ type TerminalCapabilities struct {
 	cellSize       TerminalCellSize
 	cellSizeInit   sync.Once
 	detectionMutex sync.Mutex
+	kittyCapable   bool
+	kittyInit      sync.Once
 }
 
 // NewTerminalCapabilities creates a new TerminalCapabilities instance


### PR DESCRIPTION
# Description

Image previews inside a tmux session fall back to the ANSI half-block renderer instead of using the Kitty graphics protocol, which is what users see as "heavily pixelated" previews. Outside tmux the same terminal renders correctly.

There are two independent causes, and fixing only the first one makes things worse rather than better.

**1. Detection never sees the real terminal.**

`isKittyCapable()` decided Kitty support from `TERM` / `TERM_PROGRAM` alone. tmux sets those to `tmux-256color` / `tmux` inside the pane, so a Kitty-capable outer terminal was never matched and the ANSI renderer was selected. The existing `TODO` in that function already called this out.

Detection now asks the tmux server which terminal the client is actually attached to, via `#{client_termname}` and `#{client_termtype}`, instead of trusting the in-pane environment. Matching also became substring-based so terminfo names (`xterm-ghostty`) and XTVERSION strings (`ghostty 1.3.1`) match the allowlist, not just exact names.

**2. Forcing detection on is not sufficient.**

Simply making `isKittyCapable()` return `true` inside tmux (e.g. by spoofing `TERM_PROGRAM`) does not work, and is strictly worse than the fallback. superfile transmits the image as bare APC sequences (`ESC _ G ... ESC \`) through `tea.Raw()`. tmux consumes APC as a title string, so the image payload never reaches the outer terminal — but the Unicode placeholder cells still get drawn, leaving an empty region where the image should be.

The raw Kitty output is now wrapped in tmux's DCS passthrough (`ESC P tmux; ... ESC \`) with inner `ESC` bytes doubled, which is the only form tmux forwards to the underlying terminal. Each escape sequence is wrapped **individually** rather than wrapping the whole transmission once, so a large chunked image never forms a single DCS string big enough to hit tmux's input buffer limit.

**Fallback behaviour.**

tmux only forwards passthrough when `allow-passthrough` is `on` or `all`. If it is not enabled, the image data would be discarded no matter what we emit, so detection deliberately reports `false` in that case. Those sessions keep the current working ANSI half-block preview rather than rendering blank placeholders — i.e. this change never makes an existing setup worse.

Detection results are cached on `TerminalCapabilities` (alongside the existing cell-size cache) since detection now shells out to `tmux`.

No configuration changes are required from the user beyond tmux's own `allow-passthrough`. Cell-size handling needed no change — tmux does forward real pixel dimensions via `TIOCGWINSZ`, so the existing aspect-ratio logic already works inside a pane.

# Related Issues

Fixes #1169

# Testing

Verified on tmux 3.7b + Ghostty 1.3.1 (Arch Linux), by capturing the rendered pane and counting Kitty placeholder cells (`U+10EEEE`) versus ANSI half-blocks (`U+2584`):

| Scenario | Placeholders | Half-blocks | Result |
|---|---|---|---|
| Inside tmux, patched | 2280 | 0 | Kitty path used |
| Inside tmux, unpatched | 0 | 2136 | ANSI fallback (the bug) |
| Inside tmux, `allow-passthrough off` | 0 | 2136 | ANSI fallback preserved |
| Outside tmux | unchanged | unchanged | no behaviour change |

Also confirmed images render visually in both a bare terminal window and inside tmux, and that normal file-manager operation is unaffected.

Checks run against this branch:

- `go fmt ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run` — 0 issues
- `go test ./...` — passes, except two failures that are pre-existing on the unpatched base commit and environmental (`exiftool` not installed, and a trash-related test); `src/pkg/file_preview` passes.

New unit tests cover the passthrough wrapping (escape doubling, per-sequence wrapping, unterminated input, empty input), the in/out-of-tmux transport selection, and the non-tmux detection paths.

# ✅ Pre-Submission Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I'm not committing any debug logs or TODOs
- [x] I have checked that the PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Kitty terminal graphics support, including compatibility with tmux sessions.
  * Added safer handling for terminal escape sequences when previewing images through tmux.
  * Terminal capability detection now recognizes a broader range of compatible terminal environments.

* **Bug Fixes**
  * Prevented Kitty graphics commands from being sent when tmux passthrough is unavailable.
  * Improved reliability of Kitty image clearing and transmission commands.

* **Tests**
  * Added coverage for Kitty detection and tmux escape-sequence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->