### PR TITLE
fix: renaming directory pin shortcut copies icon into pin name

### DIFF
--- a/src/internal/common/icon_utils.go
+++ b/src/internal/common/icon_utils.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/adrg/xdg"
+
 	"github.com/yorukot/superfile/src/config/icon"
 )
 
@@ -69,4 +71,34 @@ func GetElementIcon(file string, isDir bool, isLink bool, nerdFont bool) icon.St
 	}
 
 	return getFileIcon(file, isLink)
+}
+
+func GetDirectoryIcon(path string, name string) string {
+	switch path {
+	case xdg.Home:
+		return icon.Home
+	case xdg.UserDirs.Desktop:
+		return icon.Desktop
+	case xdg.UserDirs.Download:
+		return icon.Download
+	case xdg.UserDirs.Documents:
+		return icon.Documents
+	case xdg.UserDirs.Pictures:
+		return icon.Pictures
+	case xdg.UserDirs.Videos:
+		return icon.Videos
+	case xdg.UserDirs.Music:
+		return icon.Music
+	case xdg.UserDirs.Templates:
+		return icon.Templates
+	case xdg.UserDirs.PublicShare:
+		return icon.PublicShare
+	default:
+		result, exists := icon.Folders[name]
+		if !exists {
+			return icon.Directory
+		}
+
+		return result.Icon
+	}
 }

--- a/src/internal/common/icon_utils.go
+++ b/src/internal/common/icon_utils.go
@@ -73,7 +73,11 @@ func GetElementIcon(file string, isDir bool, isLink bool, nerdFont bool) icon.St
 	return getFileIcon(file, isLink)
 }
 
-func GetDirectoryIcon(path string, name string) string {
+func GetDirectoryIcon(path string, name string, nerdFont bool) string {
+	if !nerdFont {
+		return ""
+	}
+
 	switch path {
 	case xdg.Home:
 		return icon.Home

--- a/src/internal/ui/sidebar/directory_utils.go
+++ b/src/internal/ui/sidebar/directory_utils.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/adrg/xdg"
 
+	"github.com/yorukot/superfile/src/internal/common"
+
 	"github.com/yorukot/superfile/src/pkg/utils"
 
 	variable "github.com/yorukot/superfile/src/config"
 	"github.com/yorukot/superfile/src/config/icon"
-	"github.com/yorukot/superfile/src/internal/common"
 )
 
 // Fuzzy search function for a list of directories.
@@ -53,22 +54,23 @@ func getDirectories(pinnedMgr *PinnedManager, sections []string) []directory {
 // Return system default directory e.g. Home, Downloads, etc
 func getWellKnownDirectories() []directory {
 	wellKnownDirectories := []directory{
-		{Location: xdg.Home, Name: icon.Home + icon.Space + "Home"},
-		{Location: xdg.UserDirs.Desktop, Name: icon.Desktop + icon.Space + "Desktop"},
-		{Location: xdg.UserDirs.Download, Name: icon.Download + icon.Space + "Downloads"},
-		{Location: xdg.UserDirs.Documents, Name: icon.Documents + icon.Space + "Documents"},
-		{Location: xdg.UserDirs.Pictures, Name: icon.Pictures + icon.Space + "Pictures"},
-		{Location: xdg.UserDirs.Videos, Name: icon.Videos + icon.Space + "Videos"},
-		{Location: xdg.UserDirs.Music, Name: icon.Music + icon.Space + "Music"},
-		{Location: xdg.UserDirs.Templates, Name: icon.Templates + icon.Space + "Templates"},
-		{Location: xdg.UserDirs.PublicShare, Name: icon.PublicShare + icon.Space + "PublicShare"},
+		{Location: xdg.Home, Icon: icon.Home, Name: "Home"},
+		{Location: xdg.UserDirs.Desktop, Icon: icon.Desktop, Name: "Desktop"},
+		{Location: xdg.UserDirs.Download, Icon: icon.Download, Name: "Downloads"},
+		{Location: xdg.UserDirs.Documents, Icon: icon.Documents, Name: "Documents"},
+		{Location: xdg.UserDirs.Pictures, Icon: icon.Pictures, Name: "Pictures"},
+		{Location: xdg.UserDirs.Videos, Icon: icon.Videos, Name: "Videos"},
+		{Location: xdg.UserDirs.Music, Icon: icon.Music, Name: "Music"},
+		{Location: xdg.UserDirs.Templates, Icon: icon.Templates, Name: "Templates"},
+		{Location: xdg.UserDirs.PublicShare, Icon: icon.PublicShare, Name: "PublicShare"},
 	}
 
 	// Add Trash directory for Linux only
 	if runtime.GOOS == utils.OsLinux {
 		wellKnownDirectories = append(wellKnownDirectories, directory{
 			Location: variable.LinuxTrashDirectory,
-			Name:     icon.Trash + icon.Space + "Trash",
+			Icon:     icon.Trash,
+			Name:     "Trash",
 		})
 	}
 
@@ -81,8 +83,7 @@ func getWellKnownDirectories() []directory {
 func getPinnedDirectoriesWithIcon(pinnedMgr *PinnedManager) []directory {
 	dirs := pinnedMgr.Load()
 	for i := range dirs {
-		iconInfo := common.GetElementIcon(dirs[i].Name, true, false, common.Config.Nerdfont)
-		dirs[i].Name = iconInfo.Icon + icon.Space + dirs[i].Name
+		dirs[i].Icon = common.GetDirectoryIcon(dirs[i].Location, dirs[i].Name)
 	}
 	return dirs
 }

--- a/src/internal/ui/sidebar/directory_utils.go
+++ b/src/internal/ui/sidebar/directory_utils.go
@@ -83,7 +83,7 @@ func getWellKnownDirectories() []directory {
 func getPinnedDirectoriesWithIcon(pinnedMgr *PinnedManager) []directory {
 	dirs := pinnedMgr.Load()
 	for i := range dirs {
-		dirs[i].Icon = common.GetDirectoryIcon(dirs[i].Location, dirs[i].Name)
+		dirs[i].Icon = common.GetDirectoryIcon(dirs[i].Location, dirs[i].Name, common.Config.Nerdfont)
 	}
 	return dirs
 }

--- a/src/internal/ui/sidebar/disk_utils.go
+++ b/src/internal/ui/sidebar/disk_utils.go
@@ -27,6 +27,7 @@ func getExternalMediaFolders() []directory {
 		// We can ideally reduce it to one check only.
 		if shouldListDisk(disk.Mountpoint) {
 			disks = append(disks, directory{
+				Icon:     diskIcon(disk.Mountpoint),
 				Name:     diskName(disk.Mountpoint),
 				Location: diskLocation(disk.Mountpoint),
 			})
@@ -70,17 +71,23 @@ func shouldListDisk(mountPoint string) bool {
 		strings.HasPrefix(mountPoint, "/Volumes")
 }
 
+func diskIcon(mountPoint string) string {
+	if runtime.GOOS != utils.OsWindows && mountPoint == "/" {
+		return icon.Terminal
+	}
+
+	return icon.Disk
+}
+
 // diskName generates a display name for a disk based on its mount point and the operating system.
 func diskName(mountPoint string) string {
 	// In windows we dont want to use filepath.Base as it returns "\" for when
 	// mountPoint is any drive root "C:", "D:", etc. Hence causing same name
 	// for each drive
 	name := mountPoint
-	iconStr := icon.Disk
 	if runtime.GOOS != utils.OsWindows {
 		if mountPoint == "/" {
 			name = "Root"
-			iconStr = icon.Terminal
 		} else {
 			// This might cause duplicate names in case you mount two devices in
 			// /mnt/usb and /mnt/dir2/usb . Full mountpoint is a more accurate way
@@ -89,7 +96,7 @@ func diskName(mountPoint string) string {
 		}
 	}
 
-	return iconStr + icon.Space + name
+	return name
 }
 
 // diskLocation returns the normalized path for a disk's mount point.

--- a/src/internal/ui/sidebar/render.go
+++ b/src/internal/ui/sidebar/render.go
@@ -72,7 +72,9 @@ func (s *Model) directoriesRender(curFilePanelFileLocation string,
 				if s.directories[i].Location == curFilePanelFileLocation {
 					renderStyle = common.SidebarSelectedStyle
 				}
-				line := common.FilePanelCursorStyle.Render(cursor+" ") + renderStyle.Render(s.directories[i].Name)
+				line := common.FilePanelCursorStyle.Render(cursor+icon.Space) +
+					renderStyle.Render(s.directories[i].Icon+icon.Space) +
+					renderStyle.Render(s.directories[i].Name)
 				r.AddLineWithCustomTruncate(line, rendering.TailsTruncateRight)
 			}
 		}

--- a/src/internal/ui/sidebar/render.go
+++ b/src/internal/ui/sidebar/render.go
@@ -72,8 +72,8 @@ func (s *Model) directoriesRender(curFilePanelFileLocation string,
 				if s.directories[i].Location == curFilePanelFileLocation {
 					renderStyle = common.SidebarSelectedStyle
 				}
-				line := common.FilePanelCursorStyle.Render(cursor+icon.Space) +
-					renderStyle.Render(s.directories[i].Icon+icon.Space) +
+				line := common.FilePanelCursorStyle.Render(cursor+" ") +
+					renderStyle.Render(s.directories[i].Icon+" ") +
 					renderStyle.Render(s.directories[i].Name)
 				r.AddLineWithCustomTruncate(line, rendering.TailsTruncateRight)
 			}

--- a/src/internal/ui/sidebar/sidebar_test.go
+++ b/src/internal/ui/sidebar/sidebar_test.go
@@ -1,0 +1,86 @@
+package sidebar
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorukot/superfile/src/config/icon"
+	"github.com/yorukot/superfile/src/pkg/utils"
+)
+
+func TestPinnedItemRenameUsesStoredNameWithoutVisualIcon(t *testing.T) {
+	pinnedMgr, sidebar := sidebarWithPinnedDir(t)
+	require.NoError(t, pinnedMgr.Save([]directory{{
+		Location: sidebar.directories[0].Location,
+		Name:     "project",
+	}}))
+
+	sidebar.directories = formDirctorySlice(
+		nil,
+		getPinnedDirectoriesWithIcon(&pinnedMgr),
+		nil,
+		[]string{utils.SidebarSectionPinned},
+	)
+	require.Len(t, sidebar.directories, 1)
+	visualIcon := sidebar.directories[0].Icon
+	require.NotEmpty(t, visualIcon)
+
+	sidebar.PinnedItemRename()
+
+	assert.True(t, sidebar.renaming)
+	assert.Equal(t, "project", sidebar.rename.Value())
+	assert.NotContains(t, sidebar.rename.Value(), visualIcon)
+	assert.NotContains(t, sidebar.rename.Value(), icon.Space+"project")
+}
+
+func TestConfirmSidebarRenameDoesNotPersistVisualIcon(t *testing.T) {
+	pinnedMgr, sidebar := sidebarWithPinnedDir(t)
+	require.NoError(t, pinnedMgr.Save([]directory{{
+		Location: sidebar.directories[0].Location,
+		Name:     "project",
+	}}))
+
+	sidebar.directories = formDirctorySlice(
+		nil,
+		getPinnedDirectoriesWithIcon(&pinnedMgr),
+		nil,
+		[]string{utils.SidebarSectionPinned},
+	)
+	require.Len(t, sidebar.directories, 1)
+	visualIcon := sidebar.directories[0].Icon
+	require.NotEmpty(t, visualIcon)
+
+	sidebar.PinnedItemRename()
+	sidebar.ConfirmSidebarRename()
+
+	pinnedDirs := pinnedMgr.Load()
+	require.Len(t, pinnedDirs, 1)
+	assert.Equal(t, "project", pinnedDirs[0].Name)
+	assert.NotContains(t, pinnedDirs[0].Name, visualIcon)
+	assert.NotContains(t, pinnedDirs[0].Name, icon.Space+"project")
+}
+
+func sidebarWithPinnedDir(t *testing.T) (PinnedManager, Model) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	pinnedDir := filepath.Join(tempDir, "project")
+	utils.SetupDirectories(t, pinnedDir)
+
+	pinnedMgr := PinnedManager{filePath: filepath.Join(tempDir, "pinned.json")}
+	utils.SetupFilesWithData(t, []byte("[]"), pinnedMgr.filePath)
+
+	return pinnedMgr, Model{
+		directories: []directory{{
+			Location: pinnedDir,
+			Name:     "project",
+			Section:  utils.SidebarSectionPinned,
+		}},
+		cursor:    0,
+		pinnedMgr: &pinnedMgr,
+		sections:  []string{utils.SidebarSectionPinned},
+	}
+}

--- a/src/internal/ui/sidebar/sidebar_test.go
+++ b/src/internal/ui/sidebar/sidebar_test.go
@@ -54,23 +54,26 @@ func TestConfirmSidebarRenameDoesNotPersistVisualIcon(t *testing.T) {
 	visualIcon := sidebar.directories[0].Icon
 	require.NotEmpty(t, visualIcon)
 
+	const replacementName = "renamed-project"
+
 	sidebar.PinnedItemRename()
+	sidebar.rename.SetValue(replacementName)
 	sidebar.ConfirmSidebarRename()
 
 	pinnedDirs := pinnedMgr.Load()
 	require.Len(t, pinnedDirs, 1)
-	assert.Equal(t, "project", pinnedDirs[0].Name)
+	assert.Equal(t, replacementName, pinnedDirs[0].Name)
 	assert.NotContains(t, pinnedDirs[0].Name, visualIcon)
-	assert.NotContains(t, pinnedDirs[0].Name, icon.Space+"project")
+	assert.NotContains(t, pinnedDirs[0].Name, icon.Space+replacementName)
 }
 
 func sidebarWithPinnedDir(t *testing.T) (PinnedManager, Model) {
 	t.Helper()
 
-	originalConfig := common.Config
+	originalNerdfont := common.Config.Nerdfont
 	common.Config.Nerdfont = true
 	t.Cleanup(func() {
-		common.Config = originalConfig
+		common.Config.Nerdfont = originalNerdfont
 	})
 
 	tempDir := t.TempDir()

--- a/src/internal/ui/sidebar/sidebar_test.go
+++ b/src/internal/ui/sidebar/sidebar_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yorukot/superfile/src/config/icon"
+	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
@@ -65,6 +66,12 @@ func TestConfirmSidebarRenameDoesNotPersistVisualIcon(t *testing.T) {
 
 func sidebarWithPinnedDir(t *testing.T) (PinnedManager, Model) {
 	t.Helper()
+
+	originalConfig := common.Config
+	common.Config.Nerdfont = true
+	t.Cleanup(func() {
+		common.Config = originalConfig
+	})
 
 	tempDir := t.TempDir()
 	pinnedDir := filepath.Join(tempDir, "project")

--- a/src/internal/ui/sidebar/type.go
+++ b/src/internal/ui/sidebar/type.go
@@ -6,6 +6,7 @@ type directory struct {
 	Location string `json:"location"`
 	Name     string `json:"name"`
 	Section  string `json:"-"`
+	Icon     string `json:"-"`
 }
 
 type Model struct {


### PR DESCRIPTION
# Description
**Problem:**
Sidebar pinned-directory rename bug where the visual folder icon could become part of the persisted pin name.

Before this change, pinned directory display data stored the icon and the name together in `directory.Name`. When a pinned item was renamed, the rename input was initialized from that combined display string. Confirming the rename could then save the visual icon/prefix into the pinned directory name, causing the icon to appear duplicated the next time the pin was rendered.

**Solution:**
This change separates the visual icon from the editable/persisted name:
- `directory.Name` now stores only the pin name.
- `directory.Icon` stores the visual-only sidebar icon and is excluded from JSON with `json:"-"`.
- Sidebar rendering now combines cursor, icon, and name at render time instead of storing them together.
- Pinned rename input is initialized from the stored name only.
- Regression tests cover both the rename input and persisted pinned JSON behavior.

# Related Issues

Fixes: https://github.com/yorukot/superfile/issues/1537

# Screenshots (Optional)
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="400" height="225" alt="superfile-pin-before" src="https://github.com/user-attachments/assets/4980ab45-b4fe-499f-a820-17a48940752d" /></td>
    <td><img width="400" height="225" alt="superfile-pin-after" src="https://github.com/user-attachments/assets/f7697606-0ef6-4794-bc72-48121c170939" /></td>
  </tr>
</table>

---

# ✅ Pre-Submission Checklist

Please go through the following steps **before** submitting this PR.  
You can delete this section after confirming everything is done.

- [-] I have run `go fmt ./...` to format the code
- [-] I have run `golangci-lint run` and fixed any reported issues
- [-] I have tested my changes and verified they work as expected
- [-] I have reviewed the diff to make sure I’m not committing any debug logs or TODOs
- [-] I have checked that the PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated icon support for well-known directories, pinned folders, and external storage when Nerd Font is enabled.
  * Improved the sidebar layout by rendering directory icons and names separately for clearer, consistent visuals.
* **Bug Fixes**
  * Renaming pinned directories now preserves and saves only the plain folder name, without persisting any visual icon or icon-prefixed text.
* **Tests**
  * Added unit tests to verify pinned-folder rename behavior and correct name persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->