### PR TITLE
fix(metadata): gate binary architecture detection behind magic-byte c…

### DIFF
--- a/src/internal/ui/metadata/architecture.go
+++ b/src/internal/ui/metadata/architecture.go
@@ -85,12 +85,22 @@ func isCOFFMachine(m uint16) bool {
 	}
 }
 
+// Byte-swapped forms of the Mach-O magics, produced when the file was written
+// for the opposite byte order to the reader. Apple's headers call these the
+// CIGAM values ("magic" reversed); the standard library only names the native
+// forms, so they are spelled out here rather than left as bare literals.
+const (
+	machoCigam32  uint32 = 0xcefaedfe // macho.Magic32, bytes reversed
+	machoCigam64  uint32 = 0xcffaedfe // macho.Magic64, bytes reversed
+	machoCigamFat uint32 = 0xbebafeca // macho.MagicFat, bytes reversed
+)
+
 // isMachOMagic reports whether m is a Mach-O (thin or universal) magic number,
 // in either byte order.
 func isMachOMagic(m uint32) bool {
 	switch m {
 	case macho.Magic32, macho.Magic64, macho.MagicFat,
-		0xcefaedfe, 0xcffaedfe, 0xbebafeca: // byte-swapped variants
+		machoCigam32, machoCigam64, machoCigamFat:
 		return true
 	default:
 		return false

--- a/src/internal/ui/metadata/architecture.go
+++ b/src/internal/ui/metadata/architecture.go
@@ -4,8 +4,11 @@ import (
 	"debug/elf"
 	"debug/macho"
 	"debug/pe"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 )
 
@@ -24,17 +27,91 @@ const (
 
 var errNotBinary = errors.New("not a recognized binary format")
 
+// binaryFormat is a cheap classification based on a file's leading magic bytes.
+type binaryFormat int
+
+const (
+	formatUnknown binaryFormat = iota
+	formatELF
+	formatPE
+	formatMachO
+)
+
+// detectBinaryFormat reads at most the first 4 bytes of the file and decides
+// which (if any) binary parser is worth invoking.
+//
+// This gate matters: debug/pe accepts files WITHOUT an "MZ" header as raw COFF
+// objects, so calling pe.Open on an arbitrary file (e.g. a large video)
+// misinterprets its leading bytes as section/symbol counts and can read and
+// allocate memory proportional to the file's size before failing (issue #1550).
+// The debug/* parsers are documented as unsuitable for adversarial/arbitrary
+// inputs, so only hand them files whose magic bytes plausibly match.
+func detectBinaryFormat(filePath string) binaryFormat {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return formatUnknown
+	}
+	defer f.Close()
+
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return formatUnknown
+	}
+
+	switch {
+	case magic == [4]byte{0x7f, 'E', 'L', 'F'}:
+		return formatELF
+	case magic[0] == 'M' && magic[1] == 'Z':
+		return formatPE
+	case isCOFFMachine(binary.LittleEndian.Uint16(magic[:2])):
+		// Raw COFF objects (no MZ stub) begin directly with a known machine type.
+		return formatPE
+	case isMachOMagic(binary.BigEndian.Uint32(magic[:])):
+		return formatMachO
+	default:
+		return formatUnknown
+	}
+}
+
+// isCOFFMachine reports whether m is a COFF machine type superfile can display.
+func isCOFFMachine(m uint16) bool {
+	switch m {
+	case pe.IMAGE_FILE_MACHINE_I386, pe.IMAGE_FILE_MACHINE_AMD64,
+		pe.IMAGE_FILE_MACHINE_ARM, pe.IMAGE_FILE_MACHINE_ARMNT, pe.IMAGE_FILE_MACHINE_ARM64,
+		pe.IMAGE_FILE_MACHINE_RISCV32, pe.IMAGE_FILE_MACHINE_RISCV64, pe.IMAGE_FILE_MACHINE_RISCV128:
+		return true
+	default:
+		return false
+	}
+}
+
+// isMachOMagic reports whether m is a Mach-O (thin or universal) magic number,
+// in either byte order.
+func isMachOMagic(m uint32) bool {
+	switch m {
+	case macho.Magic32, macho.Magic64, macho.MagicFat,
+		0xcefaedfe, 0xcffaedfe, 0xbebafeca: // byte-swapped variants
+		return true
+	default:
+		return false
+	}
+}
+
 func GetBinaryArchitecture(filePath string) (string, error) {
-	if arch, err := getELFArchitecture(filePath); err == nil {
-		return arch, nil
-	}
-
-	if arch, err := getPEArchitecture(filePath); err == nil {
-		return arch, nil
-	}
-
-	if arch, err := getMachOArchitecture(filePath); err == nil {
-		return arch, nil
+	switch detectBinaryFormat(filePath) {
+	case formatELF:
+		if arch, err := getELFArchitecture(filePath); err == nil {
+			return arch, nil
+		}
+	case formatPE:
+		if arch, err := getPEArchitecture(filePath); err == nil {
+			return arch, nil
+		}
+	case formatMachO:
+		if arch, err := getMachOArchitecture(filePath); err == nil {
+			return arch, nil
+		}
+	case formatUnknown:
 	}
 
 	return "", errNotBinary

--- a/src/internal/ui/metadata/architecture_test.go
+++ b/src/internal/ui/metadata/architecture_test.go
@@ -1,8 +1,10 @@
 package metadata
 
 import (
+	"bytes"
 	"debug/elf"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -67,4 +69,57 @@ func TestPeArchitectureToString(t *testing.T) {
 	assert.Equal(t, archARM, peArchitectureToString(0x1c0))
 	assert.Equal(t, archARM64, peArchitectureToString(0xaa64))
 	assert.Contains(t, peArchitectureToString(0x9999), "Unknown")
+}
+
+// Regression test for #1550: files that are not ELF/PE/Mach-O must be rejected
+// by the cheap magic-byte gate without invoking the debug/* parsers.
+// Previously, pe.Open accepted MZ-less files as raw COFF objects and could
+// read and allocate memory proportional to the file size (multi-GB videos)
+// before failing.
+func TestGetBinaryArchitecture_MediaLikeFileIsGated(t *testing.T) {
+	dir := t.TempDir()
+
+	// An MP4-like header: size-prefixed "ftyp" box, followed by bytes that
+	// would decode as huge COFF section/symbol counts if misparsed.
+	path := filepath.Join(dir, "movie.mp4")
+	content := append([]byte{0x00, 0x00, 0x00, 0x20, 'f', 't', 'y', 'p', 'i', 's', 'o', 'm'},
+		bytes.Repeat([]byte{0xff}, 4096)...)
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+
+	_, err := GetBinaryArchitecture(path)
+	require.ErrorIs(t, err, errNotBinary)
+
+	// The format detector itself must classify it as unknown.
+	require.Equal(t, formatUnknown, detectBinaryFormat(path))
+}
+
+func TestDetectBinaryFormat(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, data []byte) string {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, data, 0o644))
+		return p
+	}
+
+	testCases := []struct {
+		name     string
+		data     []byte
+		expected binaryFormat
+	}{
+		{"elf", []byte{0x7f, 'E', 'L', 'F', 2, 1, 1, 0}, formatELF},
+		{"pe_mz", []byte{'M', 'Z', 0x90, 0x00}, formatPE},
+		{"coff_amd64", []byte{0x64, 0x86, 0x01, 0x00}, formatPE},
+		{"macho_64", []byte{0xfe, 0xed, 0xfa, 0xcf}, formatMachO},
+		{"macho_fat", []byte{0xca, 0xfe, 0xba, 0xbe}, formatMachO},
+		{"macho_64_swapped", []byte{0xcf, 0xfa, 0xed, 0xfe}, formatMachO},
+		{"mp4", []byte{0x00, 0x00, 0x00, 0x20, 'f', 't', 'y', 'p'}, formatUnknown},
+		{"text", []byte("hello world"), formatUnknown},
+		{"tiny", []byte{0x7f}, formatUnknown},
+		{"empty", nil, formatUnknown},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, detectBinaryFormat(write(tt.name, tt.data)))
+		})
+	}
 }


### PR DESCRIPTION
Fixes #1550

## What was happening

`GetBinaryArchitecture` runs on every regular file and tried `elf.Open` -> `pe.Open` -> `macho.Open` in sequence. The problem: Go's `debug/pe` accepts files **without** an `MZ` header as raw COFF objects. A video file's leading bytes get misinterpreted as COFF section/symbol counts, and `pe.Open` then reads and allocates memory proportional to whatever garbage offsets those bytes decode to — before eventually failing. (The stdlib documents the `debug/*` parsers as unsuitable for arbitrary/untrusted inputs.)

Since a metadata fetch goroutine is fired per cursor move, sweeping across a folder of large videos multiplies that allocation by the number of in-flight fetches — which is how RSS reaches tens of GB while pprof shows a smaller live heap, and why btm showed 13.7GB read from disk. exiftool is not involved: bisecting with `Config.Metadata = false` reproduced the full blowup, and `go-exiftool` serializes calls behind a mutex.

Measured with 200 concurrent `GetMetadata` calls over 2GB video files:

| | runtime `Sys` growth | wall time |
|---|---|---|
| before | **+1,357 MB** | ~18s |
| after | **+0.6 MB** | ~0.01s |

Single-call probe on a 2GB mp4: `pe.Open` returns `offset 0 is before the start of string table` (a COFF symbol-table misparse, not a magic rejection) after allocating ~4.5MB — the old code even reports a 1MB file of zeros as `PE Unknown (0x0)`.

## The fix

Read the first 4 bytes and only invoke a parser when they plausibly match: ELF magic, `MZ`, a known raw-COFF machine type (i386/amd64/arm/armnt/arm64/riscv), or a Mach-O magic (both byte orders, thin + fat). Anything else returns `errNotBinary` without touching the `debug/*` parsers. Real binary detection is unchanged — verified identical results across ELF/.so, cross-compiled PE (386/amd64/arm64), Mach-O (thin, byte-swapped, fat universal), and a clang-produced raw COFF `.obj`.

Known residual, unchanged from before: a file whose first two bytes happen to collide with an accepted COFF machine magic (~5 in 65536 for random data, no common media format does) still reaches `pe.Open` with the old cost. Eliminating that would mean dropping MZ-less raw COFF support entirely — happy to do that instead if you'd prefer.

## Tests

Added a regression test that an MP4-like header is gated (`errNotBinary`) plus a table test over the format detector (ELF/MZ/COFF/Mach-O variants, mp4, text, tiny, empty). Full metadata package suite passes; the wider suite's pre-existing zoxide-dependent failures are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary architecture detection by validating file formats before parsing.
  * Prevented media files, text files, empty files, and other unrecognized inputs from being misidentified as binaries.
  * Added support for reliably distinguishing ELF, PE, and Mach-O formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->