### PR TITLE
fix(image-preview): support kitty graphics inside tmux

### DIFF
--- a/src/pkg/file_preview/kitty.go
+++ b/src/pkg/file_preview/kitty.go
@@ -17,8 +17,14 @@ func isKittyCapable() bool {
 	termProgram := os.Getenv("TERM_PROGRAM")
 	term := os.Getenv("TERM")
 
+	// Inside tmux, TERM/TERM_PROGRAM describe tmux itself, so the host terminal
+	// is unknowable from the environment. Require an explicit opt-in instead,
+	// and rely on tmux passthrough (see tmuxPassthrough) to reach the host.
+	if os.Getenv("TMUX") != "" {
+		return os.Getenv("SUPERFILE_KITTY") == "1"
+	}
+
 	// TODO: Replace this allowlist with a real Kitty graphics capability check.
-	// tmux masks the underlying terminal through TERM/TERM_PROGRAM.
 	knownTerminals := []string{
 		"ghostty",
 		"WezTerm",
@@ -38,13 +44,43 @@ func isKittyCapable() bool {
 	return false
 }
 
+// tmuxPassthrough wraps each escape sequence in s in tmux's DCS passthrough,
+// so tmux forwards it to the host terminal instead of discarding it as an
+// unrecognised sequence. Requires "set -g allow-passthrough on" in tmux.
+//
+// Each APC is wrapped individually rather than wrapping the whole buffer in one
+// DCS: image data is chunked into many sequences and a single multi-megabyte DCS
+// risks hitting tmux's buffer limits.
+func tmuxPassthrough(s string) string {
+	if os.Getenv("TMUX") == "" || s == "" {
+		return s
+	}
+
+	var b strings.Builder
+	for len(s) > 0 {
+		seq := s
+		// Sequences are terminated by ST (ESC \); keep the terminator with its
+		// sequence. A trailing fragment without ST is passed through as-is.
+		if i := strings.Index(s, "\x1b\\"); i >= 0 {
+			seq, s = s[:i+2], s[i+2:]
+		} else {
+			s = ""
+		}
+		b.WriteString("\x1bPtmux;")
+		// tmux strips one level of escaping, so every ESC must be doubled.
+		b.WriteString(strings.ReplaceAll(seq, "\x1b", "\x1b\x1b"))
+		b.WriteString("\x1b\\")
+	}
+	return b.String()
+}
+
 // GetKittyClearRaw returns the raw APC command to clear all Kitty images.
 // This must be sent via tea.Raw(), not embedded in view content.
 func (p *ImagePreviewer) GetKittyClearRaw() string {
 	if !p.IsKittyCapable() {
 		return ""
 	}
-	return ansi.KittyGraphics(nil, "a=d")
+	return tmuxPassthrough(ansi.KittyGraphics(nil, "a=d"))
 }
 
 // generatePlacementID generates a unique placement ID based on file path
@@ -134,7 +170,7 @@ func (p *ImagePreviewer) renderWithKittyUsingTermCap(img image.Image, path strin
 
 	return &KittyImageResult{
 		Placeholders: placeholders,
-		RawTransmit:  transmitBuf.String(),
+		RawTransmit:  tmuxPassthrough(transmitBuf.String()),
 	}, nil
 }
 

--- a/src/pkg/file_preview/kitty_tmux_test.go
+++ b/src/pkg/file_preview/kitty_tmux_test.go
@@ -1,0 +1,37 @@
+package filepreview
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTmuxPassthrough(t *testing.T) {
+	t.Setenv("TMUX", "")
+	if got := tmuxPassthrough("\x1b_Ga=d\x1b\\"); got != "\x1b_Ga=d\x1b\\" {
+		t.Fatalf("outside tmux input must be unchanged, got %q", got)
+	}
+
+	t.Setenv("TMUX", "/tmp/tmux-501/default,123,0")
+
+	if got := tmuxPassthrough(""); got != "" {
+		t.Fatalf("empty input must stay empty, got %q", got)
+	}
+
+	// Single sequence: wrapped in DCS, inner ESCs doubled.
+	got := tmuxPassthrough("\x1b_Ga=d\x1b\\")
+	want := "\x1bPtmux;\x1b\x1b_Ga=d\x1b\x1b\\\x1b\\"
+	if got != want {
+		t.Fatalf("single sequence\n got %q\nwant %q", got, want)
+	}
+
+	// Chunked data must produce one DCS per sequence, not one giant DCS.
+	two := tmuxPassthrough("\x1b_Gm=1;AAA\x1b\\\x1b_Gm=0;BBB\x1b\\")
+	if n := strings.Count(two, "\x1bPtmux;"); n != 2 {
+		t.Fatalf("expected 2 passthrough wrappers, got %d in %q", n, two)
+	}
+
+	// A trailing fragment with no ST must not be dropped.
+	if frag := tmuxPassthrough("\x1b_Gnoterm"); !strings.Contains(frag, "_Gnoterm") {
+		t.Fatalf("unterminated fragment was dropped: %q", frag)
+	}
+}


### PR DESCRIPTION
Fixes #1169.

## Problem

Inside a tmux session, image previews fall back to pixelated ANSI blocks even when the host terminal speaks the kitty graphics protocol.

`isKittyCapable()` matches `$TERM` / `$TERM_PROGRAM` against an allowlist, but tmux overwrites both with its own values (`tmux` / `tmux-256color`), so the check always fails. This is the case the existing `TODO` in that function describes.

## Fix

The rendering path already did the hard part — `renderWithKittyUsingTermCap` uses `VirtualPlacement: true` with Unicode placeholder cells, which is exactly the design kitty documents for [multiplexers](https://sw.kovidgoyal.net/kitty/graphics-protocol/#unicode-placeholders). Only two things were missing:

1. **Detection.** Inside tmux the host terminal genuinely cannot be identified from the environment, so this gates on an explicit `SUPERFILE_KITTY=1` opt-in instead of guessing from the masked variables. A real capability probe (querying the terminal and reading the reply) would be better and would also let the allowlist go away — happy to follow up with that if you'd prefer it over an env var.

2. **Transmission.** tmux discards escape sequences it doesn't recognise, so the graphics APCs never reach the host terminal. `tmuxPassthrough()` wraps them in tmux's DCS passthrough (`\ePtmux;...\e\\`) with inner ESCs doubled.

Each APC is wrapped individually rather than wrapping the whole buffer in a single DCS, because image data is chunked into many sequences and one multi-megabyte DCS risks hitting tmux's buffer limits.

## Usage

```sh
# ~/.tmux.conf
set -g allow-passthrough on
```

```sh
SUPERFILE_KITTY=1 spf
```

## Testing

- New unit test covers the wrapping: per-sequence wrapping (not one giant DCS), ESC doubling, pass-through untouched outside tmux, and that an unterminated trailing fragment isn't dropped.
- `gofmt`, `go vet`, and `go test ./src/pkg/file_preview/` are clean.
- Manually verified on macOS with kitty 0.43.1 + tmux 3.5a: previews render at full resolution inside tmux, and behaviour outside tmux is unchanged.

Behaviour is unchanged for anyone not in tmux, and unchanged inside tmux unless `SUPERFILE_KITTY=1` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kitty image preview support when running inside tmux.
  * Kitty escape sequences are now safely forwarded through tmux.
  * Added an explicit opt-in for Kitty rendering under tmux to prevent unsupported terminal output.

* **Tests**
  * Added coverage for tmux passthrough handling, including chunked data and trailing sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->