### PR TITLE
feat(image-preview): detect kitty graphics support by querying the terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.26.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/barasher/go-exiftool v1.10.0
+	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/fatih/color v1.19.0
 	github.com/fvbommel/sortorder v1.1.0
@@ -32,7 +33,6 @@ require (
 	github.com/cavaliergopher/cpio v1.0.1 // indirect
 	github.com/cavaliergopher/rpm v1.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -18,6 +18,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/barasher/go-exiftool"
+	uv "github.com/charmbracelet/ultraviolet"
+
+	filepreview "github.com/yorukot/superfile/src/pkg/file_preview"
 
 	"github.com/yorukot/superfile/src/internal/ui/filepanel"
 	"github.com/yorukot/superfile/src/internal/ui/metadata"
@@ -54,6 +57,9 @@ func (m *model) Init() tea.Cmd {
 	return tea.Batch(
 		textinput.Blink, // Assuming textinput.Blink is a valid command
 		processCmdToTeaCmd(m.processBarModel.GetListenCmd()),
+		// Ask the terminal whether it speaks the Kitty graphics protocol. The
+		// reply is handled in Update() as a KittyGraphicsEvent.
+		tea.Raw(filepreview.KittyGraphicsQuery()),
 	)
 }
 
@@ -64,6 +70,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	var sidebarCmd, inputCmd, updateCmd, panelCmd,
 		metadataCmd, filePreviewCmd, helpMenuCmd, resizeCmd tea.Cmd
+
+	// Set when the terminal's graphics capability becomes known, so that any
+	// preview already rendered with the wrong renderer is redrawn.
+	forceFilePreviewRender := false
 
 	// These are above the key message handing to prevent issues with firstKeyInput
 	// if someone presses `/` to focus to searchBar, searchBar will otherwise
@@ -95,6 +105,20 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		slog.Debug("Got ModelUpdate message", "id", msg.GetReqID())
 		updateCmd = msg.ApplyToModel(m)
 
+	// Replies to the graphics query sent in Init(). A graphics reply means the
+	// protocol is supported; DA1 is the fence — every terminal answers it, so
+	// DA1 arriving first means no graphics support.
+	case uv.KittyGraphicsEvent:
+		if filepreview.MarkKittySupported() {
+			slog.Debug("Terminal reported Kitty graphics support")
+			forceFilePreviewRender = true
+		}
+	case uv.PrimaryDeviceAttributesEvent:
+		if filepreview.MarkKittyUnsupportedIfUnknown() {
+			slog.Debug("No Kitty graphics reply before DA1, using ANSI fallback")
+			forceFilePreviewRender = true
+		}
+
 	default:
 		slog.Debug("Message of type that is not explicitly handled")
 	}
@@ -103,7 +127,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	panelCmd = m.updateComponentState(msg)
 
 	m.updateModelStateAfterMsg()
-	filePreviewCmd = m.fileModel.GetFilePreviewCmd(false)
+	filePreviewCmd = m.fileModel.GetFilePreviewCmd(forceFilePreviewRender)
 
 	metadataCmd = m.getMetadataCmd()
 

--- a/src/pkg/file_preview/kitty.go
+++ b/src/pkg/file_preview/kitty.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/ansi/kitty"
@@ -17,14 +18,9 @@ func isKittyCapable() bool {
 	termProgram := os.Getenv("TERM_PROGRAM")
 	term := os.Getenv("TERM")
 
-	// Inside tmux, TERM/TERM_PROGRAM describe tmux itself, so the host terminal
-	// is unknowable from the environment. Require an explicit opt-in instead,
-	// and rely on tmux passthrough (see tmuxPassthrough) to reach the host.
-	if os.Getenv("TMUX") != "" {
-		return os.Getenv("SUPERFILE_KITTY") == "1"
-	}
-
-	// TODO: Replace this allowlist with a real Kitty graphics capability check.
+	// This allowlist is only a provisional guess, used until the terminal
+	// answers KittyGraphicsQuery(). It cannot see through tmux, which masks
+	// both variables with its own values.
 	knownTerminals := []string{
 		"ghostty",
 		"WezTerm",
@@ -42,6 +38,50 @@ func isKittyCapable() bool {
 	}
 
 	return false
+}
+
+// Kitty graphics support, as reported by the terminal itself.
+const (
+	kittyCapUnknown int32 = iota
+	kittyCapSupported
+	kittyCapUnsupported
+)
+
+// kittyCapability holds the terminal's answer to KittyGraphicsQuery(). It stays
+// at kittyCapUnknown until a reply arrives, during which isKittyCapable()'s
+// allowlist serves as a provisional guess.
+var kittyCapability atomic.Int32
+
+// KittyGraphicsQuery returns the escape sequences that ask the terminal whether
+// it supports the kitty graphics protocol. Send it once at startup via
+// tea.Raw(); the replies arrive as messages (see MarkKittySupported and
+// MarkKittyUnsupportedIfUnknown).
+//
+// It transmits a 1x1 RGB image with a=q, which asks the terminal to report
+// support without displaying anything, followed by a primary device attributes
+// request. Every terminal answers DA1, so a DA1 reply arriving without a
+// graphics reply means the protocol is unsupported.
+//
+// Both are wrapped in a single tmux passthrough so that the host terminal, not
+// tmux, answers both — otherwise tmux would answer DA1 itself and the fence
+// could beat the host's graphics reply back.
+func KittyGraphicsQuery() string {
+	query := ansi.KittyGraphics([]byte("AAAA"), "i=31", "s=1", "v=1", "a=q", "t=d", "f=24")
+	return tmuxPassthrough(query + ansi.RequestPrimaryDeviceAttributes)
+}
+
+// MarkKittySupported records a graphics reply from the terminal. It reports
+// whether this changed the known capability, i.e. whether previews rendered
+// before now need redrawing.
+func MarkKittySupported() bool {
+	return kittyCapability.Swap(kittyCapSupported) != kittyCapSupported
+}
+
+// MarkKittyUnsupportedIfUnknown records the DA1 fence arriving with no graphics
+// reply before it. A positive reply always wins, so this only downgrades a
+// still-unknown capability. It reports whether it changed anything.
+func MarkKittyUnsupportedIfUnknown() bool {
+	return kittyCapability.CompareAndSwap(kittyCapUnknown, kittyCapUnsupported)
 }
 
 // tmuxPassthrough wraps each escape sequence in s in tmux's DCS passthrough,
@@ -209,7 +249,16 @@ func buildKittyPlaceholders(imgID int, cols, rows int) string {
 	return buf.String()
 }
 
-// IsKittyCapable checks if the terminal supports Kitty graphics protocol
+// IsKittyCapable reports whether the terminal supports the Kitty graphics
+// protocol, preferring the terminal's own answer to KittyGraphicsQuery() and
+// falling back to the $TERM/$TERM_PROGRAM allowlist until that answer arrives.
 func (p *ImagePreviewer) IsKittyCapable() bool {
-	return isKittyCapable()
+	switch kittyCapability.Load() {
+	case kittyCapSupported:
+		return true
+	case kittyCapUnsupported:
+		return false
+	default:
+		return isKittyCapable()
+	}
 }

--- a/src/pkg/file_preview/kitty.go
+++ b/src/pkg/file_preview/kitty.go
@@ -17,8 +17,14 @@ func isKittyCapable() bool {
 	termProgram := os.Getenv("TERM_PROGRAM")
 	term := os.Getenv("TERM")
 
+	// Inside tmux, TERM/TERM_PROGRAM describe tmux itself, so the host terminal
+	// is unknowable from the environment. Require an explicit opt-in instead,
+	// and rely on tmux passthrough (see tmuxPassthrough) to reach the host.
+	if os.Getenv("TMUX") != "" {
+		return os.Getenv("SUPERFILE_KITTY") == "1"
+	}
+
 	// TODO: Replace this allowlist with a real Kitty graphics capability check.
-	// tmux masks the underlying terminal through TERM/TERM_PROGRAM.
 	knownTerminals := []string{
 		"ghostty",
 		"WezTerm",
@@ -38,13 +44,43 @@ func isKittyCapable() bool {
 	return false
 }
 
+// tmuxPassthrough wraps each escape sequence in s in tmux's DCS passthrough,
+// so tmux forwards it to the host terminal instead of discarding it as an
+// unrecognised sequence. Requires "set -g allow-passthrough on" in tmux.
+//
+// Each APC is wrapped individually rather than wrapping the whole buffer in one
+// DCS: image data is chunked into many sequences and a single multi-megabyte DCS
+// risks hitting tmux's buffer limits.
+func tmuxPassthrough(s string) string {
+	if os.Getenv("TMUX") == "" || s == "" {
+		return s
+	}
+
+	var b strings.Builder
+	for len(s) > 0 {
+		seq := s
+		// Sequences are terminated by ST (ESC \); keep the terminator with its
+		// sequence. A trailing fragment without ST is passed through as-is.
+		if i := strings.Index(s, "\x1b\\"); i >= 0 {
+			seq, s = s[:i+2], s[i+2:]
+		} else {
+			s = ""
+		}
+		b.WriteString("\x1bPtmux;")
+		// tmux strips one level of escaping, so every ESC must be doubled.
+		b.WriteString(strings.ReplaceAll(seq, "\x1b", "\x1b\x1b"))
+		b.WriteString("\x1b\\")
+	}
+	return b.String()
+}
+
 // GetKittyClearRaw returns the raw APC command to clear all Kitty images.
 // This must be sent via tea.Raw(), not embedded in view content.
 func (p *ImagePreviewer) GetKittyClearRaw() string {
 	if !p.IsKittyCapable() {
 		return ""
 	}
-	return ansi.KittyGraphics(nil, "a=d")
+	return tmuxPassthrough(ansi.KittyGraphics(nil, "a=d"))
 }
 
 // generatePlacementID generates a unique placement ID based on file path
@@ -134,7 +170,7 @@ func (p *ImagePreviewer) renderWithKittyUsingTermCap(img image.Image, path strin
 
 	return &KittyImageResult{
 		Placeholders: placeholders,
-		RawTransmit:  transmitBuf.String(),
+		RawTransmit:  tmuxPassthrough(transmitBuf.String()),
 	}, nil
 }
 

--- a/src/pkg/file_preview/kitty_tmux_test.go
+++ b/src/pkg/file_preview/kitty_tmux_test.go
@@ -5,6 +5,76 @@ import (
 	"testing"
 )
 
+func TestKittyCapabilityResolution(t *testing.T) {
+	reset := func() { kittyCapability.Store(kittyCapUnknown) }
+	p := &ImagePreviewer{}
+
+	// A graphics reply marks support, and only reports a change the first time.
+	reset()
+	if !MarkKittySupported() {
+		t.Fatal("first graphics reply should report a change")
+	}
+	if MarkKittySupported() {
+		t.Fatal("repeated graphics reply should not report a change")
+	}
+	if !p.IsKittyCapable() {
+		t.Fatal("expected capable after graphics reply")
+	}
+
+	// DA1 must not downgrade a terminal that already answered positively.
+	if MarkKittyUnsupportedIfUnknown() {
+		t.Fatal("DA1 must not override a positive reply")
+	}
+	if !p.IsKittyCapable() {
+		t.Fatal("capability was downgraded by DA1")
+	}
+
+	// DA1 alone (the fence arriving with no graphics reply) means unsupported,
+	// and must win over the allowlist even on a terminal that is on it.
+	reset()
+	t.Setenv("TERM", "xterm-kitty")
+	if !MarkKittyUnsupportedIfUnknown() {
+		t.Fatal("DA1 from unknown state should report a change")
+	}
+	if p.IsKittyCapable() {
+		t.Fatal("terminal answered DA1 only; must not be treated as capable")
+	}
+
+	// While unknown, fall back to the allowlist.
+	reset()
+	if !p.IsKittyCapable() {
+		t.Fatal("expected allowlist fallback to report capable for xterm-kitty")
+	}
+	t.Setenv("TERM", "dumb")
+	t.Setenv("TERM_PROGRAM", "dumb")
+	if p.IsKittyCapable() {
+		t.Fatal("expected allowlist fallback to report incapable for dumb")
+	}
+	reset()
+}
+
+func TestKittyGraphicsQuery(t *testing.T) {
+	t.Setenv("TMUX", "")
+	q := KittyGraphicsQuery()
+	if !strings.Contains(q, "a=q") {
+		t.Fatalf("query must ask for a report (a=q), got %q", q)
+	}
+	if !strings.HasSuffix(q, "\x1b[c") {
+		t.Fatalf("DA1 fence must come last so it arrives after any graphics reply, got %q", q)
+	}
+
+	// Inside tmux the fence must be wrapped alongside the query, so the host
+	// terminal answers both rather than tmux answering DA1 itself.
+	t.Setenv("TMUX", "/tmp/tmux-501/default,123,0")
+	wrapped := KittyGraphicsQuery()
+	if strings.HasSuffix(wrapped, "\x1b[c") {
+		t.Fatal("DA1 must be inside the tmux passthrough, not trailing it")
+	}
+	if !strings.HasPrefix(wrapped, "\x1bPtmux;") {
+		t.Fatalf("query must be wrapped for tmux, got %q", wrapped)
+	}
+}
+
 func TestTmuxPassthrough(t *testing.T) {
 	t.Setenv("TMUX", "")
 	if got := tmuxPassthrough("\x1b_Ga=d\x1b\\"); got != "\x1b_Ga=d\x1b\\" {

--- a/src/pkg/file_preview/kitty_tmux_test.go
+++ b/src/pkg/file_preview/kitty_tmux_test.go
@@ -1,0 +1,37 @@
+package filepreview
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTmuxPassthrough(t *testing.T) {
+	t.Setenv("TMUX", "")
+	if got := tmuxPassthrough("\x1b_Ga=d\x1b\\"); got != "\x1b_Ga=d\x1b\\" {
+		t.Fatalf("outside tmux input must be unchanged, got %q", got)
+	}
+
+	t.Setenv("TMUX", "/tmp/tmux-501/default,123,0")
+
+	if got := tmuxPassthrough(""); got != "" {
+		t.Fatalf("empty input must stay empty, got %q", got)
+	}
+
+	// Single sequence: wrapped in DCS, inner ESCs doubled.
+	got := tmuxPassthrough("\x1b_Ga=d\x1b\\")
+	want := "\x1bPtmux;\x1b\x1b_Ga=d\x1b\x1b\\\x1b\\"
+	if got != want {
+		t.Fatalf("single sequence\n got %q\nwant %q", got, want)
+	}
+
+	// Chunked data must produce one DCS per sequence, not one giant DCS.
+	two := tmuxPassthrough("\x1b_Gm=1;AAA\x1b\\\x1b_Gm=0;BBB\x1b\\")
+	if n := strings.Count(two, "\x1bPtmux;"); n != 2 {
+		t.Fatalf("expected 2 passthrough wrappers, got %d in %q", n, two)
+	}
+
+	// A trailing fragment with no ST must not be dropped.
+	if frag := tmuxPassthrough("\x1b_Gnoterm"); !strings.Contains(frag, "_Gnoterm") {
+		t.Fatalf("unterminated fragment was dropped: %q", frag)
+	}
+}


### PR DESCRIPTION
Resolves the `TODO: Replace this allowlist with a real Kitty graphics capability check` in `isKittyCapable()`.

> **Stacked on #1557.** The first commit here is that PR; review only the second (`feat(image-preview): detect kitty graphics...`). If you'd rather take just one, #1557 stands alone — but this one supersedes the `SUPERFILE_KITTY` env var it introduced, so merging both means that opt-in never ships.

## Approach

`Init()` sends a graphics query (`a=q` on a 1x1 image — asks the terminal to report support without drawing) followed by a primary device attributes request. Ultraviolet already decodes both replies, and bubbletea v2 has `type Msg = uv.Event`, so they land in `Update()` with no new input plumbing.

Notably this means detection never touches stdin itself, which keeps the property `utils.go` documents for the existing cell-size detection ("non-blocking and doesn't interfere with stdin"). A synchronous probe reading the reply off stdin before `tea.NewProgram` would have been a smaller diff, but it would take stdin at startup, so I avoided it.

**DA1 is the fence.** Every terminal answers DA1, so a DA1 reply arriving with no graphics reply before it means the protocol is unsupported. Under tmux both are wrapped in a *single* passthrough so the host terminal answers both — otherwise tmux answers DA1 itself and can beat the host's graphics reply back, and a capable terminal gets misread as incapable.

**Async resolution.** The capability isn't known at the first render, so the allowlist is kept as a provisional guess while the state is unknown, and a preview that rendered with the wrong renderer is re-rendered once the answer arrives (via the existing `forcePreviewRender` path). The existing cache is keyed by renderer, so no invalidation is needed.

A terminal that answers neither query leaves the state unknown and keeps the allowlist result — i.e. current behaviour, so there's no regression for anything already working.

## Dependency note

This promotes `github.com/charmbracelet/ultraviolet` from indirect to direct in `go.mod`, since the event types come from there. Same version, nothing new in the build. It is a pinned-commit module, so if you'd rather not depend on it directly, I can match on the sequences at a lower level instead — happy to change this.

## Testing

- `go build ./...`, `go vet ./...`, and `go test ./...` (14 packages) all pass.
- New unit tests cover: a positive reply winning over DA1 regardless of order, DA1-alone meaning unsupported even when `$TERM` is on the allowlist, the allowlist being used only while the answer is unknown, and the fence being wrapped *inside* the tmux passthrough rather than trailing it.
- Manually verified on macOS with kitty 0.43.1 + tmux 3.5a: full-resolution previews inside tmux with no env var set, and unchanged behaviour outside tmux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic detection of Kitty graphics support for more accurate terminal capabilities.
  - Improved image previews in Kitty-compatible terminals.
  - Added support for displaying Kitty graphics correctly inside tmux sessions.

- **Bug Fixes**
  - Prevented incorrect terminal capability detection from disabling supported graphics.
  - Improved preview refresh behavior when terminal capabilities are discovered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->