### PR TITLE
feat(metadata): MVP drive metadata

### DIFF
--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -134,14 +134,24 @@ func (m *model) updateModelStateAfterMsg() {
 	}
 }
 
-// Note : Maybe we should not trigger metadata fetch for updates
-// that dont change the currently selected file panel element
-// TODO : At least dont trigger metadata fetch when user is scrolling
-// through the metadata panel
-func (m *model) getMetadataCmd() tea.Cmd {
-	if m.disableMetadata {
+func (m *model) getSideBarMetaData() tea.Cmd {
+	focusedItem := m.sidebarModel.GetFocusedItem()
+	if focusedItem.Location == m.fileMetaData.GetMetadataLocation() {
 		return nil
 	}
+	switch focusedItem.Type {
+	case utils.SidebarSectionDisks:
+		reqCnt := m.nextIoReqCnt()
+		m.fileMetaData.SetMetadataLocationAndFocused(focusedItem.Location, false)
+		return func() tea.Msg {
+			return NewMetadataMsg(metadata.GetDriveMetadata(focusedItem.Location), false, reqCnt, DriveMetadata)
+		}
+	default:
+		return nil
+	}
+}
+
+func (m *model) getFileMetaData() tea.Cmd {
 	if m.getFocusedFilePanel().EmptyOrInvalid() {
 		m.fileMetaData.SetBlank()
 		return nil
@@ -175,8 +185,22 @@ func (m *model) getMetadataCmd() tea.Cmd {
 	slog.Debug("Submitting metadata fetch request", "id", reqCnt, "path", selectedItem.Location)
 	return func() tea.Msg {
 		return NewMetadataMsg(
-			metadata.GetMetadata(selectedItem.Location, metadataFocused, et), metadataFocused, reqCnt)
+			metadata.GetMetadata(selectedItem.Location, metadataFocused, et), metadataFocused, reqCnt, FileMetadata)
 	}
+}
+
+// Note : Maybe we should not trigger metadata fetch for updates
+// that dont change the currently selected file panel element
+// TODO : At least dont trigger metadata fetch when user is scrolling
+// through the metadata panel
+func (m *model) getMetadataCmd() tea.Cmd {
+	if m.disableMetadata {
+		return nil
+	}
+	if m.focusPanel == sidebarFocus {
+		return m.getSideBarMetaData()
+	}
+	return m.getFileMetaData()
 }
 
 // Adjust window size based on msg information

--- a/src/internal/model_msg.go
+++ b/src/internal/model_msg.go
@@ -138,35 +138,59 @@ func (msg ExtractOperationMsg) ApplyToModel(_ *model) tea.Cmd {
 	return nil
 }
 
+type MetadataType int
+
+const (
+	FileMetadata MetadataType = iota
+	DriveMetadata
+)
+
 type MetadataMsg struct {
 	BaseMessage
 
 	meta            metadata.Metadata
 	metadataFocused bool
+	metadataType    MetadataType
 }
 
-func NewMetadataMsg(meta metadata.Metadata, metadataFocused bool, reqID int) MetadataMsg {
+func NewMetadataMsg(meta metadata.Metadata, metadataFocused bool, reqID int, metadataType MetadataType) MetadataMsg {
 	return MetadataMsg{
 		meta:            meta,
 		metadataFocused: metadataFocused,
 		BaseMessage: BaseMessage{
 			reqID: reqID,
 		},
+		metadataType: metadataType,
 	}
 }
 
 func (msg MetadataMsg) ApplyToModel(m *model) tea.Cmd {
 	m.fileMetaData.SetMetadataCache(msg.meta, msg.metadataFocused)
-	selectedItem := m.getFocusedFilePanel().GetFocusedItemPtr()
-	if selectedItem == nil {
-		slog.Debug("Panel empty or cursor invalid. Ignoring MetadataMsg")
+	switch msg.metadataType {
+	case DriveMetadata:
+		selectedItem := m.sidebarModel.GetFocusedItem()
+		if selectedItem.Location != msg.meta.GetPath() {
+			slog.Debug("MetadataMsg for older drives. Ignoring",
+				"currentItem", selectedItem.Location, "msgItem", msg.meta.GetPath())
+			return nil
+		}
+	case FileMetadata:
+		selectedItem := m.getFocusedFilePanel().GetFocusedItemPtr()
+		if selectedItem == nil {
+			slog.Debug("Panel empty or cursor invalid. Ignoring MetadataMsg")
+			return nil
+		}
+		if selectedItem.Location != msg.meta.GetPath() {
+			slog.Debug("MetadataMsg for older files. Ignoring",
+				"currentItem", selectedItem.Location, "msgItem", msg.meta.GetPath())
+			return nil
+		}
+	default:
+		slog.Debug("Invalid meta type. Ignoring",
+			"currentItem", msg.metadataType)
 		return nil
 	}
-	if selectedItem.Location != msg.meta.GetPath() {
-		slog.Debug("MetadataMsg for older files. Ignoring",
-			"currentItem", selectedItem.Location, "msgItem", msg.meta.GetPath())
-		return nil
-	}
+
 	if (m.focusPanel == metadataFocus) != msg.metadataFocused {
 		slog.Debug("MetadataMsg for older state. Ignoring",
 			"actualFocus", m.focusPanel, "msgFocus", msg.metadataFocused)

--- a/src/internal/ui/metadata/const.go
+++ b/src/internal/ui/metadata/const.go
@@ -10,6 +10,7 @@ const fileStatErrorMsg = "Cannot load file stats"
 const linkFileBrokenMsg = "Link file is broken!"
 const etFetchErrorMsg = "Errors while fetching metadata via exiftool"
 
+// File metadata
 const keyName = "Name"
 const keySize = "Size"
 const keyDataModified = "Date Modified"
@@ -22,6 +23,10 @@ const keyAttributes = "Attributes"
 const keyPath = "Path"
 const keyArchitecture = "Architecture"
 const borderSize = 2
+
+// Drive metadata
+const keyDriveAvailable = "Free"
+const keyDriveTotal = "Total"
 
 // Cache configuration
 const defaultCacheSize = 300

--- a/src/internal/ui/metadata/disk_utils.go
+++ b/src/internal/ui/metadata/disk_utils.go
@@ -1,0 +1,6 @@
+package metadata
+
+type DriveSize struct {
+	Total uint64 // bytes
+	Free  uint64 // bytes
+}

--- a/src/internal/ui/metadata/disk_utils_darwin.go
+++ b/src/internal/ui/metadata/disk_utils_darwin.go
@@ -1,10 +1,8 @@
-//go:build !windows
+//go:build darwin
 
 package metadata
 
 import (
-	"fmt"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -15,9 +13,6 @@ func getFreeSpace(path string) (*DriveSize, error) {
 		return nil, err
 	}
 	blockSize := stat.Bsize
-	if blockSize < 0 {
-		return nil, fmt.Errorf("invalid disk: %s size:%d", path, stat.Bsize)
-	}
 	freeBytes := stat.Bfree * uint64(blockSize)
 	totalBytes := stat.Blocks * uint64(blockSize)
 	return &DriveSize{Total: totalBytes, Free: freeBytes}, nil

--- a/src/internal/ui/metadata/disk_utils_linux.go
+++ b/src/internal/ui/metadata/disk_utils_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package metadata
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func getFreeSpace(path string) (*DriveSize, error) {
+	var stat unix.Statfs_t
+	err := unix.Statfs(path, &stat)
+	if err != nil {
+		return nil, err
+	}
+	blockSize := stat.Bsize
+	if blockSize < 0 {
+		return nil, fmt.Errorf("invalid disk: %s size:%d", path, stat.Bsize)
+	}
+	freeBytes := stat.Bfree * uint64(blockSize)
+	totalBytes := stat.Blocks * uint64(blockSize)
+	return &DriveSize{Total: totalBytes, Free: freeBytes}, nil
+}

--- a/src/internal/ui/metadata/disk_utils_unix.go
+++ b/src/internal/ui/metadata/disk_utils_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package metadata
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func getFreeSpace(path string) (*DriveSize, error) {
+	var stat unix.Statfs_t
+	err := unix.Statfs(path, &stat)
+	if err != nil {
+		return nil, err
+	}
+	blockSize := stat.Bsize
+	if blockSize < 0 {
+		return nil, fmt.Errorf("invalid disk: %s size:%d", path, stat.Bsize)
+	}
+	freeBytes := stat.Bfree * uint64(blockSize)
+	totalBytes := stat.Blocks * uint64(blockSize)
+	return &DriveSize{Total: totalBytes, Free: freeBytes}, nil
+}

--- a/src/internal/ui/metadata/disk_utils_windows.go
+++ b/src/internal/ui/metadata/disk_utils_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package metadata
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func getFreeSpace(path string) (*DriveSize, error) {
+	var freeBytes uint64
+	var totalBytes uint64
+	err := windows.GetDiskFreeSpaceEx(windows.StringToUTF16Ptr(path), &freeBytes, &totalBytes, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DriveSize{Total: totalBytes, Available: freeBytes}, nil
+}

--- a/src/internal/ui/metadata/disk_utils_windows.go
+++ b/src/internal/ui/metadata/disk_utils_windows.go
@@ -13,5 +13,5 @@ func getFreeSpace(path string) (*DriveSize, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &DriveSize{Total: totalBytes, Available: freeBytes}, nil
+	return &DriveSize{Total: totalBytes, Free: freeBytes}, nil
 }

--- a/src/internal/ui/metadata/metadata.go
+++ b/src/internal/ui/metadata/metadata.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -78,6 +79,25 @@ func sortMetadata(meta [][2]string) {
 func GetMetadata(filePath string, metadataFocused bool, et *exiftool.Exiftool) Metadata {
 	meta := getMetaDataUnsorted(filePath, metadataFocused, et)
 	sortMetadata(meta.data)
+	return meta
+}
+
+func driveSizeRule(size uint64) int64 {
+	if size > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(size)
+}
+
+func GetDriveMetadata(location string) Metadata {
+	meta := Metadata{
+		filepath: location,
+	}
+	if space, err := getFreeSpace(location); err == nil {
+		freeSize := [2]string{keyDriveAvailable, common.FormatFileSize(driveSizeRule(space.Free))}
+		totalSize := [2]string{keyDriveTotal, common.FormatFileSize(driveSizeRule(space.Total))}
+		meta.data = append(meta.data, freeSize, totalSize)
+	}
 	return meta
 }
 

--- a/src/internal/ui/sidebar/sidebar.go
+++ b/src/internal/ui/sidebar/sidebar.go
@@ -99,6 +99,11 @@ func (s *Model) UpdateDirectories() {
 	}
 }
 
+func (s *Model) GetFocusedItem() SideBarItem {
+	item := s.directories[s.cursor]
+	return SideBarItem{Location: item.Location, Name: item.Name, Type: item.Section}
+}
+
 // TogglePinnedDirectory adds or removes a directory from the pinned list.
 func (s *Model) TogglePinnedDirectory(dir string) error {
 	return s.pinnedMgr.Toggle(dir)

--- a/src/internal/ui/sidebar/type.go
+++ b/src/internal/ui/sidebar/type.go
@@ -2,10 +2,12 @@ package sidebar
 
 import "charm.land/bubbles/v2/textinput"
 
+// deprecated. Replace it by public struct SideBarItem
 type directory struct {
-	Location string `json:"location"`
-	Name     string `json:"name"`
-	Section  string `json:"-"`
+	Location string  `json:"location"`
+	Name     string  `json:"name"`
+	Section  string  `json:"-"`
+	FreeSize *uint64 `json:"-"` // nil if size not calculated
 }
 
 type Model struct {
@@ -20,4 +22,10 @@ type Model struct {
 	height      int
 	disabled    bool
 	sections    []string
+}
+
+type SideBarItem struct {
+	Location string
+	Name     string
+	Type     string
 }


### PR DESCRIPTION
issue: #1350 

It is not a good idea to show the drive size in the sidebar. There is not enough space for it.
<img width="170" height="128" alt="image" src="https://github.com/user-attachments/assets/0ac698c4-a627-4b40-a4d9-d20f757f1d13" />

I propose use the metadata bar for it.
linux case:
<img width="957" height="572" alt="image" src="https://github.com/user-attachments/assets/e08800cb-56ac-400d-9bf8-59e3afabe274" />
windows case:
<img width="1368" height="507" alt="изображение" src="https://github.com/user-attachments/assets/7fd0a665-8e66-470a-beca-5d7e5a8b4157" />

PS The visibility changing of "sidebar.directory" changes a lot of files. So propose replace it in next commit In the name of principle "one commit one change".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drive metadata display, including available and total storage.
  * Drive metadata is now shown for the currently focused sidebar location.
  * Added platform support for retrieving drive capacity on Windows, macOS, and Linux.
  * Improved metadata handling when switching between sidebar and file panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->