### PR TITLE
feat: automatically refresh file panes on external file system events

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1995,6 +1995,40 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 
+## github.com/fsnotify/fsnotify
+
+- Version: v1.10.1
+- License: [BSD-3-Clause](https://github.com/fsnotify/fsnotify/blob/v1.10.1/LICENSE)
+
+```text
+Copyright © 2012 The Go Authors. All rights reserved.
+Copyright © fsnotify Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+* Neither the name of Google Inc. nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+
 ## github.com/fvbommel/sortorder
 
 - Version: v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/barasher/go-exiftool v1.10.0
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/fatih/color v1.19.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/fvbommel/sortorder v1.1.0
 	github.com/lazysegtree/go-zoxide v0.1.0
 	github.com/lithammer/shortuuid v3.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQmYw=
 github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=

--- a/src/internal/default_config.go
+++ b/src/internal/default_config.go
@@ -1,6 +1,9 @@
 package internal
 
 import (
+	"log/slog"
+
+	"github.com/fsnotify/fsnotify"
 	zoxidelib "github.com/lazysegtree/go-zoxide"
 
 	"github.com/atotto/clipboard"
@@ -46,5 +49,16 @@ func defaultModelConfig(toggleDotFile, toggleFooter, firstUse bool,
 		toggleFooter:    toggleFooter,
 		firstUse:        firstUse,
 		hasTrash:        common.InitTrash(),
+		fsWatcher:       initWatcher(),
 	}
+}
+
+// initWatcher initializes and returns a new fsnotify file system watcher.
+func initWatcher() *fsnotify.Watcher {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		slog.Error("Failed to initialize fsnotify watcher", "error", err)
+		return nil
+	}
+	return watcher
 }

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -4,11 +4,14 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
 
 	"github.com/yorukot/superfile/src/config/icon"
 	"github.com/yorukot/superfile/src/internal/common"
@@ -54,6 +57,7 @@ func (m *model) Init() tea.Cmd {
 	return tea.Batch(
 		textinput.Blink, // Assuming textinput.Blink is a valid command
 		processCmdToTeaCmd(m.processBarModel.GetListenCmd()),
+		m.watchFileSystem(),
 	)
 }
 
@@ -63,7 +67,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	slog.Debug("model.Update() called", "msgType", reflect.TypeOf(msg))
 
 	var sidebarCmd, inputCmd, updateCmd, panelCmd,
-		metadataCmd, filePreviewCmd, helpMenuCmd, resizeCmd tea.Cmd
+		metadataCmd, filePreviewCmd, helpMenuCmd, resizeCmd, watcherCmd tea.Cmd
 
 	// These are above the key message handing to prevent issues with firstKeyInput
 	// if someone presses `/` to focus to searchBar, searchBar will otherwise
@@ -95,6 +99,14 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		slog.Debug("Got ModelUpdate message", "id", msg.GetReqID())
 		updateCmd = msg.ApplyToModel(m)
 
+	case watcherMsg:
+		slog.Debug("File system event", "event", msg.event)
+		updateCmd = m.handleFileSystemEvent(msg.event)
+		watcherCmd = m.watchFileSystem()
+	case watcherErrMsg:
+		slog.Error("File system watcher error", "error", msg.err)
+		watcherCmd = m.watchFileSystem()
+
 	default:
 		slog.Debug("Message of type that is not explicitly handled")
 	}
@@ -108,7 +120,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	metadataCmd = m.getMetadataCmd()
 
 	return m, tea.Batch(sidebarCmd, helpMenuCmd, inputCmd, updateCmd,
-		panelCmd, metadataCmd, filePreviewCmd, resizeCmd)
+		panelCmd, metadataCmd, filePreviewCmd, resizeCmd, watcherCmd)
 }
 
 func (m *model) handleMouseMsg(msg tea.MouseMsg) {
@@ -123,6 +135,7 @@ func (m *model) handleMouseMsg(msg tea.MouseMsg) {
 func (m *model) updateModelStateAfterMsg() {
 	m.sidebarModel.UpdateDirectories()
 	m.fileModel.UpdateFilePanelsIfNeeded(false)
+	m.updateWatchedDirectories()
 	// TODO: Move to utility
 	if m.focusPanel != metadataFocus {
 		m.fileMetaData.ResetRender()
@@ -606,6 +619,9 @@ func (m *model) quitSuperfile(cdOnQuit bool) {
 	if common.Config.Metadata && et != nil {
 		_ = et.Close()
 	}
+	if m.fsWatcher != nil {
+		_ = m.fsWatcher.Close()
+	}
 	m.fileModel.FilePreview.CleanUp()
 
 	// cd on quit
@@ -628,4 +644,115 @@ func (m *model) quitSuperfile(cdOnQuit bool) {
 func (m *model) nextIoReqCnt() int {
 	var res = atomic.AddInt32(&m.ioReqCnt, 1)
 	return int(res)
+}
+
+// watcherMsg represents a filesystem event captured by the fsnotify watcher.
+type watcherMsg struct {
+	event fsnotify.Event
+}
+
+// watcherErrMsg represents an error encountered by the fsnotify watcher.
+type watcherErrMsg struct {
+	err error
+}
+
+// watchFileSystem starts a Bubble Tea command that listens for filesystem events.
+func (m *model) watchFileSystem() tea.Cmd {
+	if m.fsWatcher == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		select {
+		case event, ok := <-m.fsWatcher.Events:
+			if !ok {
+				return nil
+			}
+			return watcherMsg{event}
+		case err, ok := <-m.fsWatcher.Errors:
+			if !ok {
+				return nil
+			}
+			return watcherErrMsg{err}
+		}
+	}
+}
+
+// updateWatchedDirectories synchronizes the fsnotify watcher with the active file panels.
+func (m *model) updateWatchedDirectories() {
+	if m.fsWatcher == nil {
+		return
+	}
+	// Collect directories currently open in all file panels.
+	currentDirs := make(map[string]bool)
+	for _, panel := range m.fileModel.FilePanels {
+		if panel.Location != "" {
+			currentDirs[panel.Location] = true
+		}
+	}
+
+	// Remove directories that are no longer open from the watcher.
+	var newWatched []string
+	for _, dir := range m.watchedDirs {
+		if !currentDirs[dir] {
+			_ = m.fsWatcher.Remove(dir)
+		} else {
+			newWatched = append(newWatched, dir)
+		}
+	}
+
+	// Add newly opened directories to the watcher.
+	for dir := range currentDirs {
+		if !slices.Contains(newWatched, dir) {
+			err := m.fsWatcher.Add(dir)
+			if err == nil {
+				newWatched = append(newWatched, dir)
+			} else {
+				slog.Error("Failed to watch directory", "dir", dir, "error", err)
+			}
+		}
+	}
+	m.watchedDirs = newWatched
+}
+
+// handleFileSystemEvent processes a filesystem event and triggers a reload for affected panels.
+func (m *model) handleFileSystemEvent(event fsnotify.Event) tea.Cmd {
+	// Determine the directory containing the file associated with the event.
+	dir := filepath.Dir(event.Name)
+	
+	var cmds []tea.Cmd
+	for i, panel := range m.fileModel.FilePanels {
+		// Identify panels actively viewing the affected directory.
+		if panel.Location == dir || panel.Location == event.Name {
+			cmds = append(cmds, m.reloadPanelCmd(i, panel.Location))
+		}
+	}
+	return tea.Batch(cmds...)
+}
+
+// genericUpdateMsg is a general-purpose message wrapper for executing model updates.
+type genericUpdateMsg struct {
+	BaseMessage
+	apply func(m *model) tea.Cmd
+}
+
+// ApplyToModel executes the underlying update logic on the provided model.
+func (msg genericUpdateMsg) ApplyToModel(m *model) tea.Cmd {
+	return msg.apply(m)
+}
+
+// reloadPanelCmd generates a command to forcefully reload a specific file panel.
+func (m *model) reloadPanelCmd(index int, location string) tea.Cmd {
+	return func() tea.Msg {
+		// Dispatch an update message to reload the specific panel's directory.
+		return genericUpdateMsg{
+			BaseMessage: BaseMessage{reqID: m.nextIoReqCnt()},
+			apply: func(m *model) tea.Cmd {
+				err := m.fileModel.FilePanels[index].UpdateCurrentFilePanelDir(location)
+				if err != nil {
+					slog.Error("Failed to reload panel after fs event", "error", err)
+				}
+				return nil
+			},
+		}
+	}
 }

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -105,6 +105,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		watcherCmd = m.watchFileSystem()
 	case watcherErrMsg:
 		slog.Error("File system watcher error", "error", msg.err)
+		if errors.Is(msg.err, fsnotify.ErrEventOverflow) {
+			updateCmd = m.reloadAllWatchedPanels()
+		}
 		watcherCmd = m.watchFileSystem()
 
 	default:
@@ -738,6 +741,16 @@ type genericUpdateMsg struct {
 // ApplyToModel executes the underlying update logic on the provided model.
 func (msg genericUpdateMsg) ApplyToModel(m *model) tea.Cmd {
 	return msg.apply(m)
+}
+
+func (m *model) reloadAllWatchedPanels() tea.Cmd {
+	var cmds []tea.Cmd
+	for i, panel := range m.fileModel.FilePanels {
+		if panel.Location != "" {
+			cmds = append(cmds, m.reloadPanelCmd(i, panel.Location))
+		}
+	}
+	return tea.Batch(cmds...)
 }
 
 // reloadPanelCmd generates a command to forcefully reload a specific file panel.

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -747,6 +747,11 @@ func (m *model) reloadPanelCmd(index int, location string) tea.Cmd {
 		return genericUpdateMsg{
 			BaseMessage: BaseMessage{reqID: m.nextIoReqCnt()},
 			apply: func(m *model) tea.Cmd {
+				if index < 0 || index >= len(m.fileModel.FilePanels) ||
+					m.fileModel.FilePanels[index].Location != location {
+					return nil
+				}
+
 				err := m.fileModel.FilePanels[index].UpdateCurrentFilePanelDir(location)
 				if err != nil {
 					slog.Error("Failed to reload panel after fs event", "error", err)

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"sync"
 
+	"github.com/fsnotify/fsnotify"
 	zoxidelib "github.com/lazysegtree/go-zoxide"
 
 	"github.com/yorukot/superfile/src/internal/ui/helpmenu"
@@ -98,6 +99,10 @@ type model struct {
 
 	// whether usable trash directory exists or not
 	hasTrash bool
+
+	// file system watcher
+	fsWatcher   *fsnotify.Watcher
+	watchedDirs []string
 }
 
 type typingModal struct {


### PR DESCRIPTION
## Description

This PR introduces automatic background reloading for file panes when external file system events occur (e.g., creating, renaming, deleting, or modifying files in an external terminal).

Previously, if a user had `superfile` open in one terminal and manipulated files in another terminal, they would have to manually trigger an action or change directories in `superfile` to see the changes.

## Context / Solution

This is solved by introducing the `github.com/fsnotify/fsnotify` dependency.

- A background `fsnotify.Watcher` is initialized inside the main application model during startup.
- A new `tea.Cmd` is spawned during `Init()` to listen for file system events asynchronously.
- As the user navigates, directories that are currently open and visible in any file pane are dynamically added to the watcher. When a pane changes directory, old directories are unwatched.
- Upon receiving a file system event (Create/Write/Remove/Rename), the main model loops through the active file panes. If any file pane is currently viewing the directory where the event occurred, a `ModelUpdateMessage` is dispatched to trigger an immediate reload of that pane using `UpdateCurrentFilePanelDir`.

## Demo

Code from yorukot/superfile
- changes as of main branch head: #5f15ff9
- Example below shows how `superfile` cannot pickup changes to files instantly created/renamed/moved ..etc. User has to navigate to the application and issue an action within `superfile` and then the changes get picked up.
- In my example below, I hit the down arrow key just to 'wake up' the application then the changes get noticed.

https://github.com/user-attachments/assets/e6487f98-5c04-464e-9758-aa740966e656

My version (proposed fix in this PR)
- Example below shows how any OS changes to file system that `superfile` is viewing instantly picks up changes via implemented `fsnotify.Watcher`
- No need to navigate to Superfile, the changes always picked up - whether or not you choose to focus on the application.
- This is a very useful feature if you have other processes in the bg creating/modifying files.

https://github.com/user-attachments/assets/d6abba13-178a-4453-833f-ef0654df8f2a


## Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I’m not committing any debug logs or TODOs
- [x] I have filled out the PR template with description, context, and screenshots if needed
- [x] I have checked that the PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic refresh support when files or directories change externally.
  * Open panels now update to reflect filesystem changes without requiring manual navigation.
  * File monitoring is automatically adjusted as panels are opened or closed.
* **Bug Fixes**
  * Improved handling of watcher errors to keep updates reliable (including full reload when event overflow occurs).
  * Improved synchronization between displayed panel contents and the current filesystem state.
* **Documentation**
  * Added third-party attribution/license details for the filesystem watching dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->