### PR TITLE
fix(config): avoid error label after hotkey repair

### DIFF
--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -137,18 +137,7 @@ func LoadHotkeysFile(ignoreMissingFields bool) {
 		ignoreMissingFields,
 	)
 	if err != nil {
-		userMsg := fmt.Sprintf("%s%s", LipglossError, err.Error())
-
-		toExit := true
-		var loadError *utils.TomlLoadError
-		if errors.As(err, &loadError) {
-			if loadError.MissingFields() && !variable.FixHotkeys {
-				// Had missing fields and we did not fix
-				userMsg += "\nTo add missing fields to hotkeys file automatically run superfile " +
-					"with the --fix-hotkeys flag `spf --fix-hotkeys`"
-			}
-			toExit = loadError.IsFatal()
-		}
+		userMsg, toExit := formatHotkeysLoadError(err)
 		if toExit {
 			utils.PrintfAndExitf("%s\n", userMsg)
 		} else {
@@ -184,6 +173,30 @@ func LoadHotkeysFile(ignoreMissingFields bool) {
 			)
 		}
 	}
+}
+
+func formatHotkeysLoadError(err error) (string, bool) {
+	userMsg := err.Error()
+	toExit := true
+	repairSucceeded := false
+
+	var loadError *utils.TomlLoadError
+	if errors.As(err, &loadError) {
+		if loadError.MissingFields() && !variable.FixHotkeys {
+			// Had missing fields and we did not fix
+			userMsg += "\nTo add missing fields to hotkeys file automatically run superfile " +
+				"with the --fix-hotkeys flag `spf --fix-hotkeys`"
+		}
+		toExit = loadError.IsFatal()
+		repairSucceeded = loadError.MissingFields() && variable.FixHotkeys && !toExit
+	}
+
+	// Keep the error prefix for failures and unresolved missing fields.
+	if !repairSucceeded {
+		userMsg = fmt.Sprintf("%s%s", LipglossError, userMsg)
+	}
+
+	return userMsg, toExit
 }
 
 // LoadThemeFile : Load configurations from theme file into &theme

--- a/src/internal/common/load_config_test.go
+++ b/src/internal/common/load_config_test.go
@@ -1,0 +1,74 @@
+package common
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	variable "github.com/yorukot/superfile/src/config"
+	"github.com/yorukot/superfile/src/pkg/utils"
+)
+
+type repairMessageTestConfig struct {
+	Existing string `toml:"existing"`
+	Added    string `toml:"added"`
+}
+
+func TestFormatHotkeysLoadError(t *testing.T) {
+	originalFixHotkeys := variable.FixHotkeys
+	originalLipglossError := LipglossError
+	t.Cleanup(func() {
+		variable.FixHotkeys = originalFixHotkeys
+		LipglossError = originalLipglossError
+	})
+
+	LipglossError = "Error | "
+
+	t.Run("successful repair is not labelled as an error", func(t *testing.T) {
+		defaultData := "existing = 'default'\nadded = 'default'\n"
+		hotkeysFile := filepath.Join(t.TempDir(), "hotkeys.toml")
+		require.NoError(t, os.WriteFile(hotkeysFile, []byte("existing = 'custom'\n"), utils.ConfigFilePerm))
+
+		var target repairMessageTestConfig
+		err := utils.LoadTomlFile(hotkeysFile, defaultData, &target, true, false)
+		require.Error(t, err)
+
+		variable.FixHotkeys = true
+		message, toExit := formatHotkeysLoadError(err)
+
+		assert.False(t, toExit)
+		assert.NotContains(t, message, LipglossError)
+		assert.True(t, strings.HasPrefix(message, "config file had issues. It's fixed successfully."))
+	})
+
+	t.Run("fatal errors retain the error label", func(t *testing.T) {
+		variable.FixHotkeys = true
+
+		message, toExit := formatHotkeysLoadError(errors.New("could not load hotkeys"))
+
+		assert.True(t, toExit)
+		assert.Equal(t, LipglossError+"could not load hotkeys", message)
+	})
+
+	t.Run("unresolved missing fields retain the error label", func(t *testing.T) {
+		defaultData := "existing = 'default'\nadded = 'default'\n"
+		hotkeysFile := filepath.Join(t.TempDir(), "hotkeys.toml")
+		require.NoError(t, os.WriteFile(hotkeysFile, []byte("existing = 'custom'\n"), utils.ConfigFilePerm))
+
+		var target repairMessageTestConfig
+		err := utils.LoadTomlFile(hotkeysFile, defaultData, &target, false, false)
+		require.Error(t, err)
+
+		variable.FixHotkeys = false
+		message, toExit := formatHotkeysLoadError(err)
+
+		assert.False(t, toExit)
+		assert.True(t, strings.HasPrefix(message, LipglossError))
+		assert.Contains(t, message, "--fix-hotkeys")
+	})
+}


### PR DESCRIPTION
# Description

Running `spf --fix-hotkeys` successfully repairs missing hotkey fields, but `LoadHotkeysFile` currently adds the red `Error` prefix before it checks whether the returned `TomlLoadError` is fatal. The resulting success message is therefore presented as an error.

This change classifies the result before formatting it:

- successful automatic repairs keep the existing success message without the `Error` prefix
- fatal failures retain the existing `Error` prefix
- unresolved missing fields retain both the `Error` prefix and the `--fix-hotkeys` remediation hint

The regression tests exercise all three states through the existing TOML loader where applicable.

# Related Issues

Fixes #1570

# Testing

- `go test ./src/internal/common -run '^TestFormatHotkeysLoadError$' -count=1`
- `go test ./src/internal/common ./src/pkg/utils -count=1`
- `go vet ./src/internal/common ./src/pkg/utils`
- `gofmt -d src/internal/common/load_config.go src/internal/common/load_config_test.go`
- `git diff --check`

`go test ./...` completed every reported package except for one intermittent Windows failure in the unrelated `TestModel_Update_Prompt/open_Panel` command-substitution test. That exact test passed in isolation on both the unchanged base commit and this branch.
