### PR TITLE
feat: make bat preview flags configurable

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -95,6 +95,7 @@ type ConfigType struct {
 	FilePreviewWidth        int      `toml:"file_preview_width"         comment:"\nFile preview width allow '0' (this mean same as file panel),'x' x must be less than 10 and greater than 1 (This means that the width of the file preview will be one xth of the total width.)"`
 	EnableFilePreviewBorder bool     `toml:"enable_file_preview_border" comment:"\nEnable border around the file preview panel (default: false)"`
 	CodePreviewer           string   `toml:"code_previewer"             comment:"\nWhether to use the builtin syntax highlighting with chroma or use bat. Values: \"\" for builtin chroma, \"bat\" for bat"`
+	BatFlags                []string `toml:"bat_flags"                  comment:"\nCommand-line flags passed to bat when it is used as the code previewer."`
 	SidebarWidth            int      `toml:"sidebar_width"              comment:"\nThe length of the sidebar(excluding borders). If you don't find to display the sidebar, you can input 0 directly. If you want to display the value, please place it in the range of 5-20."`
 	SidebarSections         []string `toml:"sidebar_sections"           comment:"\nOrder of sidebar sections (valid values: \"home\", \"pinned\", \"disks\").\nOnly sections included in this list will be displayed."`
 

--- a/src/internal/ui/preview/render_utils.go
+++ b/src/internal/ui/preview/render_utils.go
@@ -19,10 +19,7 @@ func getBatSyntaxHighlightedContent(
 	background string,
 	batCmd string,
 ) (string, error) {
-	// --plain: use the plain style without line numbers and decorations
-	// --force-colorization: force colorization for non-interactive shell output
-	// --line-range <:m>: only read from line 1 to line "m"
-	batArgs := []string{itemPath, "--plain", "--force-colorization", "--line-range", fmt.Sprintf(":%d", previewLine)}
+	batArgs := buildBatArgs(itemPath, previewLine, common.Config.BatFlags)
 
 	// set timeout for the external command execution to 500ms max
 	ctx, cancel := context.WithTimeout(context.Background(), common.DefaultPreviewTimeout)
@@ -41,6 +38,14 @@ func getBatSyntaxHighlightedContent(
 		fileContent = setBatBackground(fileContent, background)
 	}
 	return fileContent, nil
+}
+
+func buildBatArgs(itemPath string, previewLine int, batFlags []string) []string {
+	batArgs := make([]string, 0, len(batFlags)+3)
+	batArgs = append(batArgs, itemPath)
+	batArgs = append(batArgs, batFlags...)
+	// --line-range <:m>: only read from line 1 to line "m"
+	return append(batArgs, "--line-range", fmt.Sprintf(":%d", previewLine))
 }
 
 func setBatBackground(input string, background string) string {

--- a/src/internal/ui/preview/render_utils_test.go
+++ b/src/internal/ui/preview/render_utils_test.go
@@ -1,0 +1,53 @@
+package preview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildBatArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		batFlags     []string
+		expectedArgs []string
+	}{
+		{
+			name:     "default flags",
+			batFlags: []string{"--plain", "--force-colorization"},
+			expectedArgs: []string{
+				"example.go",
+				"--plain",
+				"--force-colorization",
+				"--line-range",
+				":24",
+			},
+		},
+		{
+			name:     "custom flags",
+			batFlags: []string{"--style=numbers", "--color=always"},
+			expectedArgs: []string{
+				"example.go",
+				"--style=numbers",
+				"--color=always",
+				"--line-range",
+				":24",
+			},
+		},
+		{
+			name:     "no flags",
+			batFlags: nil,
+			expectedArgs: []string{
+				"example.go",
+				"--line-range",
+				":24",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedArgs, buildBatArgs("example.go", 24, test.batFlags))
+		})
+	}
+}

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -101,6 +101,11 @@ theme = "catppuccin-mocha"
 # Whether to use the builtin syntax highlighting with chroma or use bat. Values: "" for builtin chroma, "bat" for bat
 code_previewer = ""
 
+#-- Bat Previewer Flags
+# Command-line flags passed to bat when it is used as the code previewer.
+# Customize these if they conflict with options in your bat configuration file.
+bat_flags = ["--plain", "--force-colorization"]
+
 #-- Nerd Fonts Support
 # Whether to enable support for Nerd Fonts symbols.
 # Requires:  Font patched with the Nerd Fonts patch.

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -226,6 +226,10 @@ Percentage of file panel width allocated to file names (25-100). Higher values g
 
 `''` => Use the builtin syntax highlighting for code files with _chroma_. `'bat'` => Use syntax highlighting provided by the [`bat`](https://github.com/sharkdp/bat) command line tool.
 
+- ###### bat_flags
+
+Command-line flags passed to `bat` when `code_previewer = 'bat'`. The default is `['--plain', '--force-colorization']`. Customize this list if those flags conflict with options in your `bat` configuration file.
+
 - ###### nerdfont
 
 `true` => Use nerdfont for directories and file icons.

--- a/website/src/content/docs/zh-tw/configure/superfile-config.mdx
+++ b/website/src/content/docs/zh-tw/configure/superfile-config.mdx
@@ -226,6 +226,10 @@ File panel 中除檔名外的額外欄位數量。
 
 `''` => 使用內建的 _chroma_ 語法醒目提示來預覽程式碼檔案。 `'bat'` => 使用 [`bat`](https://github.com/sharkdp/bat) 命令列工具提供的語法醒目提示。
 
+- ###### bat_flags
+
+當 `code_previewer = 'bat'` 時傳遞給 `bat` 的命令列參數。預設值為 `['--plain', '--force-colorization']`。如果這些參數與你的 `bat` 設定檔衝突，可以自訂此清單。
+
 - ###### nerdfont
 
 `true` => 對目錄和檔案圖示使用 nerdfont。


### PR DESCRIPTION
# Description

- add a `bat_flags` configuration option with the existing `--plain` and `--force-colorization` behavior as defaults
- pass configured flags to `bat`, allowing users to avoid conflicts with their personal bat configuration
- document the new option in the English and Traditional Chinese configuration guides
- cover default, custom, and empty flag lists with unit tests

# Related Issues

Fixes #1193

# Testing

- `go test ./...`
- `go vet ./src/internal/common ./src/internal/ui/preview`
- `git diff --check`

# Pre-Submission Checklist

- [x] Changed Go files were formatted with `gofmt`
- [ ] `golangci-lint run` (the repository CI skips golangci-lint on Windows)
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I am not committing debug logs or TODOs
- [x] The PR title follows Conventional Commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable command-line flags for the `bat` code previewer.
  * Default preview behavior preserves plain output and colorized syntax highlighting.
  * Custom flags can be configured when needed.

* **Documentation**
  * Added configuration guidance in English and Traditional Chinese.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->