### PR TITLE
feat: scrollable file preview with configurable mouse wheel speed

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -86,6 +86,7 @@ type ConfigType struct {
 	// IgnoreMissingFields controls whether warnings about missing TOML fields are suppressed.
 	IgnoreMissingFields   bool `toml:"ignore_missing_fields"    comment:"\nWhether to ignore warnings about missing fields in the config file."`
 	PageScrollSize        int  `toml:"page_scroll_size"         comment:"\nNumber of lines to scroll for PgUp/PgDown keys (0: full page, default behavior)."`
+	WheelScrollSpeed      int  `toml:"wheel_scroll_speed"       comment:"\nLines to scroll per mouse wheel tick (1-20, default: 5)."`
 	FilePanelExtraColumns int  `toml:"file_panel_extra_columns" comment:"\nCount of extra columns in file panel in addition to file name. When option equal 0 then feature is disabled."`
 	FilePanelNamePercent  int  `toml:"file_panel_name_percent"  comment:"\nPercentage of file panel width allocated to file names (25-100). Higher values give more space to names, less to extra columns."`
 
@@ -142,6 +143,7 @@ type HotkeysType struct {
 	FocusOnProcessBar []string `toml:"focus_on_process_bar" comment:"change focus"`
 	FocusOnSidebar    []string `toml:"focus_on_sidebar"`
 	FocusOnMetaData   []string `toml:"focus_on_metadata"`
+	FocusOnPreview    []string `toml:"focus_on_preview"`
 
 	FilePanelItemCreate []string `toml:"file_panel_item_create" comment:"create file/directory and rename "`
 	FilePanelItemRename []string `toml:"file_panel_item_rename"`

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -81,12 +81,15 @@ func ValidateConfig(c *ConfigType) error {
 		return errors.New(LoadConfigError("default_sort_type", "Default sort type must be between 0 and 4."))
 	}
 
+	if c.WheelScrollSpeed < 0 || c.WheelScrollSpeed > 20 {
+		return errors.New(LoadConfigError("wheel_scroll_speed", "Wheel scroll speed must be 0–20 (0 to disable)."))
+	}
+
 	if c.FilePanelNamePercent < FileNameRatioMin || c.FilePanelNamePercent > FileNameRatioMax {
 		return errors.New(
 			LoadConfigError("file_panel_name_percent", "File panel name percent is outside the supported range."),
 		)
 	}
-
 	if ansi.StringWidth(c.BorderTop) != 1 {
 		return errors.New(LoadConfigError("border_top", "Border character must be exactly one cell wide."))
 	}

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -12,7 +12,6 @@ import (
 const (
 	// SidebarDividerLength defines the number of characters used for the horizontal divider in the sidebar.
 	SidebarDividerLength  = 20
-	WheelRunTime          = 5
 	DefaultCommandTimeout = 5000 * time.Millisecond
 	DateModifiedOption    = "Date Modified"
 	InvalidTypeString     = "InvalidType"

--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -58,3 +58,18 @@ func (m *model) focusOnMetadata() {
 		m.getFocusedFilePanel().IsFocused = false
 	}
 }
+
+// focus on preview panel
+func (m *model) focusOnPreview() {
+	if !m.fileModel.FilePreview.IsOpen() {
+		// If preview is not open, open it first
+		m.fileModel.ToggleFilePreviewPanel()
+	}
+	if m.focusPanel == previewFocus {
+		m.focusPanel = nonePanelFocus
+		m.getFocusedFilePanel().IsFocused = true
+	} else {
+		m.focusPanel = previewFocus
+		m.getFocusedFilePanel().IsFocused = false
+	}
+}

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -33,6 +33,8 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,go
 			m.processBarModel.ListUp()
 		case metadataFocus:
 			m.fileMetaData.ListUp()
+		case previewFocus:
+			m.fileModel.FilePreview.ScrollUp()
 		case nonePanelFocus:
 			m.getFocusedFilePanel().ListUp()
 		}
@@ -46,6 +48,8 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,go
 			m.processBarModel.ListDown()
 		case metadataFocus:
 			m.fileMetaData.ListDown()
+		case previewFocus:
+			m.fileModel.FilePreview.ScrollDown()
 		case nonePanelFocus:
 			m.getFocusedFilePanel().ListDown()
 		}
@@ -54,6 +58,8 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,go
 		switch m.focusPanel {
 		case metadataFocus:
 			m.fileMetaData.PgUp()
+		case previewFocus:
+			m.fileModel.FilePreview.PgUp()
 		case nonePanelFocus:
 			m.getFocusedFilePanel().PgUp()
 		case processBarFocus, sidebarFocus:
@@ -64,6 +70,8 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,go
 		switch m.focusPanel {
 		case metadataFocus:
 			m.fileMetaData.PgDown()
+		case previewFocus:
+			m.fileModel.FilePreview.PgDown()
 		case nonePanelFocus:
 			m.getFocusedFilePanel().PgDown()
 		case processBarFocus, sidebarFocus:
@@ -112,6 +120,8 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,go
 
 	case slices.Contains(common.Hotkeys.FocusOnMetaData, msg):
 		m.focusOnMetadata()
+	case slices.Contains(common.Hotkeys.FocusOnPreview, msg):
+		m.focusOnPreview()
 
 	case slices.Contains(common.Hotkeys.PasteItems, msg):
 		return m.getPasteItemCmd()

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -22,7 +22,7 @@ import (
 // check the state of model m and handle properly.
 // TODO: This function has grown too big. It needs to be fixed, via major
 // updates and fixes in key handling code
-func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,gocognit // See above
+func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,gocognit,maintidx // See above
 	switch {
 	// If move up Key is pressed, check the current state and executes
 	case slices.Contains(common.Hotkeys.ListUp, msg):

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -35,6 +35,7 @@ const (
 	processBarFocus
 	sidebarFocus
 	metadataFocus
+	previewFocus
 )
 
 const (

--- a/src/internal/type_utils.go
+++ b/src/internal/type_utils.go
@@ -16,6 +16,8 @@ func (f focusPanelType) String() string {
 		return "sidebarFocus"
 	case metadataFocus:
 		return "metadataFocus"
+	case previewFocus:
+		return "previewFocus"
 	default:
 		return common.InvalidTypeString
 	}

--- a/src/internal/ui/filemodel/render.go
+++ b/src/internal/ui/filemodel/render.go
@@ -21,7 +21,7 @@ func (m *Model) GetFilePreviewRender() string {
 		if m.FilePreview.IsLoading() {
 			return m.FilePreview.RenderText(FilePreviewLoadingText)
 		}
-		return m.FilePreview.GetContent()
+		return m.FilePreview.GetScrollRender()
 	}
 
 	// Placeholder resizing text till they get synced

--- a/src/internal/ui/helpmenu/data.go
+++ b/src/internal/ui/helpmenu/data.go
@@ -128,6 +128,11 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 			hotkeyWorkType: globalType,
 		},
 		{
+			hotkey:         common.Hotkeys.FocusOnPreview,
+			description:    "Focus on the file preview panel to scroll content",
+			hotkeyWorkType: globalType,
+		},
+		{
 			subTitle: "Panel movement",
 		},
 		{

--- a/src/internal/ui/preview/model.go
+++ b/src/internal/ui/preview/model.go
@@ -18,6 +18,11 @@ type Model struct {
 	contentWidth  int
 	contentHeight int
 
+	// Scroll state for text previews. lines is nil for non-text
+	// (image/directory) previews where scrolling doesn't apply.
+	renderIndex int
+	lines       []string
+
 	loading            bool
 	imagePreviewer     *filepreview.ImagePreviewer
 	batCmd             string

--- a/src/internal/ui/preview/model_utils.go
+++ b/src/internal/ui/preview/model_utils.go
@@ -1,6 +1,9 @@
 package preview
 
-import "log/slog"
+import (
+	"log/slog"
+	"strings"
+)
 
 func (m *Model) GetContent() string {
 	return m.content
@@ -24,6 +27,8 @@ func (m *Model) SetOpen(open bool) {
 
 func (m *Model) SetLocation(location string) {
 	m.location = location
+	m.lines = nil
+	m.renderIndex = 0
 }
 
 func (m *Model) SetLoading() {
@@ -38,6 +43,7 @@ func (m *Model) setContent(content string, width int, height int, location strin
 	m.contentHeight = height
 	m.location = location
 	m.loading = false
+	m.resetScroll()
 }
 
 func (m *Model) SetEmptyWithDimensions(width int, height int) {
@@ -71,4 +77,70 @@ func (m *Model) Open() {
 
 func (m *Model) Close() {
 	m.open = false
+}
+func (m *Model) IsTextPreview() bool {
+	return m.lines != nil
+}
+
+func (m *Model) ScrollUp() {
+	if m.lines == nil || m.renderIndex <= 0 {
+		return
+	}
+	m.renderIndex--
+}
+
+func (m *Model) ScrollDown() {
+	if m.lines == nil {
+		return
+	}
+	maxIndex := len(m.lines) - m.contentHeight
+	if maxIndex < 0 {
+		maxIndex = 0
+	}
+	if m.renderIndex < maxIndex {
+		m.renderIndex++
+	}
+}
+
+func (m *Model) PgUp() {
+	if m.lines == nil {
+		return
+	}
+	m.renderIndex -= m.contentHeight
+	if m.renderIndex < 0 {
+		m.renderIndex = 0
+	}
+}
+
+func (m *Model) PgDown() {
+	if m.lines == nil {
+		return
+	}
+	maxIndex := len(m.lines) - m.contentHeight
+	if maxIndex < 0 {
+		maxIndex = 0
+	}
+	m.renderIndex += m.contentHeight
+	if m.renderIndex > maxIndex {
+		m.renderIndex = maxIndex
+	}
+}
+
+func (m *Model) resetScroll() {
+	m.renderIndex = 0
+}
+
+// GetScrollRender returns the currently visible window of a scrolled text preview.
+// For non-text previews it falls back to the pre-rendered content.
+func (m *Model) GetScrollRender() string {
+	if m.lines == nil {
+		return m.content
+	}
+	start := m.renderIndex
+	end := start + m.contentHeight
+	if end > len(m.lines) {
+		end = len(m.lines)
+	}
+	window := strings.Join(m.lines[start:end], "\n")
+	return m.RenderTextWithDimension(window, m.contentHeight, m.contentWidth)
 }

--- a/src/internal/ui/preview/render.go
+++ b/src/internal/ui/preview/render.go
@@ -1,15 +1,18 @@
 package preview
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"image"
 	"io/fs"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
@@ -101,19 +104,24 @@ func (m *Model) renderTextPreview(r *rendering.Renderer, itemPath string,
 		isText, err := common.IsTextFile(itemPath)
 		if err != nil {
 			slog.Error("Error while checking text file", "error", err)
+			m.lines = nil
 			return r.AddLines(renderPreviewError(err)).Render()
 		} else if !isText {
+			m.lines = nil
 			return r.AddLines(common.FilePreviewUnsupportedFormatText).Render()
 		}
 	}
 
-	fileContent, err := utils.ReadFileContent(itemPath, previewWidth, previewHeight)
+	// Read full file content (0 means no line limit).
+	fileContent, err := utils.ReadFileContent(itemPath, previewWidth, 0)
 	if err != nil {
 		slog.Error("Error open file", "error", err)
+		m.lines = nil
 		return r.AddLines(renderPreviewError(err)).Render()
 	}
 
 	if fileContent == "" {
+		m.lines = nil
 		return r.AddLines(common.FilePreviewEmptyText).Render()
 	}
 
@@ -124,21 +132,27 @@ func (m *Model) renderTextPreview(r *rendering.Renderer, itemPath string,
 		}
 		if common.Config.CodePreviewer == "bat" {
 			if m.batCmd == "" {
+				m.lines = nil
 				return r.AddLines(common.FilePreviewBatNotInstalledText).Render()
 			}
-			fileContent, err = getBatSyntaxHighlightedContent(itemPath, previewHeight, background, m.batCmd)
+			fileContent, err = getBatSyntaxHighlightedContentFull(itemPath, background, m.batCmd)
 		} else {
 			fileContent, err = ansichroma.HightlightString(fileContent, format.Config().Name,
 				common.Theme.CodeSyntaxHighlightTheme, background)
 		}
 		if err != nil {
 			slog.Error("Error render code highlight", "error", err)
+			m.lines = nil
 			return r.AddLines(renderPreviewError(err)).Render()
 		}
 	}
 
-	r.AddLines(fileContent)
-	return r.Render()
+	// Store all highlighted lines for scrolling
+	m.lines = strings.Split(fileContent, "\n")
+	m.renderIndex = 0
+
+	// Render the first window
+	return m.renderTextWindow(r, previewHeight)
 }
 
 // Only use this when height and width are synced with filemodel's expectations
@@ -219,4 +233,46 @@ func (m *Model) RenderWithPath(
 	}
 
 	return m.renderTextPreview(r, itemPath, contentWidth, contentHeight), kittyClear
+}
+
+// renderTextWindow renders the visible window of stored lines for a text preview.
+func (m *Model) renderTextWindow(r *rendering.Renderer, previewHeight int) string {
+	if m.lines == nil {
+		return ""
+	}
+	start := m.renderIndex
+	end := start + previewHeight
+	if end > len(m.lines) {
+		end = len(m.lines)
+	}
+	r.AddLines(strings.Join(m.lines[start:end], "\n"))
+	return r.Render()
+}
+
+// getBatSyntaxHighlightedContentFull runs bat without a line limit to get full
+// syntax-highlighted output for scrollable preview.
+func getBatSyntaxHighlightedContentFull(
+	itemPath string,
+	background string,
+	batCmd string,
+) (string, error) {
+	// --plain: no line numbers / decorations
+	// --force-colorization: force color for non-interactive output
+	batArgs := []string{itemPath, "--plain", "--force-colorization"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), common.DefaultPreviewTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, batCmd, batArgs...)
+	fileContentBytes, err := cmd.Output()
+	if err != nil {
+		slog.Error("Error render code highlight with bat (full)", "error", err)
+		return "", err
+	}
+
+	fileContent := string(fileContentBytes)
+	if !common.Config.TransparentBackground {
+		fileContent = setBatBackground(fileContent, background)
+	}
+	return fileContent, nil
 }

--- a/src/internal/ui/preview/render_utils.go
+++ b/src/internal/ui/preview/render_utils.go
@@ -1,9 +1,6 @@
 package preview
 
 import (
-	"context"
-	"fmt"
-	"log/slog"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -12,36 +9,6 @@ import (
 
 	"github.com/yorukot/superfile/src/internal/common"
 )
-
-func getBatSyntaxHighlightedContent(
-	itemPath string,
-	previewLine int,
-	background string,
-	batCmd string,
-) (string, error) {
-	// --plain: use the plain style without line numbers and decorations
-	// --force-colorization: force colorization for non-interactive shell output
-	// --line-range <:m>: only read from line 1 to line "m"
-	batArgs := []string{itemPath, "--plain", "--force-colorization", "--line-range", fmt.Sprintf(":%d", previewLine)}
-
-	// set timeout for the external command execution to 500ms max
-	ctx, cancel := context.WithTimeout(context.Background(), common.DefaultPreviewTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, batCmd, batArgs...)
-
-	fileContentBytes, err := cmd.Output()
-	if err != nil {
-		slog.Error("Error render code highlight", "error", err)
-		return "", err
-	}
-
-	fileContent := string(fileContentBytes)
-	if !common.Config.TransparentBackground {
-		fileContent = setBatBackground(fileContent, background)
-	}
-	return fileContent, nil
-}
 
 func setBatBackground(input string, background string) string {
 	tokens := strings.Split(input, "\x1b[0m")

--- a/src/internal/wheel_function.go
+++ b/src/internal/wheel_function.go
@@ -18,6 +18,8 @@ func wheelMainAction(msg string, m *model) {
 			action = func() { m.processBarModel.ListUp() }
 		case metadataFocus:
 			action = func() { m.fileMetaData.ListUp() }
+		case previewFocus:
+			action = func() { m.fileModel.FilePreview.ScrollUp() }
 		case nonePanelFocus:
 			action = func() { m.getFocusedFilePanel().ListUp() }
 		}
@@ -30,6 +32,8 @@ func wheelMainAction(msg string, m *model) {
 			action = func() { m.processBarModel.ListDown() }
 		case metadataFocus:
 			action = func() { m.fileMetaData.ListDown() }
+		case previewFocus:
+			action = func() { m.fileModel.FilePreview.ScrollDown() }
 		case nonePanelFocus:
 			action = func() { m.getFocusedFilePanel().ListDown() }
 		}
@@ -38,7 +42,11 @@ func wheelMainAction(msg string, m *model) {
 		return
 	}
 
-	for range common.WheelRunTime {
+	scrollLines := common.Config.WheelScrollSpeed
+	if scrollLines <= 0 {
+		return
+	}
+	for range scrollLines {
 		action()
 	}
 }

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -73,6 +73,11 @@ shell_close_on_success = false
 # Number of lines to scroll for PgUp/PgDown keys (0: full page, default behavior).
 page_scroll_size = 0
 
+#-- Wheel Scroll Speed
+# Lines to scroll per mouse wheel tick. Set to 0 to disable mouse wheel scrolling.
+# Recommended range: 1–20 (default: 5).
+wheel_scroll_speed = 5
+
 #-- Debug Mode
 debug = false
 

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -39,6 +39,7 @@ toggle_reverse_sort = ['R', '']
 focus_on_metadata = ['m', '']
 focus_on_process_bar = ['p', '']
 focus_on_sidebar = ['s', '']
+focus_on_preview = ['ctrl+f', '']
 
 #-- File/Dir Creation/Renaming
 file_panel_item_create = ['ctrl+n', '']

--- a/src/superfile_config/vimHotkeys.toml
+++ b/src/superfile_config/vimHotkeys.toml
@@ -41,6 +41,7 @@ toggle_reverse_sort = ['R', '']
 focus_on_process_bar = ['ctrl+p', '']
 focus_on_sidebar = ['ctrl+s', '']
 focus_on_metadata = ['ctrl+d', '']
+focus_on_preview = ['F', '']
 
 #-- File/Dir Creation/Renaming
 file_panel_item_create = ['a', '']


### PR DESCRIPTION
## Summary

The file preview panel currently truncates text/code content to the visible panel height with no way to scroll. This PR adds:

### Scrollable text preview
- Press `ctrl+f` (default) / `F` (vim) to focus the preview panel
- `j`/`k` scroll line-by-line, `PgUp`/`PgDn` page-by-page
- Mouse wheel / trackpad scrolls naturally
- Press the focus key again to return to the file panel
- Non-text previews (images, directories) are unaffected

**How it works:** `renderTextPreview` now reads the full file (line limit 0), syntax-highlights it, and stores the result as `[]string` lines. Each render frame, `GetScrollRender()` slices the visible window and re-renders through the existing `RenderTextWithDimension` pipeline.

### Configurable mouse wheel speed
- New `wheel_scroll_speed` config field (default 5, range 0–20)
- Replaces the hardcoded `WheelRunTime` constant
- Applies to all scrollable panels: sidebar, file panel, metadata, process bar, preview
- Set to 0 to disable mouse wheel scrolling entirely

### Implementation notes
- Follows the exact pattern established by `metadataFocus`/`sidebarFocus`/`processBarFocus` — a `previewFocus` panel type with a toggle function
- Scroll methods on `preview.Model` (`ScrollUp`, `ScrollDown`, `PgUp`, `PgDown`) mirror the metadata panel API
- All 13 test packages pass
- No breaking changes to existing config — `--fix-config-file` and `--fix-hotkeys` auto-add the new fields

## Files changed
| File | Change |
|---|---|
| `src/internal/ui/preview/model.go` | Added `renderIndex`, `lines` fields |
| `src/internal/ui/preview/model_utils.go` | Scroll methods, `GetScrollRender`, `IsTextPreview` |
| `src/internal/ui/preview/render.go` | Full-file read, `renderTextWindow`, `getBatSyntaxHighlightedContentFull` |
| `src/internal/ui/filemodel/render.go` | Uses `GetScrollRender` for text previews |
| `src/internal/type.go` | Added `previewFocus` to `focusPanelType` |
| `src/internal/handle_panel_navigation.go` | Added `focusOnPreview()` toggle |
| `src/internal/key_function.go` | Wired `previewFocus` into scroll keys + `FocusOnPreview` hotkey |
| `src/internal/wheel_function.go` | Config-driven wheel speed + `previewFocus` case |
| `src/internal/common/config_type.go` | `FocusOnPreview` hotkey + `WheelScrollSpeed` config |
| `src/internal/common/load_config.go` | Validation for `WheelScrollSpeed` |
| `src/internal/common/predefined_variable.go` | Removed hardcoded `WheelRunTime` |
| `src/superfile_config/config.toml` | Added `wheel_scroll_speed` |
| `src/superfile_config/hotkeys.toml` | Added `focus_on_preview` |
| `src/superfile_config/vimHotkeys.toml` | Added `focus_on_preview` (vim variant) |
| `src/internal/ui/helpmenu/data.go` | Help menu entry for new hotkey |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added line and page scrolling for text file previews (including keyboard Up/Down and PageUp/PageDown when the preview is focused).
  * Added a configurable mouse-wheel scroll speed (`wheel_scroll_speed`, default 5; set to `0` to disable; validated range 0–20).
  * Added hotkeys to focus the file preview panel (`Ctrl+F`, and `F` in Vim mode) plus help-menu documentation for the shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->