### PR TITLE
feat(config): add support for custom commands and hotkeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ CLAUDE.md
 spf.exe
 spf
 superfile.lnk
+spf.exe~
+spf~

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ testsuite/.venv/
 
 # Agent configs
 CLAUDE.md
+
+# Compiled files
+spf.exe
+spf
+superfile.lnk

--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -112,6 +112,8 @@ type ConfigType struct {
 	Metadata          bool `toml:"metadata"            comment:"\n==========PLUGINS========== #\nPlugins means that you need to install some external dependencies to use them.\n\nShow more detailed metadata, please install exiftool before enabling this plugin!"`
 	EnableMD5Checksum bool `toml:"enable_md5_checksum" comment:"Enable MD5 checksum generation for files"`
 	ZoxideSupport     bool `toml:"zoxide_support"      comment:"Zoxide support for the fast navigation"`
+
+	CustomCommands map[string][]string `toml:"custom_commands"`
 }
 
 // GetIgnoreMissingFields reports whether warnings about missing TOML fields should be ignored.
@@ -180,4 +182,6 @@ type HotkeysType struct {
 	FilePanelSelectModeItemsSelectDown []string `toml:"file_panel_select_mode_items_select_down" comment:"=================================================================================================\nSelect mode hotkeys (can conflict with other modes, cannot conflict with global hotkeys)"`
 	FilePanelSelectModeItemsSelectUp   []string `toml:"file_panel_select_mode_items_select_up"`
 	FilePanelSelectAllItem             []string `toml:"file_panel_select_all_items"`
+
+	CustomHotkeys map[string][]string `toml:"custom_hotkeys"`
 }

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -162,6 +162,22 @@ func LoadHotkeysFile(ignoreMissingFields bool) {
 		field := val.Type().Field(i)
 		value := val.Field(i)
 
+		// Handle custom hotkeys separately
+		if field.Name == "CustomHotkeys" {
+			// Validate only the keybindings defined by the user
+			for keyName, keys := range Hotkeys.CustomHotkeys {
+				if len(keys) == 0 || keys[0] == "" {
+					utils.PrintlnAndExit(
+						LoadHotkeysError(
+							"CustomHotkeys."+keyName,
+							"Hotkey list is empty; at least one key binding is required.",
+						),
+					)
+				}
+			}
+			continue // Skip the standard slice validation for this map field
+		}
+
 		// Although this is redundant as Hotkey is always a slice
 		// This adds a layer against accidental struct modifications
 		// Makes sure its always be a string slice. It's somewhat like a unit test

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -164,8 +164,9 @@ func LoadHotkeysFile(ignoreMissingFields bool) {
 
 		// Handle custom hotkeys separately
 		if field.Name == "CustomHotkeys" {
-			// Validate only the keybindings defined by the user
+			seenKeys := make(map[string]string) // map of keybinding -> commandName
 			for keyName, keys := range Hotkeys.CustomHotkeys {
+				// 1. Ensure the custom hotkey list is not empty
 				if len(keys) == 0 || keys[0] == "" {
 					utils.PrintlnAndExit(
 						LoadHotkeysError(
@@ -173,6 +174,29 @@ func LoadHotkeysFile(ignoreMissingFields bool) {
 							"Hotkey list is empty; at least one key binding is required.",
 						),
 					)
+				}
+
+				// 2. Ensure the custom hotkey references an existing custom command
+				if _, exists := Config.CustomCommands[keyName]; !exists {
+					utils.PrintlnAndExit(
+						LoadHotkeysError(
+							"CustomHotkeys."+keyName,
+							"No matching custom command found in config.toml.",
+						),
+					)
+				}
+
+				// 3. Prevent duplicate keybindings across custom hotkeys
+				for _, key := range keys {
+					if existingCmd, duplicate := seenKeys[key]; duplicate {
+						utils.PrintlnAndExit(
+							LoadHotkeysError(
+								"CustomHotkeys."+keyName,
+								"Duplicate keybinding '"+key+"' is already assigned to custom command '"+existingCmd+"'.",
+							),
+						)
+					}
+					seenKeys[key] = keyName
 				}
 			}
 			continue // Skip the standard slice validation for this map field

--- a/src/internal/custom_command.go
+++ b/src/internal/custom_command.go
@@ -1,0 +1,96 @@
+package internal
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/ui/notify"
+)
+
+// executeCustomCommand executes a custom command defined in CustomCommands.
+// The first element of the array must be either "foreground" or "background".
+func (m *model) executeCustomCommand(cmdName string) tea.Cmd {
+	rawArgs, ok := common.Config.CustomCommands[cmdName]
+	if !ok || len(rawArgs) < 2 {
+		return m.warnModalForCustomCommand("Configuration Error", "Command '"+cmdName+"' is not found or invalid in config.toml.")
+	}
+
+	mode := rawArgs[0]
+	cmdPayload := rawArgs[1:]
+
+	switch mode {
+	case "background":
+		c := m.prepareCommand(cmdPayload)
+		if c == nil {
+			return m.warnModalForCustomCommand("Execution Error", "Failed to resolve selected file path for '"+cmdName+"'.")
+		}
+
+		err := c.Start()
+		if err != nil {
+			return m.warnModalForCustomCommand("Execution Error", "Failed to start command '"+cmdPayload[0]+"': "+err.Error())
+		}
+
+		go func() {
+			_ = c.Wait()
+		}()
+		return nil
+
+	case "foreground":
+		c := m.prepareCommand(cmdPayload)
+		if c == nil {
+			return m.warnModalForCustomCommand("Execution Error", "Failed to resolve selected file path for '"+cmdName+"'.")
+		}
+
+		return tea.ExecProcess(c, func(err error) tea.Msg {
+			if err != nil {
+				reqID := m.nextIoReqCnt()
+				notifyModel := notify.New(true,
+					"Execution Error",
+					"Failed to run command '"+cmdPayload[0]+"': "+err.Error(),
+					notify.NoAction)
+				return NewNotifyModalMsg(notifyModel, reqID)
+			}
+			return nil
+		})
+	}
+
+	return nil
+}
+
+// prepareCommand builds the exec.Cmd structure and replaces templates with file details.
+func (m *model) prepareCommand(rawArgs []string) *exec.Cmd {
+	panel := m.fileModel.GetFocusedFilePanel()
+	if panel.EmptyOrInvalid() {
+		return nil
+	}
+
+	selectedItem := panel.GetFocusedItem()
+	selectedFile := selectedItem.Location
+	fileName := filepath.Base(selectedFile)
+	selectedDir := panel.Location
+
+	processedArgs := make([]string, len(rawArgs))
+	for i, arg := range rawArgs {
+		arg = strings.ReplaceAll(arg, "{filepath}", selectedFile)
+		arg = strings.ReplaceAll(arg, "{filename}", fileName)
+		arg = strings.ReplaceAll(arg, "{dir}", selectedDir)
+		processedArgs[i] = arg
+	}
+
+	return exec.Command(processedArgs[0], processedArgs[1:]...)
+}
+
+// warnModalForCustomCommand creates a tea.Cmd that displays a standard superfile warning modal.
+func (m *model) warnModalForCustomCommand(title string, content string) tea.Cmd {
+	reqID := m.nextIoReqCnt()
+	return func() tea.Msg {
+		notifyModel := notify.New(true,
+			title,
+			content,
+			notify.NoAction)
+		return NewNotifyModalMsg(notifyModel, reqID)
+	}
+}

--- a/src/internal/custom_command.go
+++ b/src/internal/custom_command.go
@@ -84,9 +84,11 @@ func (m *model) prepareCommand(rawArgs []string) *exec.Cmd {
 	}
 
 	selectedItem := panel.GetFocusedItem()
-	selectedFile := selectedItem.Location
+
+	// use filepath.ToSlash to convert '\' into '/' for Windows.
+	selectedFile := filepath.ToSlash(selectedItem.Location)
 	fileName := filepath.Base(selectedFile)
-	selectedDir := panel.Location
+	selectedDir := filepath.ToSlash(panel.Location)
 
 	// Shell injection prevention: escape arguments if explicitly invoking a POSIX shell
 	binary := rawArgs[0]

--- a/src/internal/custom_command.go
+++ b/src/internal/custom_command.go
@@ -78,6 +78,10 @@ func (m *model) executeCustomCommand(cmdName string) tea.Cmd {
 
 // prepareCommand builds the exec.Cmd structure and replaces templates with file details.
 func (m *model) prepareCommand(rawArgs []string) *exec.Cmd {
+	if len(rawArgs) == 0 {
+		return nil
+	}
+
 	panel := m.fileModel.GetFocusedFilePanel()
 	if panel.EmptyOrInvalid() {
 		return nil
@@ -96,24 +100,46 @@ func (m *model) prepareCommand(rawArgs []string) *exec.Cmd {
 
 	processedArgs := make([]string, len(rawArgs))
 	for i, arg := range rawArgs {
-		fileVal := selectedFile
-		nameVal := fileName
-		dirVal := selectedDir
-
-		// If running via shell, wrap placeholders in single quotes and escape existing single quotes
 		if isShell {
-			fileVal = "'" + strings.ReplaceAll(selectedFile, "'", "'\\''") + "'"
-			nameVal = "'" + strings.ReplaceAll(fileName, "'", "'\\''") + "'"
-			dirVal = "'" + strings.ReplaceAll(selectedDir, "'", "'\\''") + "'"
+			arg = replaceShellPlaceholder(arg, "{filepath}", selectedFile)
+			arg = replaceShellPlaceholder(arg, "{filename}", fileName)
+			arg = replaceShellPlaceholder(arg, "{dir}", selectedDir)
+		} else {
+			arg = strings.ReplaceAll(arg, "{filepath}", selectedFile)
+			arg = strings.ReplaceAll(arg, "{filename}", fileName)
+			arg = strings.ReplaceAll(arg, "{dir}", selectedDir)
 		}
-
-		arg = strings.ReplaceAll(arg, "{filepath}", fileVal)
-		arg = strings.ReplaceAll(arg, "{filename}", nameVal)
-		arg = strings.ReplaceAll(arg, "{dir}", dirVal)
 		processedArgs[i] = arg
 	}
 
 	return exec.Command(processedArgs[0], processedArgs[1:]...)
+}
+
+// replaceShellPlaceholder replaces a template placeholder in a shell command argument,
+// taking into account surrounding single or double quotes for proper escaping.
+func replaceShellPlaceholder(arg, placeholder, val string) string {
+	singleQuoted := "'" + placeholder + "'"
+	doubleQuoted := `"` + placeholder + `"`
+
+	if strings.Contains(arg, singleQuoted) {
+		// Surrounded by single quotes in arg: escape single quotes inside val, no extra outer quotes
+		escapedVal := strings.ReplaceAll(val, "'", "'\\''")
+		return strings.ReplaceAll(arg, singleQuoted, "'"+escapedVal+"'")
+	}
+
+	if strings.Contains(arg, doubleQuoted) {
+		// Surrounded by double quotes in arg: escape special double-quote characters (\, ", $, `)
+		escapedVal := val
+		escapedVal = strings.ReplaceAll(escapedVal, `\`, `\\`)
+		escapedVal = strings.ReplaceAll(escapedVal, `"`, `\"`)
+		escapedVal = strings.ReplaceAll(escapedVal, `$`, `\$`)
+		escapedVal = strings.ReplaceAll(escapedVal, "`", "\\`")
+		return strings.ReplaceAll(arg, doubleQuoted, `"`+escapedVal+`"`)
+	}
+
+	// Unquoted placeholder: wrap in single quotes and escape internal single quotes
+	escapedVal := "'" + strings.ReplaceAll(val, "'", "'\\''") + "'"
+	return strings.ReplaceAll(arg, placeholder, escapedVal)
 }
 
 // warnModalForCustomCommand creates a tea.Cmd that displays a standard superfile warning modal.

--- a/src/internal/custom_command.go
+++ b/src/internal/custom_command.go
@@ -94,17 +94,30 @@ func (m *model) prepareCommand(rawArgs []string) *exec.Cmd {
 	fileName := filepath.Base(selectedFile)
 	selectedDir := filepath.ToSlash(panel.Location)
 
-	// Shell injection prevention: escape arguments if explicitly invoking a POSIX shell
+	// Shell injection prevention: identify if invoking a POSIX shell
 	binary := rawArgs[0]
 	isShell := binary == "sh" || binary == "bash" || binary == "zsh" || binary == "dash"
 
+	// Find the shell command string index right after "-c" flag if present
+	shellCmdIdx := -1
+	if isShell {
+		for i, arg := range rawArgs {
+			if arg == "-c" && i+1 < len(rawArgs) {
+				shellCmdIdx = i + 1
+				break
+			}
+		}
+	}
+
 	processedArgs := make([]string, len(rawArgs))
 	for i, arg := range rawArgs {
-		if isShell {
+		if isShell && i == shellCmdIdx {
+			// Apply contextual shell quoting ONLY to the command string argument after -c
 			arg = replaceShellPlaceholder(arg, "{filepath}", selectedFile)
 			arg = replaceShellPlaceholder(arg, "{filename}", fileName)
 			arg = replaceShellPlaceholder(arg, "{dir}", selectedDir)
 		} else {
+			// Direct substitution for binary name, flags, script paths, and positional arguments
 			arg = strings.ReplaceAll(arg, "{filepath}", selectedFile)
 			arg = strings.ReplaceAll(arg, "{filename}", fileName)
 			arg = strings.ReplaceAll(arg, "{dir}", selectedDir)

--- a/src/internal/custom_command.go
+++ b/src/internal/custom_command.go
@@ -27,7 +27,6 @@ func (m *model) executeCustomCommand(cmdName string) tea.Cmd {
 			return m.warnModalForCustomCommand("Execution Error", "Failed to resolve selected file path for '"+cmdName+"'.")
 		}
 
-		// Return an asynchronous command to run the process and monitor exit status
 		return func() tea.Msg {
 			err := c.Start()
 			if err != nil {
@@ -39,7 +38,6 @@ func (m *model) executeCustomCommand(cmdName string) tea.Cmd {
 				return NewNotifyModalMsg(notifyModel, reqID)
 			}
 
-			// Wait for completion in background to catch any exit errors safely
 			err = c.Wait()
 			if err != nil {
 				reqID := m.nextIoReqCnt()
@@ -71,7 +69,6 @@ func (m *model) executeCustomCommand(cmdName string) tea.Cmd {
 		})
 
 	default:
-		// Explicitly handle unsupported execution modes instead of falling through silently
 		return m.warnModalForCustomCommand("Configuration Error", "Invalid mode '"+mode+"' for command '"+cmdName+"'. Must be 'foreground' or 'background'.")
 	}
 }
@@ -88,21 +85,19 @@ func (m *model) prepareCommand(rawArgs []string) *exec.Cmd {
 	}
 
 	selectedItem := panel.GetFocusedItem()
-
-	// use filepath.ToSlash to convert '\' into '/' for Windows.
 	selectedFile := filepath.ToSlash(selectedItem.Location)
 	fileName := filepath.Base(selectedFile)
 	selectedDir := filepath.ToSlash(panel.Location)
 
-	// Shell injection prevention: identify if invoking a POSIX shell
-	binary := rawArgs[0]
-	isShell := binary == "sh" || binary == "bash" || binary == "zsh" || binary == "dash"
+	binary := strings.ToLower(rawArgs[0])
+	isShell := binary == "sh" || binary == "bash" || binary == "zsh" || binary == "dash" || binary == "powershell" || binary == "pwsh"
 
-	// Find the shell command string index right after "-c" flag if present
+	// Find the shell command string index right after "-c" or "-command"
 	shellCmdIdx := -1
 	if isShell {
 		for i, arg := range rawArgs {
-			if arg == "-c" && i+1 < len(rawArgs) {
+			lowerArg := strings.ToLower(arg)
+			if (lowerArg == "-c" || lowerArg == "-command") && i+1 < len(rawArgs) {
 				shellCmdIdx = i + 1
 				break
 			}
@@ -112,12 +107,10 @@ func (m *model) prepareCommand(rawArgs []string) *exec.Cmd {
 	processedArgs := make([]string, len(rawArgs))
 	for i, arg := range rawArgs {
 		if isShell && i == shellCmdIdx {
-			// Apply contextual shell quoting ONLY to the command string argument after -c
 			arg = replaceShellPlaceholder(arg, "{filepath}", selectedFile)
 			arg = replaceShellPlaceholder(arg, "{filename}", fileName)
 			arg = replaceShellPlaceholder(arg, "{dir}", selectedDir)
 		} else {
-			// Direct substitution for binary name, flags, script paths, and positional arguments
 			arg = strings.ReplaceAll(arg, "{filepath}", selectedFile)
 			arg = strings.ReplaceAll(arg, "{filename}", fileName)
 			arg = strings.ReplaceAll(arg, "{dir}", selectedDir)
@@ -128,29 +121,18 @@ func (m *model) prepareCommand(rawArgs []string) *exec.Cmd {
 	return exec.Command(processedArgs[0], processedArgs[1:]...)
 }
 
-// replaceShellPlaceholder replaces a template placeholder in a shell command argument,
-// taking into account surrounding single or double quotes for proper escaping.
+// replaceShellPlaceholder safely substitutes placeholders in shell arguments.
 func replaceShellPlaceholder(arg, placeholder, val string) string {
-	singleQuoted := "'" + placeholder + "'"
-	doubleQuoted := `"` + placeholder + `"`
-
-	if strings.Contains(arg, singleQuoted) {
-		// Surrounded by single quotes in arg: escape single quotes inside val, no extra outer quotes
-		escapedVal := strings.ReplaceAll(val, "'", "'\\''")
-		return strings.ReplaceAll(arg, singleQuoted, "'"+escapedVal+"'")
+	if !strings.Contains(arg, placeholder) {
+		return arg
 	}
 
-	if strings.Contains(arg, doubleQuoted) {
-		// Surrounded by double quotes in arg: escape special double-quote characters (\, ", $, `)
-		escapedVal := val
-		escapedVal = strings.ReplaceAll(escapedVal, `\`, `\\`)
-		escapedVal = strings.ReplaceAll(escapedVal, `"`, `\"`)
-		escapedVal = strings.ReplaceAll(escapedVal, `$`, `\$`)
-		escapedVal = strings.ReplaceAll(escapedVal, "`", "\\`")
-		return strings.ReplaceAll(arg, doubleQuoted, `"`+escapedVal+`"`)
+	// If placeholder is already enclosed in quotes, substitute directly without adding extra quotes
+	if strings.Contains(arg, `"`+placeholder+`"`) || strings.Contains(arg, `'`+placeholder+`'`) {
+		return strings.ReplaceAll(arg, placeholder, val)
 	}
 
-	// Unquoted placeholder: wrap in single quotes and escape internal single quotes
+	// Unquoted placeholder: safely wrap value in single quotes
 	escapedVal := "'" + strings.ReplaceAll(val, "'", "'\\''") + "'"
 	return strings.ReplaceAll(arg, placeholder, escapedVal)
 }

--- a/src/internal/custom_command.go
+++ b/src/internal/custom_command.go
@@ -11,7 +11,6 @@ import (
 )
 
 // executeCustomCommand executes a custom command defined in CustomCommands.
-// The first element of the array must be either "foreground" or "background".
 func (m *model) executeCustomCommand(cmdName string) tea.Cmd {
 	rawArgs, ok := common.Config.CustomCommands[cmdName]
 	if !ok || len(rawArgs) < 2 {
@@ -28,15 +27,30 @@ func (m *model) executeCustomCommand(cmdName string) tea.Cmd {
 			return m.warnModalForCustomCommand("Execution Error", "Failed to resolve selected file path for '"+cmdName+"'.")
 		}
 
-		err := c.Start()
-		if err != nil {
-			return m.warnModalForCustomCommand("Execution Error", "Failed to start command '"+cmdPayload[0]+"': "+err.Error())
-		}
+		// Return an asynchronous command to run the process and monitor exit status
+		return func() tea.Msg {
+			err := c.Start()
+			if err != nil {
+				reqID := m.nextIoReqCnt()
+				notifyModel := notify.New(true,
+					"Execution Error",
+					"Failed to start command '"+cmdPayload[0]+"': "+err.Error(),
+					notify.NoAction)
+				return NewNotifyModalMsg(notifyModel, reqID)
+			}
 
-		go func() {
-			_ = c.Wait()
-		}()
-		return nil
+			// Wait for completion in background to catch any exit errors safely
+			err = c.Wait()
+			if err != nil {
+				reqID := m.nextIoReqCnt()
+				notifyModel := notify.New(true,
+					"Execution Error",
+					"Command '"+cmdPayload[0]+"' exited with error: "+err.Error(),
+					notify.NoAction)
+				return NewNotifyModalMsg(notifyModel, reqID)
+			}
+			return nil
+		}
 
 	case "foreground":
 		c := m.prepareCommand(cmdPayload)
@@ -55,9 +69,11 @@ func (m *model) executeCustomCommand(cmdName string) tea.Cmd {
 			}
 			return nil
 		})
-	}
 
-	return nil
+	default:
+		// Explicitly handle unsupported execution modes instead of falling through silently
+		return m.warnModalForCustomCommand("Configuration Error", "Invalid mode '"+mode+"' for command '"+cmdName+"'. Must be 'foreground' or 'background'.")
+	}
 }
 
 // prepareCommand builds the exec.Cmd structure and replaces templates with file details.
@@ -72,11 +88,26 @@ func (m *model) prepareCommand(rawArgs []string) *exec.Cmd {
 	fileName := filepath.Base(selectedFile)
 	selectedDir := panel.Location
 
+	// Shell injection prevention: escape arguments if explicitly invoking a POSIX shell
+	binary := rawArgs[0]
+	isShell := binary == "sh" || binary == "bash" || binary == "zsh" || binary == "dash"
+
 	processedArgs := make([]string, len(rawArgs))
 	for i, arg := range rawArgs {
-		arg = strings.ReplaceAll(arg, "{filepath}", selectedFile)
-		arg = strings.ReplaceAll(arg, "{filename}", fileName)
-		arg = strings.ReplaceAll(arg, "{dir}", selectedDir)
+		fileVal := selectedFile
+		nameVal := fileName
+		dirVal := selectedDir
+
+		// If running via shell, wrap placeholders in single quotes and escape existing single quotes
+		if isShell {
+			fileVal = "'" + strings.ReplaceAll(selectedFile, "'", "'\\''") + "'"
+			nameVal = "'" + strings.ReplaceAll(fileName, "'", "'\\''") + "'"
+			dirVal = "'" + strings.ReplaceAll(selectedDir, "'", "'\\''") + "'"
+		}
+
+		arg = strings.ReplaceAll(arg, "{filepath}", fileVal)
+		arg = strings.ReplaceAll(arg, "{filename}", nameVal)
+		arg = strings.ReplaceAll(arg, "{dir}", dirVal)
 		processedArgs[i] = arg
 	}
 

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -23,6 +23,15 @@ import (
 // TODO: This function has grown too big. It needs to be fixed, via major
 // updates and fixes in key handling code
 func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,gocognit // See above
+	// Custom hotkeys support
+	for cmdName, keys := range common.Hotkeys.CustomHotkeys {
+		for _, key := range keys {
+			if msg == key {
+				return m.executeCustomCommand(cmdName)
+			}
+		}
+	}
+
 	switch {
 	// If move up Key is pressed, check the current state and executes
 	case slices.Contains(common.Hotkeys.ListUp, msg):

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -219,5 +219,3 @@ zoxide_support = false
 #   4. Run an interactive command in classic Command Prompt (CMD):
 #      cmd_echo = ["foreground", "cmd.exe", "/C", "echo Selected: {filepath} && pause"]
 [custom_commands]
-# zellij_edit = ["zellij-editor", "{filepath}"]
-# run_script = ["bash", "./someshell.sh", "{filepath}"]

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -179,3 +179,45 @@ zoxide_support = false
 #   pdf = "zathura"
 #   conf = "nvim"
 [open_with]
+
+#-- Custom commands
+# Define custom command templates that can be triggered by hotkeys.
+#
+# Format: An array of strings where:
+#   - The first element MUST be either "foreground" or "background"
+#   - The second element is the executable/shell
+#   - The remaining elements are the arguments
+#
+# Execution Modes:
+#   "foreground" - Suspends superfile and runs the command interactively.
+#   "background" - Runs the command in the background without interrupting superfile.
+#
+# Available placeholders:
+#   {filepath} - Full path to the selected item (e.g., /home/user/docs/file.txt)
+#   {filename} - Name of the selected item only (e.g., file.txt)
+#   {dir}      - Path to the current active directory (e.g., /home/user/docs)
+#
+# MUST BE IN THE VERY END OF THE FILE BECAUSE TOML CANNOT CLOSE TABLES
+#
+# Examples for Linux & macOS:
+#   1. Run a script in background (extremely fast, no flickering):
+#      zellij_edit = ["background", "zellij-editor", "{filepath}"]
+#   2. Open file in an interactive terminal editor (Helix):
+#      helix_edit = ["foreground", "hx", "{filepath}"]
+#   3. Execute a local bash script in background:
+#      run_bash = ["background", "bash", "./my-script.sh", "{filepath}"]
+#   4. Run complex shell commands using sh (interactive):
+#      show_info = ["foreground", "sh", "-c", "echo 'Selected: {filename} in {dir}' && read -p 'Press Enter to close...'"]
+#
+# Examples for Windows:
+#   1. Launch a GUI application in background (e.g., VS Code):
+#      vscode = ["background", "code", "{filepath}"]
+#   2. Run an interactive terminal editor (Neovim):
+#      nvim_edit = ["foreground", "nvim", "{filepath}"]
+#   3. Run a command in PowerShell in background:
+#      ps_echo = ["background", "powershell.exe", "-NoProfile", "-Command", "Write-Host 'Processing {filename}...'; Start-Sleep -Seconds 2"]
+#   4. Run an interactive command in classic Command Prompt (CMD):
+#      cmd_echo = ["foreground", "cmd.exe", "/C", "echo Selected: {filepath} && pause"]
+[custom_commands]
+# zellij_edit = ["zellij-editor", "{filepath}"]
+# run_script = ["bash", "./someshell.sh", "{filepath}"]


### PR DESCRIPTION
### Description
This PR introduces support for user-defined custom commands and hotkeys, allowing users to integrate external tools (like scripts, editors, or multiplexer commands) directly into `superfile`.

### Key Features
- Added `[custom_commands]` table in `config.toml` where commands can be defined.
- Added `[custom_hotkeys]` table in `hotkeys.toml` to bind keys to custom commands.
- Supports two execution modes (defined as the first element of the command array):
  - `"foreground"`: Suspends the TUI and runs the command interactively (ideal for terminal editors like Helix/Neovim).
  - `"background"`: Runs the command asynchronously in the background without terminal interruption (ideal for scripts, opening files in new terminal panes/tabs, or launching GUI apps).
- Available placeholders for arguments: `{filepath}`, `{filename}`, and `{dir}`.
- Built-in error handling: If a custom command fails to execute, a beautiful native warning modal is displayed inside the `superfile` UI instead of silent logging or crashing.

### Validation Checklist
- [x] I have run `go fmt ./...` on the modified files.
- [x] I have verified the code passes `golangci-lint run`.
- [x] I have tested both background and foreground executions on Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable custom commands and custom hotkey bindings.
  * Custom commands can run in the foreground or background and use `{filepath}`, `{filename}`, and `{dir}` placeholders.
  * Custom hotkeys now trigger configured commands immediately.

* **Documentation**
  * Added configuration templates and examples for custom commands, execution modes, and placeholders.

* **Bug Fixes**
  * Improved validation for empty, invalid, missing, or duplicate custom hotkey definitions.
  * Added notifications when custom commands fail to start, run, or complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->