### PR TITLE
fix(rendering): stop flagging renders without visible content as inconsistent

### DIFF
--- a/src/internal/ui/rendering/renderer_core.go
+++ b/src/internal/ui/rendering/renderer_core.go
@@ -70,6 +70,17 @@ func (r *Renderer) actualContentHeight() int {
 	return r.committedContentHeight + r.contentSections[r.curSectionIdx].CntLines()
 }
 
+// A render with no visible characters occupies no lines. An empty render still carries the
+// ANSI style codes of its colors, so counting newlines would report it as one line and
+// wrongly flag renderers with zero height as inconsistent.
+// maxWidth is the widest visible line of res.
+func renderedLineCount(res string, maxWidth int) int {
+	if maxWidth == 0 && !strings.Contains(res, "\n") {
+		return 0
+	}
+	return strings.Count(res, "\n") + 1
+}
+
 // Should not do any updates on 'r'
 func (r *Renderer) Render() string {
 	content := strings.Builder{}
@@ -97,7 +108,7 @@ func (r *Renderer) Render() string {
 		maxW = max(maxW, ansi.StringWidth(line))
 	}
 
-	lineCnt := strings.Count(res, "\n") + 1
+	lineCnt := renderedLineCount(res, maxW)
 	if maxW > r.totalWidth || lineCnt > r.totalHeight {
 		slog.Error(
 			"Rendered output data inconsistency",

--- a/src/internal/ui/rendering/renderer_test.go
+++ b/src/internal/ui/rendering/renderer_test.go
@@ -88,6 +88,27 @@ func TestRendererBasic(t *testing.T) {
 	})
 }
 
+func TestRenderedLineCount(t *testing.T) {
+	testdata := []struct {
+		name     string
+		res      string
+		maxWidth int
+		expected int
+	}{
+		{"Empty render occupies no lines", "", 0, 0},
+		{"Style codes without visible text", "\x1b[38;2;255;255;255;48;2;0;0;0m\x1b[m", 0, 0},
+		{"Single line", "L1", 2, 1},
+		{"Single empty line", "\n", 0, 2},
+		{"Multiple lines", "L1\nL2\nL3", 2, 3},
+		{"Trailing newline", "L1\n", 2, 2},
+	}
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, renderedLineCount(tt.res, tt.maxWidth))
+		})
+	}
+}
+
 func TestSections(t *testing.T) {
 	sectionTests := []struct {
 		name           string


### PR DESCRIPTION
# Description

Every startup logs an ERROR for the file preview panel, even when everything renders correctly:

```text
level=ERROR msg="Rendered output data inconsistency" name=R-962-preview lineCnt=1 totalHeight=0 totalWidth=0 maxW=0
```

The post-render validation in `Renderer.Render()` counts lines with `strings.Count(res, "\n") + 1`, which returns `1` even when the render contains no visible characters. The file preview renderer is built with zero dimensions before the terminal size is known, so `lineCnt > r.totalHeight` (`1 > 0`) is always true and the check fires on a render that is in fact correct.

Checking `res == ""` is not enough: a zero-size render is not an empty string, it still carries the ANSI style codes of the panel colors.

```go
lipgloss.NewStyle().Width(0).Height(0).
    Foreground(...).Background(...).Render("")
// "\x1b[38;2;255;255;255;48;2;0;0;0m\x1b[m" -> len 33, visible width 0
```

This PR counts a render with no visible characters as zero lines, using the visible width that the validation already computes just above, so there is no extra pass over the output. Rendered output is unchanged: capturing a full frame in a 130x40 pty before and after the change gives byte-identical results.

Side note: `preview.RenderTextWithDimension` already guards against zero dimensions with the comment *"Its kinda hack, but its to prevent error logs"*. I left that call site untouched to keep this change minimal, but with the validation fixed it is no longer needed to silence the log. The path that produces the log above is `RenderWithPath`, which has no such guard.

# Related Issues

Related to #1512 — that report contains this same log line. Note this PR only removes the misleading log; it does **not** address the freeze described in that issue.

# Screenshots (Optional)

N/A — no visual change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering behavior for empty or styling-only output, preventing it from being treated as occupying an extra line.
  * Fixed line-count validation and truncation for rendered content with blank output or trailing newlines.

* **Tests**
  * Added coverage for empty, styled, single-line, multi-line, and trailing-newline rendering cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->