### PR TITLE
fix: preserve files when cutting duplicate names

### DIFF
--- a/src/internal/file_operations.go
+++ b/src/internal/file_operations.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -54,14 +55,16 @@ func moveElement(src, dst string) error {
 
 	// If on the same partition, attempt to rename (which will use the same inode)
 	if sameDev {
-		if err = os.Rename(src, dst); err == nil {
+		if err = renameNoReplace(src, dst); err == nil {
 			return nil
 		}
-		// If rename fails, fall back to copy+delete
+		if errors.Is(err, os.ErrExist) {
+			return err
+		}
 	}
 
-	// If on different partitions or rename failed, fall back to copy+delete
-	err = copyElement(src, dst)
+	// If on different partitions, fall back to an exclusive copy+delete.
+	err = copyElementNoReplace(src, dst)
 	if err != nil {
 		return fmt.Errorf("failed to copy: %w", err)
 	}
@@ -71,6 +74,25 @@ func moveElement(src, dst string) error {
 		return fmt.Errorf("failed to remove source after copy: %w", err)
 	}
 
+	return nil
+}
+
+func copyElementNoReplace(src, dst string) (err error) {
+	stagingDir, err := os.MkdirTemp(filepath.Dir(dst), ".superfile-move-")
+	if err != nil {
+		return fmt.Errorf("failed to create staging directory: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(stagingDir))
+	}()
+
+	stagedDestination := filepath.Join(stagingDir, filepath.Base(dst))
+	if err = copyElement(src, stagedDestination); err != nil {
+		return fmt.Errorf("failed to stage copy: %w", err)
+	}
+	if err = renameNoReplace(stagedDestination, dst); err != nil {
+		return fmt.Errorf("failed to publish staged copy: %w", err)
+	}
 	return nil
 }
 

--- a/src/internal/file_operations_test.go
+++ b/src/internal/file_operations_test.go
@@ -1,0 +1,60 @@
+package internal
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMoveElementDoesNotReplaceConcurrentDestination(t *testing.T) {
+	tempDir := t.TempDir()
+	destination := filepath.Join(tempDir, "destination.txt")
+	sources := []string{
+		filepath.Join(tempDir, "first.txt"),
+		filepath.Join(tempDir, "second.txt"),
+	}
+	contents := []string{"first", "second"}
+	contentBySource := make(map[string]string, len(sources))
+	for index, source := range sources {
+		contentBySource[source] = contents[index]
+		require.NoError(t, os.WriteFile(source, []byte(contents[index]), 0o644))
+	}
+
+	type result struct {
+		source string
+		err    error
+	}
+	start := make(chan struct{})
+	results := make(chan result, len(sources))
+	for _, source := range sources {
+		go func() {
+			<-start
+			results <- result{source: source, err: moveElement(source, destination)}
+		}()
+	}
+	close(start)
+
+	var succeeded, rejected result
+	for range sources {
+		moveResult := <-results
+		if moveResult.err == nil {
+			succeeded = moveResult
+		} else {
+			rejected = moveResult
+		}
+	}
+
+	require.NotEmpty(t, succeeded.source)
+	require.NotEmpty(t, rejected.source)
+	assert.True(t, errors.Is(rejected.err, os.ErrExist), rejected.err)
+	_, err := os.Stat(succeeded.source)
+	assert.True(t, os.IsNotExist(err))
+	assert.FileExists(t, rejected.source)
+	destinationContents, err := os.ReadFile(destination)
+	require.NoError(t, err)
+	assert.Equal(t, contentBySource[succeeded.source], string(destinationContents))
+}

--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -433,6 +433,27 @@ func TestPasteItem(t *testing.T) {
 		// Verify duplicate file with different name
 		verifyDestinationFiles(t, destDir, []string{"duplicate(1).txt"})
 	})
+
+	t.Run("Cut Duplicate File Handling", func(t *testing.T) {
+		source := filepath.Join(sourceDir, "cut-duplicate.txt")
+		destination := filepath.Join(destDir, "cut-duplicate.txt")
+		duplicate := filepath.Join(destDir, "cut-duplicate(1).txt")
+		require.NoError(t, os.WriteFile(source, []byte("source"), 0o644))
+		require.NoError(t, os.WriteFile(destination, []byte("destination"), 0o644))
+
+		m := setupModelAndPerformOperation(t, sourceDir, false, "cut-duplicate.txt", nil, true)
+		p := NewTestTeaProgWithEventLoop(t, m)
+		navigateToTargetDir(t, m, sourceDir, destDir)
+		p.SendKey(common.Hotkeys.PasteItems[0])
+
+		assert.Eventually(t, func() bool {
+			existing, existingErr := os.ReadFile(destination)
+			moved, movedErr := os.ReadFile(duplicate)
+			_, sourceErr := os.Stat(source)
+			return existingErr == nil && movedErr == nil && os.IsNotExist(sourceErr) &&
+				string(existing) == "destination" && string(moved) == "source"
+		}, DefaultTestTimeout, DefaultTestTick)
+	})
 }
 
 // ------  Very specific utilities that are required for this test case file only

--- a/src/internal/handle_file_operation_test.go
+++ b/src/internal/handle_file_operation_test.go
@@ -437,9 +437,11 @@ func TestPasteItem(t *testing.T) {
 	t.Run("Cut Duplicate File Handling", func(t *testing.T) {
 		source := filepath.Join(sourceDir, "cut-duplicate.txt")
 		destination := filepath.Join(destDir, "cut-duplicate.txt")
-		duplicate := filepath.Join(destDir, "cut-duplicate(1).txt")
+		firstDuplicate := filepath.Join(destDir, "cut-duplicate(1).txt")
+		secondDuplicate := filepath.Join(destDir, "cut-duplicate(2).txt")
 		require.NoError(t, os.WriteFile(source, []byte("source"), 0o644))
 		require.NoError(t, os.WriteFile(destination, []byte("destination"), 0o644))
+		require.NoError(t, os.WriteFile(firstDuplicate, []byte("first duplicate"), 0o644))
 
 		m := setupModelAndPerformOperation(t, sourceDir, false, "cut-duplicate.txt", nil, true)
 		p := NewTestTeaProgWithEventLoop(t, m)
@@ -448,10 +450,11 @@ func TestPasteItem(t *testing.T) {
 
 		assert.Eventually(t, func() bool {
 			existing, existingErr := os.ReadFile(destination)
-			moved, movedErr := os.ReadFile(duplicate)
+			first, firstErr := os.ReadFile(firstDuplicate)
+			moved, movedErr := os.ReadFile(secondDuplicate)
 			_, sourceErr := os.Stat(source)
-			return existingErr == nil && movedErr == nil && os.IsNotExist(sourceErr) &&
-				string(existing) == "destination" && string(moved) == "source"
+			return existingErr == nil && firstErr == nil && movedErr == nil && os.IsNotExist(sourceErr) &&
+				string(existing) == "destination" && string(first) == "first duplicate" && string(moved) == "source"
 		}, DefaultTestTimeout, DefaultTestTick)
 	})
 }

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -323,13 +323,17 @@ func makePasteProcessor(process processbar.Process,
 		var err error
 		for i, filePath := range items {
 			errMessage := "cut item error"
+			destination := filepath.Join(panelLocation, filepath.Base(filePath))
 			if cut && !isExternalDiskPath(filePath) {
-				err = moveElement(filePath, filepath.Join(panelLocation, filepath.Base(filePath)))
+				destination, err = renameIfDuplicate(destination)
+				if err == nil {
+					err = moveElement(filePath, destination)
+				}
 			} else {
 				// TODO : These error cases are hard to test. We have to somehow make the paste operations fail,
 				// which is time consuming and manual. We should test these with automated testcases
 				// UPD: use "chattr +i" for target catalog to fail past opeations
-				err = pasteDir(filePath, filepath.Join(panelLocation, filepath.Base(filePath)),
+				err = pasteDir(filePath, destination,
 					&process, cut, processBarModel)
 				if err != nil {
 					errMessage = "paste item error"

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -325,10 +325,7 @@ func makePasteProcessor(process processbar.Process,
 			errMessage := "cut item error"
 			destination := filepath.Join(panelLocation, filepath.Base(filePath))
 			if cut && !isExternalDiskPath(filePath) {
-				destination, err = renameIfDuplicate(destination)
-				if err == nil {
-					err = moveElement(filePath, destination)
-				}
+				err = moveElementToAvailableName(filePath, destination)
 			} else {
 				// TODO : These error cases are hard to test. We have to somehow make the paste operations fail,
 				// which is time consuming and manual. We should test these with automated testcases
@@ -360,6 +357,20 @@ func makePasteProcessor(process processbar.Process,
 		return process, notProcessed
 	}
 	return processorFunction
+}
+
+func moveElementToAvailableName(source, destination string) error {
+	for range 10_000 {
+		availableDestination, err := renameIfDuplicate(destination)
+		if err != nil {
+			return err
+		}
+		if err = moveElement(source, availableDestination); !errors.Is(err, os.ErrExist) {
+			return err
+		}
+	}
+
+	return fmt.Errorf("could not move %s without replacing an existing destination", source)
 }
 
 func (m *model) executePasteOperation(processBarModel *processbar.Model,

--- a/src/internal/rename_noreplace_darwin.go
+++ b/src/internal/rename_noreplace_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package internal
+
+import "golang.org/x/sys/unix"
+
+func renameNoReplace(src, dst string) error {
+	return unix.RenamexNp(src, dst, unix.RENAME_EXCL)
+}

--- a/src/internal/rename_noreplace_linux.go
+++ b/src/internal/rename_noreplace_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package internal
+
+import "golang.org/x/sys/unix"
+
+func renameNoReplace(src, dst string) error {
+	return unix.Renameat2(unix.AT_FDCWD, src, unix.AT_FDCWD, dst, unix.RENAME_NOREPLACE)
+}

--- a/src/internal/rename_noreplace_unsupported.go
+++ b/src/internal/rename_noreplace_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux && !windows
+
+package internal
+
+import "errors"
+
+func renameNoReplace(_, _ string) error {
+	return errors.ErrUnsupported
+}

--- a/src/internal/rename_noreplace_windows.go
+++ b/src/internal/rename_noreplace_windows.go
@@ -2,9 +2,41 @@
 
 package internal
 
-import "golang.org/x/sys/windows"
+import (
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func extendedLengthPath(path string) (string, error) {
+	path = strings.ReplaceAll(path, "/", `\`)
+
+	if path == "" || strings.HasPrefix(path, `\\?\`) || strings.HasPrefix(path, `\??\`) ||
+		strings.HasPrefix(path, `\\.\`) {
+		return path, nil
+	}
+
+	fullPath, err := windows.FullPath(path)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(fullPath, `\\`) {
+		return `\\?\UNC\` + strings.TrimPrefix(fullPath, `\\`), nil
+	}
+
+	return `\\?\` + fullPath, nil
+}
 
 func renameNoReplace(src, dst string) error {
+	src, err := extendedLengthPath(src)
+	if err != nil {
+		return err
+	}
+	dst, err = extendedLengthPath(dst)
+	if err != nil {
+		return err
+	}
+
 	srcPtr, err := windows.UTF16PtrFromString(src)
 	if err != nil {
 		return err

--- a/src/internal/rename_noreplace_windows.go
+++ b/src/internal/rename_noreplace_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package internal
+
+import "golang.org/x/sys/windows"
+
+func renameNoReplace(src, dst string) error {
+	srcPtr, err := windows.UTF16PtrFromString(src)
+	if err != nil {
+		return err
+	}
+	dstPtr, err := windows.UTF16PtrFromString(dst)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(srcPtr, dstPtr, 0)
+}

--- a/src/internal/rename_noreplace_windows_test.go
+++ b/src/internal/rename_noreplace_windows_test.go
@@ -1,0 +1,102 @@
+//go:build windows
+
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtendedLengthPath(t *testing.T) {
+	t.Run("local path", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "file.txt")
+		got, err := extendedLengthPath(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := `\\?\` + strings.ReplaceAll(path, "/", `\`)
+		if got != want {
+			t.Fatalf("extendedLengthPath(%q) = %q, want %q", path, got, want)
+		}
+	})
+
+	t.Run("UNC path", func(t *testing.T) {
+		const path = `\\server\share\directory\file.txt`
+		const want = `\\?\UNC\server\share\directory\file.txt`
+
+		got, err := extendedLengthPath(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("extendedLengthPath(%q) = %q, want %q", path, got, want)
+		}
+	})
+
+	for _, path := range []string{`\\?\C:\directory\file.txt`, `\??\C:\directory\file.txt`, `\\.\C:`} {
+		t.Run("preserves "+path[:4], func(t *testing.T) {
+			got, err := extendedLengthPath(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != path {
+				t.Fatalf("extendedLengthPath(%q) = %q, want unchanged", path, got)
+			}
+		})
+	}
+}
+
+func TestRenameNoReplaceSupportsLongPaths(t *testing.T) {
+	longDir := filepath.Join(
+		t.TempDir(),
+		strings.Repeat("a", 100),
+		strings.Repeat("b", 100),
+		strings.Repeat("c", 100),
+	)
+	if len(longDir) <= 260 {
+		t.Fatalf("test path length = %d, want more than MAX_PATH", len(longDir))
+	}
+	if err := os.MkdirAll(longDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	src := filepath.Join(longDir, "source.txt")
+	dst := filepath.Join(longDir, "destination.txt")
+	if err := os.WriteFile(src, []byte("source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := renameNoReplace(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "source" {
+		t.Fatalf("destination content = %q, want %q", content, "source")
+	}
+
+	if err := os.WriteFile(src, []byte("new source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := renameNoReplace(src, dst); err == nil {
+		t.Fatal("renameNoReplace replaced an existing destination")
+	}
+	content, err = os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "new source" {
+		t.Fatalf("source content after collision = %q, want %q", content, "new source")
+	}
+	content, err = os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "source" {
+		t.Fatalf("destination content after collision = %q, want %q", content, "source")
+	}
+}


### PR DESCRIPTION
# Description

Prevent cut/paste from overwriting an existing same-named file. The normal cut path now chooses the next free filename before moving the source, matching copy behavior.

Adds a UI-path regression test that preserves the original destination contents and moves the cut source to the numbered filename.

# Related Issues

None.

# Screenshots

Not applicable.

# Verification

`go test ./src/internal -run '^TestPasteItem$' -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cut-and-paste handling when a file with the same name already exists at the destination.
  * Preserves existing destination files while creating a uniquely named copy for the moved item.
  * Ensures the original cut source is removed after a successful move.
  * Prevents concurrent moves from overwriting each other, preserving the unsuccessful source.
  * Improved support for moving files using long paths on Windows.
* **Tests**
  * Added coverage for duplicate destinations, concurrent move operations, and long-path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->