### PR TITLE
fix(config): atomically replace repaired TOML files

### DIFF
--- a/src/pkg/utils/atomic_write.go
+++ b/src/pkg/utils/atomic_write.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func writeFileAtomically(
+	filePath string,
+	data []byte,
+	mode os.FileMode,
+) (resultErr error) { //nolint:nonamedreturns // Deferred close and cleanup failures must reach the caller.
+	tempFile, err := os.CreateTemp(filepath.Dir(filePath), "."+filepath.Base(filePath)+".tmp-")
+	if err != nil {
+		return fmt.Errorf("create replacement file: %w", err)
+	}
+	tempPath := tempFile.Name()
+	tempFileClosed := false
+	replacementPublished := false
+	defer func() {
+		if !tempFileClosed {
+			closeErr := tempFile.Close()
+			tempFileClosed = true
+			if closeErr != nil {
+				resultErr = errors.Join(resultErr, fmt.Errorf("close replacement file: %w", closeErr))
+			}
+		}
+		if !replacementPublished {
+			if removeErr := os.Remove(tempPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("remove replacement file: %w", removeErr))
+			}
+		}
+	}()
+
+	if err = tempFile.Chmod(mode); err != nil {
+		return fmt.Errorf("set replacement file permissions: %w", err)
+	}
+
+	n, err := tempFile.Write(data)
+	if err != nil {
+		return fmt.Errorf("write replacement file: %w", err)
+	}
+	if n != len(data) {
+		return fmt.Errorf("write replacement file: %w", io.ErrShortWrite)
+	}
+
+	if err = tempFile.Sync(); err != nil {
+		return fmt.Errorf("sync replacement file: %w", err)
+	}
+	err = tempFile.Close()
+	tempFileClosed = true
+	if err != nil {
+		return fmt.Errorf("close replacement file: %w", err)
+	}
+
+	if err = replaceFile(tempPath, filePath); err != nil {
+		return fmt.Errorf("publish replacement file: %w", err)
+	}
+	replacementPublished = true
+	return nil
+}

--- a/src/pkg/utils/atomic_write.go
+++ b/src/pkg/utils/atomic_write.go
@@ -12,7 +12,13 @@ func writeFileAtomically(
 	filePath string,
 	data []byte,
 	mode os.FileMode,
-) (resultErr error) { //nolint:nonamedreturns // Deferred close and cleanup failures must reach the caller.
+) (resultErr error) {
+	resolvedPath, err := filepath.EvalSymlinks(filePath)
+	if err != nil {
+		return fmt.Errorf("resolve replacement path: %w", err)
+	}
+	filePath = resolvedPath
+
 	tempFile, err := os.CreateTemp(filepath.Dir(filePath), "."+filepath.Base(filePath)+".tmp-")
 	if err != nil {
 		return fmt.Errorf("create replacement file: %w", err)

--- a/src/pkg/utils/atomic_write_test.go
+++ b/src/pkg/utils/atomic_write_test.go
@@ -25,3 +25,28 @@ func TestWriteFileAtomicallyRemovesReplacementAfterPublishFailure(t *testing.T) 
 	require.NoError(t, globErr)
 	assert.Empty(t, replacementFiles, "failed publication must remove its temporary replacement")
 }
+
+func TestWriteFileAtomicallyPreservesSymlinkAndReplacesTarget(t *testing.T) {
+	parentDir := t.TempDir()
+	targetDir := filepath.Join(parentDir, "config")
+	require.NoError(t, os.Mkdir(targetDir, 0o700))
+
+	targetPath := filepath.Join(targetDir, "config.toml")
+	require.NoError(t, os.WriteFile(targetPath, []byte("debug = false\n"), 0o640))
+
+	symlinkPath := filepath.Join(parentDir, "config.toml")
+	if err := os.Symlink(targetPath, symlinkPath); err != nil {
+		t.Skipf("creating symlinks is not supported in this environment: %v", err)
+	}
+
+	repairedData := []byte("debug = true\n")
+	require.NoError(t, writeFileAtomically(symlinkPath, repairedData, 0o640))
+
+	symlinkInfo, err := os.Lstat(symlinkPath)
+	require.NoError(t, err)
+	assert.NotZero(t, symlinkInfo.Mode()&os.ModeSymlink, "atomic replacement must preserve the symlink")
+
+	targetData, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, repairedData, targetData)
+}

--- a/src/pkg/utils/atomic_write_test.go
+++ b/src/pkg/utils/atomic_write_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteFileAtomicallyRemovesReplacementAfterPublishFailure(t *testing.T) {
+	parentDir := t.TempDir()
+	destinationDir := filepath.Join(parentDir, "config.toml")
+	require.NoError(t, os.Mkdir(destinationDir, 0o700))
+
+	err := writeFileAtomically(destinationDir, []byte("debug = true\n"), ConfigFilePerm)
+	require.Error(t, err)
+
+	info, statErr := os.Stat(destinationDir)
+	require.NoError(t, statErr)
+	assert.True(t, info.IsDir(), "failed publication must leave the destination unchanged")
+
+	replacementFiles, globErr := filepath.Glob(filepath.Join(parentDir, ".config.toml.tmp-*"))
+	require.NoError(t, globErr)
+	assert.Empty(t, replacementFiles, "failed publication must remove its temporary replacement")
+}

--- a/src/pkg/utils/file_utils.go
+++ b/src/pkg/utils/file_utils.go
@@ -125,10 +125,10 @@ func LoadTomlFile(filePath string, defaultData string, target interface{},
 	}
 
 	// Start fixing
-	return fixTomlFile(resultErr, filePath, target)
+	return fixTomlFile(resultErr, filePath, data, target)
 }
 
-func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) error {
+func fixTomlFile(resultErr *TomlLoadError, filePath string, originalData []byte, target interface{}) error {
 	resultErr.isFatal = true
 	// Create a unique backup of the current config file
 	backupFile, err := os.CreateTemp(filepath.Dir(filePath), filepath.Base(filePath)+".bak-")
@@ -140,42 +140,21 @@ func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) 
 	backupPath := backupFile.Name()
 	needsBackupFileRemoval := true
 	defer func() {
-		if backupFile != nil {
-			if closeErr := backupFile.Close(); closeErr != nil {
-				if resultErr.wrappedError == nil {
-					resultErr.UpdateMessageAndError("failed to close backup file", closeErr)
-				}
-			}
-		}
-		// Remove backup in case of unsuccessful write
-		if needsBackupFileRemoval {
-			if errRem := os.Remove(backupPath); errRem != nil {
-				// Modify result Error
-				resultErr.AddMessageAndError("warning: failed to remove backup file, backupPath : "+backupPath, errRem)
-			}
-		}
+		cleanupTomlBackup(resultErr, backupFile, backupPath, needsBackupFileRemoval)
 	}()
-	// Copy the original file to the backup.
-	origFile, err := os.Open(filePath)
+	originalInfo, err := os.Stat(filePath)
 	if err != nil {
-		resultErr.UpdateMessageAndError("failed to open original file for backup", err)
-		return resultErr
-	}
-	originalInfo, err := origFile.Stat()
-	if err != nil {
-		_ = origFile.Close()
 		resultErr.UpdateMessageAndError("failed to read original file permissions", err)
 		return resultErr
 	}
 
-	_, err = io.Copy(backupFile, origFile)
+	writtenBytes, err := backupFile.Write(originalData)
 	if err != nil {
-		_ = origFile.Close()
 		resultErr.UpdateMessageAndError("failed to copy original file to backup", err)
 		return resultErr
 	}
-	if err = origFile.Close(); err != nil {
-		resultErr.UpdateMessageAndError("failed to close original file after backup", err)
+	if writtenBytes != len(originalData) {
+		resultErr.UpdateMessageAndError("failed to copy original file to backup", io.ErrShortWrite)
 		return resultErr
 	}
 	if err = backupFile.Sync(); err != nil {
@@ -208,6 +187,24 @@ func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) 
 	needsBackupFileRemoval = false
 
 	return resultErr
+}
+
+func cleanupTomlBackup(
+	resultErr *TomlLoadError,
+	backupFile *os.File,
+	backupPath string,
+	needsRemoval bool,
+) {
+	if backupFile != nil {
+		if closeErr := backupFile.Close(); closeErr != nil && resultErr.wrappedError == nil {
+			resultErr.UpdateMessageAndError("failed to close backup file", closeErr)
+		}
+	}
+	if needsRemoval {
+		if removeErr := os.Remove(backupPath); removeErr != nil {
+			resultErr.AddMessageAndError("warning: failed to remove backup file, backupPath : "+backupPath, removeErr)
+		}
+	}
 }
 
 // If path is not absolute, then append to currentDir and get absolute path

--- a/src/pkg/utils/file_utils.go
+++ b/src/pkg/utils/file_utils.go
@@ -140,9 +140,11 @@ func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) 
 	backupPath := backupFile.Name()
 	needsBackupFileRemoval := true
 	defer func() {
-		if closeErr := backupFile.Close(); closeErr != nil {
-			if resultErr.wrappedError == nil {
-				resultErr.UpdateMessageAndError("failed to close backup file", closeErr)
+		if backupFile != nil {
+			if closeErr := backupFile.Close(); closeErr != nil {
+				if resultErr.wrappedError == nil {
+					resultErr.UpdateMessageAndError("failed to close backup file", closeErr)
+				}
 			}
 		}
 		// Remove backup in case of unsuccessful write
@@ -153,20 +155,39 @@ func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) 
 			}
 		}
 	}()
-	// Copy the original file to the backup
-	// Open it in read write mode
-	origFile, err := os.OpenFile(filePath, os.O_RDWR, ConfigFilePerm)
+	// Copy the original file to the backup.
+	origFile, err := os.Open(filePath)
 	if err != nil {
 		resultErr.UpdateMessageAndError("failed to open original file for backup", err)
 		return resultErr
 	}
-	defer origFile.Close()
+	originalInfo, err := origFile.Stat()
+	if err != nil {
+		_ = origFile.Close()
+		resultErr.UpdateMessageAndError("failed to read original file permissions", err)
+		return resultErr
+	}
 
 	_, err = io.Copy(backupFile, origFile)
 	if err != nil {
+		_ = origFile.Close()
 		resultErr.UpdateMessageAndError("failed to copy original file to backup", err)
 		return resultErr
 	}
+	if err = origFile.Close(); err != nil {
+		resultErr.UpdateMessageAndError("failed to close original file after backup", err)
+		return resultErr
+	}
+	if err = backupFile.Sync(); err != nil {
+		resultErr.UpdateMessageAndError("failed to sync backup file", err)
+		return resultErr
+	}
+	if err = backupFile.Close(); err != nil {
+		backupFile = nil
+		resultErr.UpdateMessageAndError("failed to close backup file", err)
+		return resultErr
+	}
+	backupFile = nil
 
 	tomlData, err := toml.Marshal(target)
 	if err != nil {
@@ -174,15 +195,8 @@ func fixTomlFile(resultErr *TomlLoadError, filePath string, target interface{}) 
 		return resultErr
 	}
 
-	// Truncate the file
-	if err = origFile.Truncate(0); err != nil {
-		resultErr.UpdateMessageAndError("failed to truncate TOML file", err)
-		return resultErr
-	}
-	// Write updated TOML to file
-	_, err = origFile.WriteAt(tomlData, 0)
-	if err != nil {
-		resultErr.UpdateMessageAndError("failed to write TOML data to original file", err)
+	if err = writeFileAtomically(filePath, tomlData, originalInfo.Mode().Perm()); err != nil {
+		resultErr.UpdateMessageAndError("failed to atomically replace TOML file", err)
 		return resultErr
 	}
 

--- a/src/pkg/utils/file_utils_test.go
+++ b/src/pkg/utils/file_utils_test.go
@@ -210,6 +210,42 @@ func TestLoadTomlFileFixOverwritesStaleTail(t *testing.T) {
 	assert.Equal(t, expectedVal, tomlVal)
 }
 
+func TestLoadTomlFileFixReplacesOriginalFile(t *testing.T) {
+	defaultData := strings.Join([]string{
+		"sample_bool = true",
+		"sample_int = 2",
+		"sample_str = \"default\"",
+		"sample_slice = ['a', 'b']",
+		"",
+	}, "\n")
+	originalContent := strings.Join([]string{
+		"sample_bool = false",
+		"sample_int = -1",
+		"sample_slice = ['custom']",
+		"",
+	}, "\n")
+
+	testFile := filepath.Join(t.TempDir(), "missing-field.toml")
+	require.NoError(t, os.WriteFile(testFile, []byte(originalContent), 0o640))
+
+	originalInfo, err := os.Stat(testFile)
+	require.NoError(t, err)
+
+	var tomlVal TestTOMLType
+	err = LoadTomlFile(testFile, defaultData, &tomlVal, true, false)
+	var tomlErr *TomlLoadError
+	require.ErrorAs(t, err, &tomlErr)
+	require.False(t, tomlErr.IsFatal())
+
+	repairedInfo, err := os.Stat(testFile)
+	require.NoError(t, err)
+
+	assert.False(t, os.SameFile(originalInfo, repairedInfo),
+		"repair must publish a replacement file instead of modifying the original in place")
+	assert.Equal(t, originalInfo.Mode().Perm(), repairedInfo.Mode().Perm(),
+		"repair must preserve the original file permissions")
+}
+
 func TestLoadTomlFileIgnorer(t *testing.T) {
 	_, curFilename, _, ok := runtime.Caller(0)
 	require.True(t, ok)

--- a/src/pkg/utils/replace_file_nonwindows.go
+++ b/src/pkg/utils/replace_file_nonwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package utils
+
+import "os"
+
+func replaceFile(replacementPath, replacedPath string) error {
+	return os.Rename(replacementPath, replacedPath)
+}

--- a/src/pkg/utils/replace_file_windows.go
+++ b/src/pkg/utils/replace_file_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package utils
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func replaceFile(replacementPath, replacedPath string) error {
+	replacedPathPtr, err := windows.UTF16PtrFromString(replacedPath)
+	if err != nil {
+		return err
+	}
+	replacementPathPtr, err := windows.UTF16PtrFromString(replacementPath)
+	if err != nil {
+		return err
+	}
+
+	result, _, callErr := windows.NewLazySystemDLL("kernel32.dll").NewProc("ReplaceFileW").Call(
+		uintptr(unsafe.Pointer(replacedPathPtr)),
+		uintptr(unsafe.Pointer(replacementPathPtr)),
+		0,
+		0,
+		0,
+		0,
+	)
+	if result == 0 {
+		if callErr != syscall.Errno(0) {
+			return callErr
+		}
+		return syscall.EINVAL
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

This PR changes the `--fix-config-file` repair process to replace repaired TOML configuration files atomically instead of truncating and rewriting the active file in place.

Previously, the repair process truncated the original configuration before writing the repaired content. If the write failed or the process was interrupted, the active configuration could be left empty or partially written.

The updated repair process now:

- Creates a temporary replacement file in the same directory as the original configuration.
- Preserves the original file permissions.
- Writes the complete repaired TOML to the replacement file.
- Detects incomplete writes.
- Syncs and closes the replacement file before publishing it.
- Syncs and closes the existing backup before replacing the configuration.
- Uses `os.Rename` for atomic replacement on non-Windows platforms.
- Uses the Windows `ReplaceFileW` API on Windows.
- Removes temporary replacement files when publication fails.
- Leaves the original configuration unchanged when replacement preparation fails.
- Preserves the existing backup behavior so users can restore their original configuration manually.

Platform-specific replacement logic is kept in separate files using Go build constraints, while the shared atomic-write workflow remains platform-independent.

Regression tests verify that:

- The repaired configuration is published as a replacement file rather than modifying the original file in place.
- The original file permissions are preserved.
- The repaired content fully replaces the previous file without leaving a stale tail.
- A failed publication leaves the destination unchanged.
- Temporary replacement files are removed after publication failures.
- The original configuration backup still contains the correct content.

# Related Issue

Fixes #1531

https://github.com/yorukot/superfile/issues/1531

# Screenshots

Not applicable. This change does not affect the user interface.

# Verification

The following checks pass:

- `go test ./... -count=1`
- `go test -race ./src/pkg/utils -count=1`
- `go vet ./...`
- `go build ./...`
- `golangci-lint run`
- `GOOS=windows GOARCH=amd64 go test -c ./src/pkg/utils`
- `git diff --check`

# Pre-Submission Checklist

- [x] All changed Go files have been formatted with `gofmt`
- [x] I have run `golangci-lint run` and fixed all reported issues
- [x] I have tested the changes and verified they work as expected
- [x] I have reviewed the diff for debug logs, TODOs, and unrelated changes
- [x] The PR title follows the Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - TOML repair operations now write updates atomically, lowering the chance of partial or corrupted files.
  - Repair-created files preserve the original file permissions.
  - Temporary artifacts from failed repairs are cleaned up, leaving the original content unchanged.
  - Symbolic links are preserved while updating the linked target contents.
  - File replacement is supported consistently on both Windows and non-Windows systems.
- **Tests**
  - Added coverage for symlink-safe atomic writes and for verifying TOML repairs replace (not modify) the original file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->