### PR TITLE
feat: background highlight cursor option

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -45,6 +45,8 @@ type ThemeType struct {
 	FilePanelTopPath          string `toml:"file_panel_top_path"`
 	FilePanelItemSelectedFG   string `toml:"file_panel_item_selected_fg"`
 	FilePanelItemSelectedBG   string `toml:"file_panel_item_selected_bg"`
+	FilePanelItemActiveFG     string `toml:"file_panel_item_active_fg"`
+	FilePanelItemActiveBG     string `toml:"file_panel_item_active_bg"`
 
 	// Sidebar Special Items
 	SidebarTitle          string `toml:"sidebar_title"`
@@ -92,6 +94,7 @@ type ConfigType struct {
 	Nerdfont                bool     `toml:"nerdfont"                   comment:"\n================   Style =================\n\n If you don't have or don't want Nerdfont installed you can turn this off"`
 	ShowSelectIcons         bool     `toml:"show_select_icons"          comment:"\nShow checkbox icons in select mode (requires nerdfont)"`
 	TransparentBackground   bool     `toml:"transparent_background"     comment:"\nSet transparent background or not (this only work when your terminal background is transparent)"`
+	CursorStyle             string   `toml:"cursor_style"               comment:"\nSet the cursor style. Valid values: \"arrow\", \"highlight\""`
 	FilePreviewWidth        int      `toml:"file_preview_width"         comment:"\nFile preview width allow '0' (this mean same as file panel),'x' x must be less than 10 and greater than 1 (This means that the width of the file preview will be one xth of the total width.)"`
 	EnableFilePreviewBorder bool     `toml:"enable_file_preview_border" comment:"\nEnable border around the file preview panel (default: false)"`
 	CodePreviewer           string   `toml:"code_previewer"             comment:"\nWhether to use the builtin syntax highlighting with chroma or use bat. Values: \"\" for builtin chroma, \"bat\" for bat"`

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
+	"strings"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/pelletier/go-toml/v2"
@@ -85,6 +87,14 @@ func ValidateConfig(c *ConfigType) error {
 		return errors.New(
 			LoadConfigError("file_panel_name_percent", "File panel name percent is outside the supported range."),
 		)
+	}
+
+	cursorOptions := []string{"arrow", "highlight"}
+	if !slices.Contains(cursorOptions, c.CursorStyle) {
+		return errors.New(LoadConfigError(
+			"cursor_style",
+			fmt.Sprintf("Invalid cursor style. Supported values: %s.", strings.Join(cursorOptions, ", ")),
+		))
 	}
 
 	if ansi.StringWidth(c.BorderTop) != 1 {

--- a/src/internal/common/load_config.go
+++ b/src/internal/common/load_config.go
@@ -89,7 +89,7 @@ func ValidateConfig(c *ConfigType) error {
 		)
 	}
 
-	cursorOptions := []string{"arrow", "highlight"}
+	cursorOptions := []string{CursorStyleArrow, CursorStyleHighlight}
 	if !slices.Contains(cursorOptions, c.CursorStyle) {
 		return errors.New(LoadConfigError(
 			"cursor_style",

--- a/src/internal/common/predefined_variable.go
+++ b/src/internal/common/predefined_variable.go
@@ -30,6 +30,12 @@ const (
 	PermanentDeleteWarnContent = "This operation cannot be undone and your data will be completely lost."
 )
 
+// Cursor style types
+const (
+	CursorStyleArrow     = "arrow"
+	CursorStyleHighlight = "highlight"
+)
+
 const (
 	MinimumHeight = 24
 	MinimumWidth  = 60

--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -107,7 +107,7 @@ func FilePanelItemRender(data string,
 	alignment lipgloss.Position,
 ) string {
 	outputData := ansi.Truncate(data, width, "...")
-	isActive = isActive && Config.CursorStyle == "highlight"
+	isActive = isActive && Config.CursorStyle == CursorStyleHighlight
 	style := FilePanelStyle
 	switch {
 	case isSelected && isActive:

--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -84,6 +84,7 @@ func FilePanelItemRenderWithIcon(
 	isDir bool,
 	isLink bool,
 	isSelected bool,
+	isActive bool,
 	bgColor color.Color,
 ) string {
 	style := GetElementIcon(name, isDir, isLink, Config.Nerdfont)
@@ -95,21 +96,28 @@ func FilePanelItemRenderWithIcon(
 		return ""
 	}
 	return StringColorRender(lipgloss.Color(style.Color), bgColor).
-		Background(bgColor).Render(iconData) +
-		FilePanelItemRender(name, filenameWidth, isSelected, bgColor, lipgloss.Left)
+		Render(iconData) +
+		FilePanelItemRender(name, filenameWidth, isSelected, isActive, lipgloss.Left)
 }
+
 func FilePanelItemRender(data string,
 	width int,
 	isSelected bool,
-	bgColor color.Color,
+	isActive bool,
 	alignment lipgloss.Position,
 ) string {
 	outputData := ansi.Truncate(data, width, "...")
+	isActive = isActive && Config.CursorStyle == "highlight"
 	style := FilePanelStyle
-	if isSelected {
+	switch {
+	case isSelected && isActive:
+		style = FilePanelItemSelectedActiveStyle
+	case isSelected:
 		style = FilePanelItemSelectedStyle
+	case isActive:
+		style = FilePanelItemActiveStyle
 	}
-	return style.Background(bgColor).Width(width).Align(alignment).Render(outputData)
+	return style.Width(width).Align(alignment).Render(outputData)
 }
 
 func ClipboardPrettierName(name string, width int, isDir bool, isLink bool, isSelected bool) string {

--- a/src/internal/common/style.go
+++ b/src/internal/common/style.go
@@ -23,9 +23,10 @@ var (
 )
 
 var (
-	SidebarDividerStyle  lipgloss.Style
-	SidebarTitleStyle    lipgloss.Style
-	SidebarSelectedStyle lipgloss.Style
+	SidebarDividerStyle        lipgloss.Style
+	SidebarTitleStyle          lipgloss.Style
+	SidebarSelectedStyle       lipgloss.Style
+	SidebarSelectedActiveStyle lipgloss.Style
 )
 
 var (
@@ -209,6 +210,8 @@ func LoadThemeConfig() { //nolint: funlen // Variable initialization
 	SidebarTitleStyle = lipgloss.NewStyle().Foreground(sidebarTitleColor).Background(SidebarBGColor)
 	SidebarSelectedStyle = lipgloss.NewStyle().Foreground(sidebarItemSelectedFGColor).
 		Background(sidebarItemSelectedBGColor)
+	SidebarSelectedActiveStyle = lipgloss.NewStyle().Foreground(sidebarItemSelectedFGColor).
+		Background(filePanelItemActiveBGColor)
 
 	// Footer Special Style
 	ProcessErrorStyle = lipgloss.NewStyle().Foreground(errorColor).Background(FooterBGColor)
@@ -221,6 +224,7 @@ func LoadThemeConfig() { //nolint: funlen // Variable initialization
 	ModalConfirm = lipgloss.NewStyle().Foreground(modalConfirmFGColor).Background(modalConfirmBGColor)
 	ModalTitleStyle = lipgloss.NewStyle().Foreground(hintColor).Background(ModalBGColor)
 	ModalErrorStyle = lipgloss.NewStyle().Foreground(errorColor).Background(ModalBGColor)
+
 	// Help Menu Style
 	HelpMenuHotkeyStyle = lipgloss.NewStyle().Foreground(helpMenuHotkeyColor).Background(ModalBGColor)
 	HelpMenuTitleStyle = lipgloss.NewStyle().Foreground(helpMenuTitleColor).Background(ModalBGColor)

--- a/src/internal/common/style.go
+++ b/src/internal/common/style.go
@@ -201,8 +201,10 @@ func LoadThemeConfig() { //nolint: funlen // Variable initialization
 	FilePanelTopPathStyle = lipgloss.NewStyle().Foreground(filePanelTopPathColor).Background(FilePanelBGColor)
 	FilePanelItemSelectedStyle = lipgloss.NewStyle().Foreground(filePanelItemSelectedFGColor).
 		Background(filePanelItemSelectedBGColor)
-	FilePanelItemActiveStyle = lipgloss.NewStyle().Foreground(filePanelItemActiveFGColor).Background(filePanelItemActiveBGColor)
-	FilePanelItemSelectedActiveStyle = lipgloss.NewStyle().Foreground(filePanelItemSelectedFGColor).Background(filePanelItemActiveBGColor)
+	FilePanelItemActiveStyle = lipgloss.NewStyle().Foreground(filePanelItemActiveFGColor).
+		Background(filePanelItemActiveBGColor)
+	FilePanelItemSelectedActiveStyle = lipgloss.NewStyle().Foreground(filePanelItemSelectedFGColor).
+		Background(filePanelItemActiveBGColor)
 	FilePanelSelectBoxStyle = lipgloss.NewStyle().Background(FilePanelBGColor)
 
 	// Sidebar Special Style

--- a/src/internal/common/style.go
+++ b/src/internal/common/style.go
@@ -35,10 +35,12 @@ var (
 )
 
 var (
-	FilePanelTopDirectoryIconStyle lipgloss.Style
-	FilePanelTopPathStyle          lipgloss.Style
-	FilePanelItemSelectedStyle     lipgloss.Style
-	FilePanelSelectBoxStyle        lipgloss.Style
+	FilePanelTopDirectoryIconStyle   lipgloss.Style
+	FilePanelTopPathStyle            lipgloss.Style
+	FilePanelItemSelectedStyle       lipgloss.Style
+	FilePanelItemActiveStyle         lipgloss.Style
+	FilePanelItemSelectedActiveStyle lipgloss.Style
+	FilePanelSelectBoxStyle          lipgloss.Style
 )
 
 var (
@@ -98,6 +100,8 @@ var (
 	filePanelTopPathColor          color.Color
 	filePanelItemSelectedFGColor   color.Color
 	filePanelItemSelectedBGColor   color.Color
+	filePanelItemActiveFGColor     color.Color
+	filePanelItemActiveBGColor     color.Color
 
 	sidebarTitleColor          color.Color
 	sidebarItemSelectedFGColor color.Color
@@ -150,6 +154,8 @@ func LoadThemeConfig() { //nolint: funlen // Variable initialization
 	filePanelTopPathColor = lipgloss.Color(Theme.FilePanelTopPath)
 	filePanelItemSelectedFGColor = lipgloss.Color(Theme.FilePanelItemSelectedFG)
 	filePanelItemSelectedBGColor = lipgloss.Color(Theme.FilePanelItemSelectedBG)
+	filePanelItemActiveFGColor = lipgloss.Color(Theme.FilePanelItemActiveFG)
+	filePanelItemActiveBGColor = lipgloss.Color(Theme.FilePanelItemActiveBG)
 
 	sidebarTitleColor = lipgloss.Color(Theme.SidebarTitle)
 	sidebarItemSelectedFGColor = lipgloss.Color(Theme.SidebarItemSelectedFG)
@@ -194,6 +200,8 @@ func LoadThemeConfig() { //nolint: funlen // Variable initialization
 	FilePanelTopPathStyle = lipgloss.NewStyle().Foreground(filePanelTopPathColor).Background(FilePanelBGColor)
 	FilePanelItemSelectedStyle = lipgloss.NewStyle().Foreground(filePanelItemSelectedFGColor).
 		Background(filePanelItemSelectedBGColor)
+	FilePanelItemActiveStyle = lipgloss.NewStyle().Foreground(filePanelItemActiveFGColor).Background(filePanelItemActiveBGColor)
+	FilePanelItemSelectedActiveStyle = lipgloss.NewStyle().Foreground(filePanelItemSelectedFGColor).Background(filePanelItemActiveBGColor)
 	FilePanelSelectBoxStyle = lipgloss.NewStyle().Background(FilePanelBGColor)
 
 	// Sidebar Special Style

--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -15,8 +15,9 @@ import (
 func (m *Model) renderFileName(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
+	isActive := indexElement == m.GetCursor() && !m.SearchBar.Focused()
 	cursor := emptyCursor
-	if indexElement == m.GetCursor() && !m.SearchBar.Focused() {
+	if isActive && common.Config.CursorStyle == "arrow" {
 		cursor = icon.Cursor
 	}
 
@@ -28,12 +29,14 @@ func (m *Model) renderFileName(indexElement int, columnWidth int) string {
 	if elem.Info != nil {
 		isLink = elem.Info.Mode()&os.ModeSymlink != 0
 	}
+
 	renderedName := common.FilePanelItemRenderWithIcon(
 		elem.Name,
 		columnWidth-prefixWidth,
 		elem.Directory,
 		isLink,
 		isSelected,
+		isActive,
 		common.FilePanelBGColor,
 	)
 	return common.FilePanelCursorStyle.Render(cursor+" ") + selectBox + renderedName
@@ -42,11 +45,12 @@ func (m *Model) renderFileName(indexElement int, columnWidth int) string {
 // The renderer of delimiter spaces. It has a strict fixed size that depends only on the delimiter string.
 func (m *Model) renderDelimiter(indexElement int, columnWidth int) string {
 	isSelected := m.CheckSelected(m.GetElementAtIdx(indexElement).Location)
+	isActive := indexElement == m.GetCursor() && !m.SearchBar.Focused()
 	return common.FilePanelItemRender(
 		ColumnDelimiter,
 		columnWidth,
 		isSelected,
-		common.FilePanelBGColor,
+		isActive,
 		lipgloss.Left,
 	)
 }
@@ -54,6 +58,7 @@ func (m *Model) renderDelimiter(indexElement int, columnWidth int) string {
 func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
+	isActive := indexElement == m.GetCursor() && !m.SearchBar.Focused()
 	sizeValue := common.FormatFileSize(elem.Info.Size())
 	if elem.Info.IsDir() {
 		sizeValue = ""
@@ -62,7 +67,7 @@ func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 		sizeValue,
 		columnWidth,
 		isSelected,
-		common.FilePanelBGColor,
+		isActive,
 		lipgloss.Right,
 	)
 }
@@ -71,12 +76,13 @@ func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 func (m *Model) renderModifyTime(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
+	isActive := indexElement == m.GetCursor() && !m.SearchBar.Focused()
 	modifyTime := elem.Info.ModTime().Format("2006-01-02 15:04")
 	return common.FilePanelItemRender(
 		modifyTime,
 		columnWidth,
 		isSelected,
-		common.FilePanelBGColor,
+		isActive,
 		lipgloss.Right,
 	)
 }
@@ -84,11 +90,12 @@ func (m *Model) renderModifyTime(indexElement int, columnWidth int) string {
 func (m *Model) renderPermissions(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
+	isActive := indexElement == m.GetCursor() && !m.SearchBar.Focused()
 	return common.FilePanelItemRender(
 		elem.Info.Mode().String(),
 		columnWidth,
 		isSelected,
-		common.FilePanelBGColor,
+		isActive,
 		lipgloss.Right,
 	)
 }
@@ -102,7 +109,7 @@ func (cd *columnDefinition) RenderHeader() string {
 		cd.Name,
 		cd.Size,
 		false,
-		common.FilePanelBGColor,
+		false,
 		cd.HeaderAlign,
 	)
 }

--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -17,7 +17,7 @@ func (m *Model) renderFileName(indexElement int, columnWidth int) string {
 	isSelected := m.CheckSelected(elem.Location)
 	isActive := indexElement == m.GetCursor() && !m.SearchBar.Focused()
 	cursor := emptyCursor
-	if isActive && common.Config.CursorStyle == "arrow" {
+	if isActive && common.Config.CursorStyle == common.CursorStyleArrow {
 		cursor = icon.Cursor
 	}
 

--- a/src/internal/ui/helpmenu/render.go
+++ b/src/internal/ui/helpmenu/render.go
@@ -85,10 +85,14 @@ func (m *Model) getContent(r *rendering.Renderer, renderHotkeyLength int, valueL
 		description := common.TruncateText(m.filteredData[i].description, valueLength, "...")
 
 		cursor := "  "
-		if m.cursor == i {
+		style := common.ModalStyle
+		if m.cursor == i && common.Config.CursorStyle == "arrow" {
 			cursor = common.FilePanelCursorStyle.Render(icon.Cursor + " ")
 		}
+		if m.cursor == i && common.Config.CursorStyle == "highlight" {
+			style = common.FilePanelItemActiveStyle
+		}
 		r.AddLines(cursor + common.ModalStyle.Render(fmt.Sprintf("%*s%s", renderHotkeyLength,
-			common.HelpMenuHotkeyStyle.Render(hotkey+" "), common.ModalStyle.Render(description))))
+			common.HelpMenuHotkeyStyle.Render(hotkey+" "), style.Render(description))))
 	}
 }

--- a/src/internal/ui/helpmenu/render.go
+++ b/src/internal/ui/helpmenu/render.go
@@ -86,10 +86,10 @@ func (m *Model) getContent(r *rendering.Renderer, renderHotkeyLength int, valueL
 
 		cursor := "  "
 		style := common.ModalStyle
-		if m.cursor == i && common.Config.CursorStyle == "arrow" {
+		if m.cursor == i && common.Config.CursorStyle == common.CursorStyleArrow {
 			cursor = common.FilePanelCursorStyle.Render(icon.Cursor + " ")
 		}
-		if m.cursor == i && common.Config.CursorStyle == "highlight" {
+		if m.cursor == i && common.Config.CursorStyle == common.CursorStyleHighlight {
 			style = common.FilePanelItemActiveStyle
 		}
 		r.AddLines(cursor + common.ModalStyle.Render(fmt.Sprintf("%*s%s", renderHotkeyLength,

--- a/src/internal/ui/sidebar/render.go
+++ b/src/internal/ui/sidebar/render.go
@@ -62,16 +62,29 @@ func (s *Model) directoriesRender(curFilePanelFileLocation string,
 			r.AddLines("", common.SideBarDisksDivider, "")
 		default:
 			cursor := " "
-			if s.cursor == i && sideBarFocused && !s.searchBar.Focused() {
-				cursor = icon.Cursor
+			renderStyle := common.SidebarStyle
+			isActive := s.cursor == i && sideBarFocused && !s.searchBar.Focused()
+			isSelected := s.directories[i].Location == curFilePanelFileLocation
+
+			if isSelected {
+				renderStyle = common.SidebarSelectedStyle
 			}
+
+			if isActive {
+				if common.Config.CursorStyle == "arrow" {
+					cursor = icon.Cursor
+				} else { // Highlight
+					if isSelected {
+						renderStyle = common.SidebarSelectedActiveStyle
+					} else {
+						renderStyle = common.FilePanelItemActiveStyle
+					}
+				}
+			}
+
 			if s.renaming && s.cursor == i {
 				r.AddLines(s.rename.View())
 			} else {
-				renderStyle := common.SidebarStyle
-				if s.directories[i].Location == curFilePanelFileLocation {
-					renderStyle = common.SidebarSelectedStyle
-				}
 				line := common.FilePanelCursorStyle.Render(cursor+" ") +
 					renderStyle.Render(s.directories[i].Icon+" ") +
 					renderStyle.Render(s.directories[i].Name)

--- a/src/internal/ui/sidebar/render.go
+++ b/src/internal/ui/sidebar/render.go
@@ -79,7 +79,7 @@ func (s *Model) directoryRenderLine(i int, curFilePanelFileLocation string,
 	}
 
 	if isActive {
-		if common.Config.CursorStyle == "arrow" {
+		if common.Config.CursorStyle == common.CursorStyleArrow {
 			cursor = icon.Cursor
 		} else { // Highlight
 			if isSelected {

--- a/src/internal/ui/sidebar/render.go
+++ b/src/internal/ui/sidebar/render.go
@@ -61,35 +61,41 @@ func (s *Model) directoriesRender(curFilePanelFileLocation string,
 		case diskDividerDir:
 			r.AddLines("", common.SideBarDisksDivider, "")
 		default:
-			cursor := " "
-			renderStyle := common.SidebarStyle
-			isActive := s.cursor == i && sideBarFocused && !s.searchBar.Focused()
-			isSelected := s.directories[i].Location == curFilePanelFileLocation
+			s.directoryRenderLine(i, curFilePanelFileLocation, sideBarFocused, r)
+		}
+	}
+}
 
+// renders a single directory line in the sidebar.
+func (s *Model) directoryRenderLine(i int, curFilePanelFileLocation string,
+	sideBarFocused bool, r *rendering.Renderer) {
+	cursor := " "
+	renderStyle := common.SidebarStyle
+	isActive := s.cursor == i && sideBarFocused && !s.searchBar.Focused()
+	isSelected := s.directories[i].Location == curFilePanelFileLocation
+
+	if isSelected {
+		renderStyle = common.SidebarSelectedStyle
+	}
+
+	if isActive {
+		if common.Config.CursorStyle == "arrow" {
+			cursor = icon.Cursor
+		} else { // Highlight
 			if isSelected {
-				renderStyle = common.SidebarSelectedStyle
-			}
-
-			if isActive {
-				if common.Config.CursorStyle == "arrow" {
-					cursor = icon.Cursor
-				} else { // Highlight
-					if isSelected {
-						renderStyle = common.SidebarSelectedActiveStyle
-					} else {
-						renderStyle = common.FilePanelItemActiveStyle
-					}
-				}
-			}
-
-			if s.renaming && s.cursor == i {
-				r.AddLines(s.rename.View())
+				renderStyle = common.SidebarSelectedActiveStyle
 			} else {
-				line := common.FilePanelCursorStyle.Render(cursor+" ") +
-					renderStyle.Render(s.directories[i].Icon+" ") +
-					renderStyle.Render(s.directories[i].Name)
-				r.AddLineWithCustomTruncate(line, rendering.TailsTruncateRight)
+				renderStyle = common.FilePanelItemActiveStyle
 			}
 		}
+	}
+
+	if s.renaming && s.cursor == i {
+		r.AddLines(s.rename.View())
+	} else {
+		line := common.FilePanelCursorStyle.Render(cursor+" ") +
+			renderStyle.Render(s.directories[i].Icon+" ") +
+			renderStyle.Render(s.directories[i].Name)
+		r.AddLineWithCustomTruncate(line, rendering.TailsTruncateRight)
 	}
 }

--- a/src/internal/ui/sortmodel/render.go
+++ b/src/internal/ui/sortmodel/render.go
@@ -14,10 +14,14 @@ func (m *Model) Render() string {
 	sortOptionsContent.WriteString(common.ModalTitleStyle.Render(" Sort Options") + "\n\n")
 	for i, option := range SortOptionsStr {
 		cursor := " "
-		if i == m.Cursor {
+		style := common.ModalStyle
+		if i == m.Cursor && common.Config.CursorStyle == "arrow" {
 			cursor = common.FilePanelCursorStyle.Render(icon.Cursor)
 		}
-		sortOptionsContent.WriteString(cursor + common.ModalStyle.Render(" "+option) + "\n")
+		if i == m.Cursor && common.Config.CursorStyle == "highlight" {
+			style = common.FilePanelItemActiveStyle
+		}
+		sortOptionsContent.WriteString(cursor + " " + style.Render(option) + "\n")
 	}
 	bottomBorder := common.GenerateFooterBorder(
 		fmt.Sprintf("%s/%s", strconv.Itoa(m.Cursor+1),

--- a/src/internal/ui/sortmodel/render.go
+++ b/src/internal/ui/sortmodel/render.go
@@ -15,10 +15,10 @@ func (m *Model) Render() string {
 	for i, option := range SortOptionsStr {
 		cursor := " "
 		style := common.ModalStyle
-		if i == m.Cursor && common.Config.CursorStyle == "arrow" {
+		if i == m.Cursor && common.Config.CursorStyle == common.CursorStyleArrow {
 			cursor = common.FilePanelCursorStyle.Render(icon.Cursor)
 		}
-		if i == m.Cursor && common.Config.CursorStyle == "highlight" {
+		if i == m.Cursor && common.Config.CursorStyle == common.CursorStyleHighlight {
 			style = common.FilePanelItemActiveStyle
 		}
 		sortOptionsContent.WriteString(cursor + " " + style.Render(option) + "\n")

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -16,7 +16,7 @@
 editor = ""
 
 #-- Directory Editor
-# 
+#
 dir_editor = ""
 
 #-- Auto check for update
@@ -24,7 +24,7 @@ auto_check_update = true
 
 #-- cd on quit
 # Should we cd the shell to the last directory open in superfile when the
-# program exits? 
+# program exits?
 cd_on_quit = false
 
 #-- File Preview
@@ -114,6 +114,10 @@ show_select_icons = true
 # Set to true to enable background transparency.
 # Requires: terminal support for colour transparency
 transparent_background = false
+
+#-- Cursor Style
+# Set the cursor style. Valid values: "arrow", "highlight"
+cursor_style = "arrow"
 
 #-- File Preview Panel Width
 # Width of the file preview panel will be 1/n of the total width.

--- a/src/superfile_config/theme/0x96f.toml
+++ b/src/superfile_config/theme/0x96f.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#64d2e8"
 file_panel_top_path = "#fcfcfc"
 file_panel_item_selected_fg = "#c6e472"
 file_panel_item_selected_bg = "#262427"
+file_panel_item_active_fg = "#fcfcfc"
+file_panel_item_active_bg = "#64d2e8"
 
 #-- Footer
 footer_fg = "#fcfcfc"

--- a/src/superfile_config/theme/ayu-dark.toml
+++ b/src/superfile_config/theme/ayu-dark.toml
@@ -27,7 +27,7 @@ full_screen_bg = "#0f1419"
 
 #-- Gradient
 # Note: This currently only supports two colors.
-gradient_color = ["#FFB454", "#36A3D9"]
+gradient_color = ["#ffb454", "#36a3d9"]
 directory_icon_color = ""
 
 #-- File Panel
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#aad94c"
 file_panel_top_path = "#ffcc66"
 file_panel_item_selected_fg = "#36a3d9"
 file_panel_item_selected_bg = "#1f2430"
+file_panel_item_active_fg = "#b3b1ad"
+file_panel_item_active_bg = "#ffcc66"
 
 #-- Footer
 footer_fg = "#b3b1ad"

--- a/src/superfile_config/theme/blood.toml
+++ b/src/superfile_config/theme/blood.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#ff522e"
 file_panel_top_path = "#ff9999"
 file_panel_item_selected_fg = "#ff8d34"
 file_panel_item_selected_bg = "#524549"
+file_panel_item_active_fg = "#f8f8f2"
+file_panel_item_active_bg = "#615250"
 
 #-- Footer
 footer_fg = "#f8f8f2"

--- a/src/superfile_config/theme/catppuccin-frappe.toml
+++ b/src/superfile_config/theme/catppuccin-frappe.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#a6d189"
 file_panel_top_path = "#89b5fa"
 file_panel_item_selected_fg = "#99d1db"
 file_panel_item_selected_bg = "#303446"
+file_panel_item_active_fg = "#a5adce"
+file_panel_item_active_bg = "#737994"
 
 #-- Footer
 footer_fg = "#a5adce"

--- a/src/superfile_config/theme/catppuccin-latte.toml
+++ b/src/superfile_config/theme/catppuccin-latte.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#40a02b"
 file_panel_top_path = "#89b5fa"
 file_panel_item_selected_fg = "#04a5e5"
 file_panel_item_selected_bg = "#eff1f5"
+file_panel_item_active_fg = "#4c4f69"
+file_panel_item_active_bg = "#89b5fa"
 
 #-- Footer
 footer_fg = "#4c4f69"

--- a/src/superfile_config/theme/catppuccin-macchiato.toml
+++ b/src/superfile_config/theme/catppuccin-macchiato.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#a6da95"
 file_panel_top_path = "#8aadf4"
 file_panel_item_selected_fg = "#91d7e3"
 file_panel_item_selected_bg = "#24273a"
+file_panel_item_active_fg = "#a5adcb"
+file_panel_item_active_bg = "#8aadf4"
 
 #-- Footer
 footer_fg = "#a5adcb"

--- a/src/superfile_config/theme/catppuccin-mocha.toml
+++ b/src/superfile_config/theme/catppuccin-mocha.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#a6e3a1"
 file_panel_top_path = "#89b5fa"
 file_panel_item_selected_fg = "#98D0FD"
 file_panel_item_selected_bg = "#1e1e2e"
+file_panel_item_active_fg = "#1e1e2e"
+file_panel_item_active_bg = "#89b5fa"
 
 #-- Footer
 footer_fg = "#a6adc8"

--- a/src/superfile_config/theme/dracula.toml
+++ b/src/superfile_config/theme/dracula.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#50fa7b"
 file_panel_top_path = "#8be9fd"
 file_panel_item_selected_fg = "#ffb86c"
 file_panel_item_selected_bg = "#282a36"
+file_panel_item_active_fg = "#f8f8f2"
+file_panel_item_active_bg = "#bd93f9"
 
 #-- Footer
 footer_fg = "#f8f8f2"

--- a/src/superfile_config/theme/everforest-dark-hard.toml
+++ b/src/superfile_config/theme/everforest-dark-hard.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#a7c080"
 file_panel_top_path = "#7fbbb3"
 file_panel_item_selected_fg = "#d699b6"
 file_panel_item_selected_bg = "#232a2e"
+file_panel_item_active_fg = "#232a2e"
+file_panel_item_active_bg = "#a7c080"
 
 #-- Footer
 footer_fg = "#d3c6aa"

--- a/src/superfile_config/theme/everforest-dark-medium.toml
+++ b/src/superfile_config/theme/everforest-dark-medium.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#a7c080"
 file_panel_top_path = "#7fbbb3"
 file_panel_item_selected_fg = "#d699b6"
 file_panel_item_selected_bg = "#232a2e"
+file_panel_item_active_fg = "#232a2e"
+file_panel_item_active_bg = "#a7c080"
 
 #-- Footer
 footer_fg = "#d3c6aa"

--- a/src/superfile_config/theme/gruvbox-dark-hard.toml
+++ b/src/superfile_config/theme/gruvbox-dark-hard.toml
@@ -38,7 +38,9 @@ file_panel_border_active = "#98971a"
 file_panel_top_directory_icon = "#689d6a"
 file_panel_top_path = "#458588"
 file_panel_item_selected_fg = "#d65d0e"
-file_panel_item_selected_bg = ""
+file_panel_item_selected_bg = "#928374"
+file_panel_item_active_fg = "#fbf1c7"
+file_panel_item_active_bg = "#689d6a"
 
 #-- Footer
 footer_fg = "#fbf1c7"
@@ -53,7 +55,7 @@ sidebar_title = "#b16286"
 sidebar_border = "#928374"
 sidebar_border_active = "#b16286"
 sidebar_item_selected_fg = "#d65d0e"
-sidebar_item_selected_bg = ""
+sidebar_item_selected_bg = "#928374"
 sidebar_divider = "#928374"
 
 #-- Modals
@@ -61,9 +63,9 @@ modal_fg = "#fbf1c7"
 modal_bg = "#1d2021"
 modal_border_active = "#689d6a"
 modal_cancel_fg = "#fb4934"
-modal_cancel_bg = ""
+modal_cancel_bg = "#928374"
 modal_confirm_fg = "#b8bb26"
-modal_confirm_bg = ""
+modal_confirm_bg = "#d65d0e"
 
 #-- Help Menu
 help_menu_hotkey = "#689d6a"

--- a/src/superfile_config/theme/gruvbox.toml
+++ b/src/superfile_config/theme/gruvbox.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#8ec07c"
 file_panel_top_path = "#458588"
 file_panel_item_selected_fg = "#d3869b"
 file_panel_item_selected_bg = "#282828"
+file_panel_item_active_fg = "#ebdbb2"
+file_panel_item_active_bg = "#8ec07c"
 
 #-- Footer
 footer_fg = "#ebdbb2"

--- a/src/superfile_config/theme/hacks.toml
+++ b/src/superfile_config/theme/hacks.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#afff00"
 file_panel_top_path = "#afff00"
 file_panel_item_selected_fg = "#ff8d34"
 file_panel_item_selected_bg = "#524549"
+file_panel_item_active_fg = "#f8f8f2"
+file_panel_item_active_bg = "#6532ff"
 
 #-- Footer
 footer_fg = "#f8f8f2"

--- a/src/superfile_config/theme/kaolin.toml
+++ b/src/superfile_config/theme/kaolin.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#f5c791"
 file_panel_top_path = "#d7936d"
 file_panel_item_selected_fg = "#4fa8a3"
 file_panel_item_selected_bg = "#17171a"
+file_panel_item_active_fg = "#efefef"
+file_panel_item_active_bg = "#74b09a"
 
 #-- Footer
 footer_fg = "#efefef"

--- a/src/superfile_config/theme/monokai.toml
+++ b/src/superfile_config/theme/monokai.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#e6db74"
 file_panel_top_path = "#e6db74"
 file_panel_item_selected_fg = "#66d9ef"
 file_panel_item_selected_bg = "#2e2e2e"
+file_panel_item_active_fg = "#2e2e2e"
+file_panel_item_active_bg = "#e6db74"
 
 #-- Footer
 footer_fg = "#f8f8f2"

--- a/src/superfile_config/theme/nord.toml
+++ b/src/superfile_config/theme/nord.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#88c0d0"
 file_panel_top_path = "#88c0d0"
 file_panel_item_selected_fg = "#bf616a"
 file_panel_item_selected_bg = "#2e3440"
+file_panel_item_active_fg = "#e5e9f0"
+file_panel_item_active_bg = "#81a1c1"
 
 #-- Footer
 footer_fg = "#e5e9f0"

--- a/src/superfile_config/theme/onedark.toml
+++ b/src/superfile_config/theme/onedark.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#dbb671"
 file_panel_top_path = "#dbb671"
 file_panel_item_selected_fg = "#51a8b3"
 file_panel_item_selected_bg = "#2c2d31"
+file_panel_item_active_fg = "#2c2d31"
+file_panel_item_active_bg = "#7fb573"
 
 #-- Footer
 footer_fg = "#a7aab0"

--- a/src/superfile_config/theme/poimandres.toml
+++ b/src/superfile_config/theme/poimandres.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#a6e3a1"
 file_panel_top_path = "#89b4fa"
 file_panel_item_selected_fg = "#a6e3a1"
 file_panel_item_selected_bg = "#2a303c"
+file_panel_item_active_fg = "#2a303c"
+file_panel_item_active_bg = "#7fbbb3"
 
 #-- Footer
 footer_fg = "#cdd6f4"

--- a/src/superfile_config/theme/rose-pine.toml
+++ b/src/superfile_config/theme/rose-pine.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#9ccfd8"
 file_panel_top_path = "#ebbcba"
 file_panel_item_selected_fg = "#c4a7e7"
 file_panel_item_selected_bg = "#191724"
+file_panel_item_active_fg = "#191724"
+file_panel_item_active_bg = "#9ccfd8"
 
 #-- Footer
 footer_fg = "#e0def4"

--- a/src/superfile_config/theme/sugarplum.toml
+++ b/src/superfile_config/theme/sugarplum.toml
@@ -37,8 +37,10 @@ file_panel_border = "#a175d4"
 file_panel_border_active = "#53aaa1"
 file_panel_top_directory_icon = "#249a84"
 file_panel_top_path = "#249a84"
-file_panel_item_selected_fg = "#53b397"
+file_panel_item_selected_fg = "#a175d4"
 file_panel_item_selected_bg = "#53b397"
+file_panel_item_active_fg = "#db7ddd"
+file_panel_item_active_bg = "#249a84"
 
 #-- Footer
 footer_fg = "#5ca8dc"

--- a/src/superfile_config/theme/tokyonight.toml
+++ b/src/superfile_config/theme/tokyonight.toml
@@ -39,6 +39,8 @@ file_panel_top_directory_icon = "#73daca"
 file_panel_top_path = "#7aa2f7"
 file_panel_item_selected_fg = "#2ac3de"
 file_panel_item_selected_bg = "#1a1b26"
+file_panel_item_active_fg = "#1a1b26"
+file_panel_item_active_bg = "#7aa2f7"
 
 #-- Footer
 footer_fg = "#a9b1d6"

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -250,6 +250,14 @@ This setting is ignored unless `nerdfont = true`. Both `nerdfont` and `show_sele
 
 `false` => The background is rendered (with color) to maintain theme consistency.
 
+- ###### cursor_style
+
+Set the cursor style
+
+`arrow` => Arrow cursor (default)
+
+`highlight` => Highlights the entire line
+
 - ###### file_preview_width
 
 This setting is an integer.


### PR DESCRIPTION
Adds a config option `cursor_style` to change how the cursor shows the current item.

"arrow" for previous functionality ( > ). Default.
"highlight" to highlight the row.

This has been changed for the main panel, help, side panel, and sort options. It also makes it much clearer to see which files the size, modify time, and permissions are for.

Arrow:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/567a6609-f72a-451c-ac72-df718a62ac65" />
Highlight:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6a0f2a62-8cef-431a-ac9d-50cec3bc87b0" />


A new theme option has been added. Could someone else add a flag similar to `--fix-config-file` to add the new theme option to the user's theme and to error if it is missing?

Closes #1502.