### PR TITLE
fix(tests): decouple shell substitution timeouts to stop windows flake

### DIFF
--- a/src/internal/ui/prompt/consts.go
+++ b/src/internal/ui/prompt/consts.go
@@ -26,7 +26,17 @@ const (
 	splitCommandArgError = "split command should not be given arguments"
 
 	// Timeout for command executed for shell substitution
-	shellSubTimeout        = 1000 * time.Millisecond
+	shellSubTimeout = 1000 * time.Millisecond
+
+	// Budget for substitutions that tests expect to succeed. Those commands
+	// return immediately, so the budget only has to cover spawning a shell.
+	// Being generous costs nothing on a healthy run, and keeps a CI runner
+	// that is slow to spawn one from being reported as a substitution failure.
+	shellSubSuccessTimeoutInTests = 30 * time.Second
+
+	// Budget for the substitution that tests expect to expire. It is paired
+	// with a command that runs for far longer, so a slow spawn can never look
+	// like a command that finished in time.
 	shellSubTimeoutInTests = 100 * time.Millisecond
 
 	defaultTestCwd = "/"

--- a/src/internal/ui/prompt/tokenize_test.go
+++ b/src/internal/ui/prompt/tokenize_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,15 +82,10 @@ func Test_tokenizePromptCommand(t *testing.T) {
 	}
 }
 
-// Note : resolving shell subsitution is flaky in windows.
-// It usually times out, and environment variables sometimes dont work.
 func Test_resolveShellSubstitution(t *testing.T) {
-	timeout := shellSubTimeoutInTests
 	newLineSuffix := "\n"
 	noopCommand := "true"
 	if runtime.GOOS == "windows" {
-		// Substitution is slow in windows
-		timeout = 2 * time.Second
 		// Windows uses \r\n as new line for echo
 		newLineSuffix = "\r\n"
 		noopCommand = "cd ."
@@ -182,7 +176,7 @@ func Test_resolveShellSubstitution(t *testing.T) {
 
 	for _, tt := range testdata {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := resolveShellSubstitution(timeout, tt.command, defaultTestCwd)
+			result, err := resolveShellSubstitution(shellSubSuccessTimeoutInTests, tt.command, defaultTestCwd)
 
 			assert.Equal(t, tt.expectedResult, result)
 			if err != nil {
@@ -195,7 +189,9 @@ func Test_resolveShellSubstitution(t *testing.T) {
 	}
 
 	t.Run("Testing shell substitution timeout", func(t *testing.T) {
-		result, err := resolveShellSubstitution(timeout, "$(sleep 2)", defaultTestCwd)
+		// sleep runs for 20x the budget, so the deadline is what ends this, not
+		// a slow shell. sleep is a Start-Sleep alias in powershell.
+		result, err := resolveShellSubstitution(shellSubTimeoutInTests, "$(sleep 2)", defaultTestCwd)
 		assert.Empty(t, result)
 		require.Error(t, err)
 		require.ErrorIs(t, err, context.DeadlineExceeded)


### PR DESCRIPTION
# Description

Fixes the flaky Windows CI run reported in #938.

## The failure

`Test_resolveShellSubstitution` in `internal/ui/prompt` fails on `windows-latest` while `ubuntu-latest` and `macos-latest` pass, and **a different subtest fails on each run**. From [run 30581330177](https://github.com/yorukot/superfile/actions/runs/30581330177) (a lockfile-only renovate PR, so nothing in it touched Go):

```
--- FAIL: Test_resolveShellSubstitution (10.38s)
    --- PASS: Test_resolveShellSubstitution/Ill_formed_command_1 (0.00s)
    --- FAIL: Test_resolveShellSubstitution/Ill_formed_command_2 (2.06s)
    --- FAIL: Test_resolveShellSubstitution/Basic_substitution (2.01s)
    --- FAIL: Test_resolveShellSubstitution/Command_with_internal_substitution (2.01s)
    --- PASS: Test_resolveShellSubstitution/Multiple_substitution (1.68s)
    --- PASS: Test_resolveShellSubstitution/Empty_output (0.61s)
    --- PASS: Test_resolveShellSubstitution/Testing_shell_substitution_timeout (2.01s)
```

Every failing subtest sits at ~2.01s — exactly the Windows budget. The passing ones cluster just under it (1.68s, 0.61s). This is a latency distribution straddling the deadline, not a logic error.

## Root cause

The test shared **one** timeout between two opposite cases:

```go
timeout := shellSubTimeoutInTests        // 100ms
if runtime.GOOS == "windows" {
    timeout = 2 * time.Second            // "Substitution is slow in windows"
}
```

That single value had to be *large* enough for a shell to spawn (the success cases) and *small* enough to keep the expiry case quick — and the expiry case ran `$(sleep 2)` against that same 2s budget, a margin of zero.

On Windows `ExecuteCommandInShell` spawns `powershell.exe`, whose startup under CI load regularly crossed 2s. When it did, a substitution that should have succeeded returned `context.DeadlineExceeded`, `resolveShellSubstitution` returned `""`, and `assert.Equal` failed. Which subtests lost the race varied per run — the signature in the issue.

## The fix

Give the two cases their own budgets.

- **Success cases**: their commands (`echo abc` and friends) return immediately, so the budget only has to cover process spawn. Being generous costs nothing on a healthy run — the call returns as soon as the command does — and stops a slow runner from being misreported as a substitution failure. The Windows special case disappears with it.
- **Expiry case**: keeps the short 100ms budget, now paired with a command that runs 20x longer, so a slow spawn can never look like a command that finished in time.

Wall time is unchanged (2.01s for the package on Linux, before and after): the expiry case is bounded by `sleep`, which holds the output pipe open until it exits, not by the deadline.

## Verification

I don't have a Windows machine, so the Windows result will come from CI on this PR. What I could establish directly:

**The mechanism reproduces on Linux.** Setting the success budget near this container's shell-spawn cost makes the same test flake the same way — five consecutive runs, varying subset:

```
run 1 failing:
run 2 failing:
run 3 failing: Command_with_internal_substitution Multiple_substitution
run 4 failing:
run 5 failing: Command_with_internal_substitution Multiple_substitution
```

That is the issue's "different subtest each time" signature, produced purely by moving the budget across spawn latency — which is what Windows does to it naturally.

**The fix holds under load.** 8 consecutive runs with all 32 cores saturated: pass. `go test -count=5 ./internal/ui/prompt/`: pass.

**No regressions.** Full `./...` on this branch and on pristine `main` produce an identical failure set — `internal` (`TestLayout` needs a populated home dir), `internal/ui/metadata` (needs `exiftool`), `internal/ui/zoxide` (needs `zoxide`); all missing-tool failures in my container, all present before this change. `gofmt -l` and `go vet ./...` are clean.

Also removed the stale `// Note : resolving shell subsitution is flaky in windows.` comment, since that is what this change addresses.


# ✅ Pre-Submission Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `go test ./...`
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff for debug logs, exposed secrets, and unintended changes
- [x] The PR title follows the Conventional Commits format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved command-substitution test reliability across platforms.
  * Added separate time limits for successful command execution and expiration scenarios.
  * Clarified timeout behavior in test coverage to reduce intermittent failures and make expected outcomes more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->