### PR TITLE
fix(filepanel): refresh panel after rename

### DIFF
--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -146,6 +146,11 @@ func (m *model) confirmRename() {
 	if err != nil {
 		slog.Error("Error while confirmRename during rename", "error", err)
 		// Dont return. We have to also reset the panel and model information
+	} else {
+		// The keypress that confirmed the rename already drives an update, but
+		// the panel's re-render timer would skip re-reading the directory and
+		// leave the old name on screen. See #818.
+		panel.InvalidateElements()
 	}
 	m.fileModel.Renaming = false
 	panel.Rename.Blur()

--- a/src/internal/model_file_operations_test.go
+++ b/src/internal/model_file_operations_test.go
@@ -16,6 +16,7 @@ import (
 
 	variable "github.com/yorukot/superfile/src/config"
 	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/ui/filepanel"
 	"github.com/yorukot/superfile/src/internal/ui/notify"
 )
 
@@ -223,6 +224,52 @@ func TestFileRename(t *testing.T) {
 		actualTest(false)
 		actualTest(true)
 	})
+}
+
+// Regression test for #818. The panel's re-render timer is
+// min(elemCount/100, ReRenderMaxDelay) seconds, so this directory is sized to
+// pin the timer at its 3s maximum. The panel is then polled for only
+// DefaultTestTimeout (1s): refreshing on the rename itself lands well inside
+// that, while waiting out the timer cannot.
+func TestFileRenameRefreshesPanel(t *testing.T) {
+	curTestDir := t.TempDir()
+	for i := range filepanel.ReRenderChunkDivisor * filepanel.ReRenderMaxDelay {
+		utils.SetupFilesWithData(t, []byte("x"),
+			filepath.Join(curTestDir, fmt.Sprintf("file%03d.txt", i)))
+	}
+	oldName := "file000.txt"
+	newName := "file000_new.txt"
+
+	m := defaultTestModel(curTestDir)
+	p := NewTestTeaProgWithEventLoop(t, m)
+	setFilePanelSelectedItemByLocation(t, m.getFocusedFilePanel(),
+		filepath.Join(curTestDir, oldName))
+
+	p.SendKey(common.Hotkeys.FilePanelItemRename[0])
+	p.SendKey("_new")
+	p.Send(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(curTestDir, newName))
+		return err == nil
+	}, DefaultTestTimeout, DefaultTestTick, "File never got renamed")
+
+	// No further input is sent after the rename.
+	assert.Eventually(t, func() bool {
+		return panelContainsName(m.getFocusedFilePanel(), newName)
+	}, DefaultTestTimeout, DefaultTestTick,
+		"panel should show the renamed file without further input")
+	assert.False(t, panelContainsName(m.getFocusedFilePanel(), oldName),
+		"panel should no longer show the old name")
+}
+
+func panelContainsName(panel *filepanel.Model, name string) bool {
+	for i := range panel.ElemCount() {
+		if panel.GetElementAtIdx(i).Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func isTrashed(fileAbsPath string) bool {

--- a/src/internal/ui/filepanel/get_elements.go
+++ b/src/internal/ui/filepanel/get_elements.go
@@ -86,6 +86,15 @@ func (m *Model) shouldSkipPanelUpdate(nowTime time.Time) bool {
 		nowTime.Sub(m.LastTimeGetElement) < time.Duration(reRenderTime)*time.Second
 }
 
+// InvalidateElements makes the next UpdateElementsIfNeeded re-read the
+// directory instead of waiting out the re-render timer. Call it after changing
+// this panel's directory from inside superfile, where the timer would other-
+// wise keep stale entries on screen until an unrelated message happens to
+// arrive late enough.
+func (m *Model) InvalidateElements() {
+	m.LastTimeGetElement = time.Time{}
+}
+
 func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) {
 	nowTime := time.Now()
 	if force || !m.shouldSkipPanelUpdate(nowTime) {


### PR DESCRIPTION
# Description

Fixes #818 — after renaming an item, the file panel keeps showing the old name until you press something else.

## Root cause

@lazysegtree's note on the issue suggested sending a `tea.Msg` from `confirmRename` to trigger a model update. Tracing it, the update turns out not to be the missing piece — the keypress that confirms the rename already drives one, and `updateModelStateAfterMsg` already calls `UpdateFilePanelsIfNeeded(false)` on every message.

What actually swallows the change is the re-render timer:

```go
// filepanel/get_elements.go
func (m *Model) shouldSkipPanelUpdate(nowTime time.Time) bool {
	...
	reRenderTime := int(float64(m.ElemCount()) / ReRenderChunkDivisor)
	reRenderTime = min(reRenderTime, ReRenderMaxDelay)
	return !m.NeedsReRender() &&
		nowTime.Sub(m.LastTimeGetElement) < time.Duration(reRenderTime)*time.Second
}
```

A rename does not change the panel's location, so `NeedsReRender()` stays false, and the directory is not re-read until `min(elemCount/100, 3)` seconds have passed. So an extra `tea.Msg` would have been skipped by the same guard unless it happened to arrive after the timer expired.

This also explains the shape of the bug report — the timer is `0` for directories under 100 entries, so small directories refresh instantly and the bug only shows up in busier ones.

## The fix

Invalidate the panel's cached listing when a rename succeeds, so the update already in flight re-reads the directory:

```go
func (m *Model) InvalidateElements() {
	m.LastTimeGetElement = time.Time{}
}
```

No new message type, and the timer keeps doing its job for every other path. If you'd still prefer a `RenameOperationMsg` alongside the other operation messages, happy to rework it — this seemed like the smaller change, since the rename is synchronous and has no process-bar state to report.

## Testing

Added `TestFileRenameRefreshesPanel`, which sizes the directory to pin the timer at its 3s maximum and then polls the panel for only `DefaultTestTimeout` (1s). Refreshing on the rename itself lands well inside that window; waiting out the timer cannot.

- With the fix: **20/20 runs pass**, and 10/10 pass with all 32 cores saturated.
- With the fix reverted: **5/5 runs fail**, on both assertions.

My first version of this test polled for the file appearing on disk and then asserted on the panel once. That raced the model's update cycle and flaked ~30% — the version here waits on the panel instead, which is what the test is actually about.

`gofmt -l` and `go vet ./...` are clean. Full `./...` shows the same failures on this branch as on pristine `main` — `TestLayout` and `TestZoxide` in `internal`, `internal/ui/metadata` (needs `exiftool`), `internal/ui/zoxide` (needs `zoxide`) — all missing-tool/environment failures in my container, none introduced here.

# Related Issues

Closes #818

# ✅ Pre-Submission Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `go test ./...`
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff for debug logs, exposed secrets, and unintended changes
- [x] The PR title follows the Conventional Commits format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Renamed files now appear immediately in the focused file panel without requiring additional input.
  * Improved panel refresh behavior after successful rename operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->