### PR TITLE
feat(sidebar): configurable disk listing via disk_mounts/excluded_disk_mounts

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -97,6 +97,8 @@ type ConfigType struct {
 	CodePreviewer           string   `toml:"code_previewer"             comment:"\nWhether to use the builtin syntax highlighting with chroma or use bat. Values: \"\" for builtin chroma, \"bat\" for bat"`
 	SidebarWidth            int      `toml:"sidebar_width"              comment:"\nThe length of the sidebar(excluding borders). If you don't find to display the sidebar, you can input 0 directly. If you want to display the value, please place it in the range of 5-20."`
 	SidebarSections         []string `toml:"sidebar_sections"           comment:"\nOrder of sidebar sections (valid values: \"home\", \"pinned\", \"disks\").\nOnly sections included in this list will be displayed."`
+	DiskMounts              []string `toml:"disk_mounts"                comment:"\nMountpoint prefixes shown in the disks section. A mount is listed only if its\nmountpoint starts with one of these prefixes. Use an empty list ([]) to list\nevery mount, i.e. all filesystem types including network/FUSE mounts (sshfs, nfs).\nThe root mount \"/\" (and all drives on Windows) is always shown."`
+	ExcludedDiskMounts      []string `toml:"excluded_disk_mounts"       comment:"\nMountpoint prefixes always hidden from the disks section, even if they match a\ndisk_mounts prefix above."`
 
 	BorderTop         string `toml:"border_top"          comment:"\nBorder style"`
 	BorderBottom      string `toml:"border_bottom"`

--- a/src/internal/ui/sidebar/disk_utils.go
+++ b/src/internal/ui/sidebar/disk_utils.go
@@ -9,13 +9,18 @@ import (
 	"github.com/shirou/gopsutil/v4/disk"
 
 	"github.com/yorukot/superfile/src/config/icon"
+	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
-// getExternalMediaFolders retrieves a list of mounted physical drives and external media.
+// getExternalMediaFolders retrieves the list of mounted drives to display in the
+// disks section, filtered according to the user's disk_mounts / excluded_disk_mounts
+// configuration.
 func getExternalMediaFolders() []directory {
-	// only get physical drives
-	parts, err := disk.Partitions(false)
+	// List every mount (all=true) so that non-physical filesystems such as FUSE
+	// (sshfs) and network mounts are available. Filtering to what the user wants
+	// is then handled entirely by shouldListDisk.
+	parts, err := disk.Partitions(true)
 
 	if err != nil {
 		slog.Error("Error while getting external media: ", "error", err)
@@ -36,8 +41,23 @@ func getExternalMediaFolders() []directory {
 	return disks
 }
 
-// shouldListDisk determines whether a given mount point should be displayed in the sidebar's disks section.
+// shouldListDisk determines whether a given mount point should be displayed in the
+// sidebar's disks section, based on the configured include/exclude mountpoint prefixes.
 func shouldListDisk(mountPoint string) bool {
+	return shouldListDiskWithConfig(mountPoint, common.Config.DiskMounts, common.Config.ExcludedDiskMounts)
+}
+
+// shouldListDiskWithConfig contains the mountpoint filtering logic, taking the
+// include/exclude prefix lists explicitly so it can be unit tested without touching
+// global config.
+//
+// Rules, in order:
+//  1. Windows: always list (drives are enumerated; the POSIX prefixes don't apply).
+//  2. The root mount "/" is always listed.
+//  3. A mountpoint matching any excludePrefixes entry is hidden (blacklist wins).
+//  4. An empty includePrefixes list lists every mountpoint (all filesystem types).
+//  5. Otherwise the mountpoint is listed only if it matches an includePrefixes entry.
+func shouldListDiskWithConfig(mountPoint string, includePrefixes, excludePrefixes []string) bool {
 	if runtime.GOOS == utils.OsWindows {
 		// We need to get C:, D: drive etc in the list
 		return true
@@ -48,27 +68,28 @@ func shouldListDisk(mountPoint string) bool {
 		return true
 	}
 
-	// TODO : make a configurable field in config.yaml
-	// excluded_disk_mounts = ["/Volumes/.timemachine"]
-	// Mountpoints that are in subdirectory of disk_mounts
-	// but still are to be excluded in disk section of sidebar
-	if strings.HasPrefix(mountPoint, "/Volumes/.timemachine") {
+	// Blacklist takes precedence over the include list.
+	if hasAnyPrefix(mountPoint, excludePrefixes) {
 		return false
 	}
 
-	// We avoid listing all mounted partitions (Otherwise listed disk could get huge)
-	// but only a few partitions that usually corresponds to external physical devices
-	// For example : mounts like /boot, /var/ will get skipped
-	// This can be inaccurate based on your system setup if you mount any external devices
-	// on other directories, or if you have some extra mounts on these directories
-	// TODO : make a configurable field in config.yaml
-	// disk_mounts = ["/mnt", "/media", "/run/media", "/Volumes"]
-	// Only block devicies that are mounted on these or any subdirectory of these Mountpoints
-	// Will be shown in disk sidebar
-	return strings.HasPrefix(mountPoint, "/mnt") ||
-		strings.HasPrefix(mountPoint, "/media") ||
-		strings.HasPrefix(mountPoint, "/run/media") ||
-		strings.HasPrefix(mountPoint, "/Volumes")
+	// An empty include list means "list everything" (all filesystem types).
+	if len(includePrefixes) == 0 {
+		return true
+	}
+
+	// Otherwise only list mounts under one of the included prefixes.
+	return hasAnyPrefix(mountPoint, includePrefixes)
+}
+
+// hasAnyPrefix reports whether s starts with any of the given prefixes.
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func diskIcon(mountPoint string) string {

--- a/src/internal/ui/sidebar/disk_utils_test.go
+++ b/src/internal/ui/sidebar/disk_utils_test.go
@@ -1,0 +1,137 @@
+package sidebar
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/yorukot/superfile/src/pkg/utils"
+)
+
+func TestShouldListDiskWithConfig(t *testing.T) {
+	if runtime.GOOS == utils.OsWindows {
+		// The prefix filtering only applies to POSIX systems; on Windows every
+		// drive is always listed.
+		t.Skip("prefix filtering is not used on Windows")
+	}
+
+	defaultInclude := []string{"/mnt", "/media", "/run/media", "/Volumes"}
+	defaultExclude := []string{"/Volumes/.timemachine"}
+
+	testCases := []struct {
+		name       string
+		mountPoint string
+		include    []string
+		exclude    []string
+		expected   bool
+	}{
+		{
+			name:       "root is always listed",
+			mountPoint: "/",
+			include:    defaultInclude,
+			exclude:    defaultExclude,
+			expected:   true,
+		},
+		{
+			name:       "root is listed even with empty include list",
+			mountPoint: "/",
+			include:    nil,
+			exclude:    nil,
+			expected:   true,
+		},
+		{
+			name:       "mount under an included prefix is listed",
+			mountPoint: "/mnt/almighty",
+			include:    defaultInclude,
+			exclude:    defaultExclude,
+			expected:   true,
+		},
+		{
+			name:       "sshfs mount under /media is listed with defaults",
+			mountPoint: "/media/remote",
+			include:    defaultInclude,
+			exclude:    defaultExclude,
+			expected:   true,
+		},
+		{
+			name:       "system mount not under any prefix is hidden",
+			mountPoint: "/boot",
+			include:    defaultInclude,
+			exclude:    defaultExclude,
+			expected:   false,
+		},
+		{
+			name:       "proc is hidden with default prefixes",
+			mountPoint: "/proc",
+			include:    defaultInclude,
+			exclude:    defaultExclude,
+			expected:   false,
+		},
+		{
+			name:       "excluded prefix wins over included prefix",
+			mountPoint: "/Volumes/.timemachine/foo",
+			include:    defaultInclude,
+			exclude:    defaultExclude,
+			expected:   false,
+		},
+		{
+			name:       "empty include list lists every mount",
+			mountPoint: "/proc",
+			include:    []string{},
+			exclude:    nil,
+			expected:   true,
+		},
+		{
+			name:       "empty include list still respects the exclude list",
+			mountPoint: "/proc",
+			include:    []string{},
+			exclude:    []string{"/proc"},
+			expected:   false,
+		},
+		{
+			name:       "no include and no exclude lists everything",
+			mountPoint: "/mnt/whatever",
+			include:    nil,
+			exclude:    nil,
+			expected:   true,
+		},
+		{
+			name:       "custom whitelist excludes non-matching mount",
+			mountPoint: "/mnt/data",
+			include:    []string{"/media"},
+			exclude:    nil,
+			expected:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldListDiskWithConfig(tc.mountPoint, tc.include, tc.exclude)
+			if got != tc.expected {
+				t.Errorf("shouldListDiskWithConfig(%q, %v, %v) = %v, want %v",
+					tc.mountPoint, tc.include, tc.exclude, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestHasAnyPrefix(t *testing.T) {
+	testCases := []struct {
+		name     string
+		s        string
+		prefixes []string
+		expected bool
+	}{
+		{name: "matches first prefix", s: "/mnt/x", prefixes: []string{"/mnt", "/media"}, expected: true},
+		{name: "matches later prefix", s: "/media/x", prefixes: []string{"/mnt", "/media"}, expected: true},
+		{name: "no match", s: "/boot", prefixes: []string{"/mnt", "/media"}, expected: false},
+		{name: "empty prefixes", s: "/mnt/x", prefixes: nil, expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasAnyPrefix(tc.s, tc.prefixes); got != tc.expected {
+				t.Errorf("hasAnyPrefix(%q, %v) = %v, want %v", tc.s, tc.prefixes, got, tc.expected)
+			}
+		})
+	}
+}

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -136,6 +136,18 @@ sidebar_width = 20
 # Only enabled sections will be displayed
 sidebar_sections = ["home", "pinned", "disks"]
 
+#-- Disks Section: Included Mountpoint Prefixes
+# A mount is shown in the disks section only if its mountpoint starts with one of
+# these prefixes. Use an empty list ([]) to list every mount, i.e. all filesystem
+# types including network/FUSE mounts such as sshfs and nfs.
+# The root mount "/" (and all drives on Windows) is always shown.
+disk_mounts = ["/mnt", "/media", "/run/media", "/Volumes"]
+
+#-- Disks Section: Excluded Mountpoint Prefixes
+# A mount whose mountpoint starts with one of these prefixes is always hidden,
+# even if it matches a disk_mounts prefix above.
+excluded_disk_mounts = ["/Volumes/.timemachine"]
+
 #-- Border
 # Make sure to add strings that are exactly one character wide!
 # Use ' ' for borderless.


### PR DESCRIPTION
Closes #1388.

## Problem
Directories mounted via sshfs (and other FUSE/network filesystems) never appear in the disks sidebar because `disk.Partitions(false)` skips "nodev" filesystems on Linux, so they never reach `shouldListDisk`.

## Approach
Switch to `disk.Partitions(true)` to enumerate all mounts, then filter entirely via two new config lists (names taken from the existing TODO comments in disk_utils.go):

- `disk_mounts` — mountpoint prefixes to include. Empty list ([]) lists every mount (all filesystem types). Defaults to `["/mnt", "/media", "/run/media", "/Volumes"]`.
- `excluded_disk_mounts` — mountpoint prefixes always hidden (wins over include). Defaults to `["/Volumes/.timemachine"]`.

Root `/` and all Windows drives are always shown.

## Backward compatibility
`LoadTomlFile` seeds defaults before overlaying the user file, so existing configs inherit the defaults. The only behavior change is that FUSE/network mounts under the whitelisted prefixes now appear — the fix.

## Testing
- Added table-driven tests for `shouldListDiskWithConfig` and `hasAnyPrefix`.
- `go build ./...`, `go vet`, `gofmt -l` all clean; sidebar and common test packages pass.

## Note
Design was discussed on the issue; open question there on whether fstype-level filtering is also wanted (can be added symmetrically later).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable filtering for mounts displayed in the disks section.
  * View all mounts by default or limit results to selected mountpoint prefixes.
  * Exclude specific mountpoints, with exclusions taking priority over inclusions.
  * Root and Windows drives remain visible automatically.

* **Documentation**
  * Documented the new `disk_mounts` and `excluded_disk_mounts` configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->