### PR TITLE
feat: copy/paste files via system clipboard (#741)

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -152,6 +152,9 @@ type HotkeysType struct {
 	DeleteItems            []string `toml:"delete_items"`
 	PermanentlyDeleteItems []string `toml:"permanently_delete_items"`
 
+	CopyToSystemClipboard    []string `toml:"copy_to_system_clipboard"`
+	PasteFromSystemClipboard []string `toml:"paste_from_system_clipboard"`
+
 	ExtractFile  []string `toml:"extract_file"  comment:"compress and extract"`
 	CompressFile []string `toml:"compress_file"`
 

--- a/src/internal/default_config.go
+++ b/src/internal/default_config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/yorukot/superfile/src/internal/ui/sidebar"
 
 	"github.com/yorukot/superfile/src/internal/common"
+	"github.com/yorukot/superfile/src/internal/systemclipboard"
 	"github.com/yorukot/superfile/src/internal/ui/prompt"
 	zoxideui "github.com/yorukot/superfile/src/internal/ui/zoxide"
 )
@@ -31,20 +32,21 @@ import (
 func defaultModelConfig(toggleDotFile, toggleFooter, firstUse bool,
 	firstPanelPaths []string, zClient *zoxidelib.Client) *model {
 	return &model{
-		focusPanel:      nonePanelFocus,
-		processBarModel: processbar.New(),
-		clipboardWriter: clipboard.WriteAll,
-		sidebarModel:    sidebar.New(),
-		fileMetaData:    metadata.New(),
-		fileModel:       filemodel.New(firstPanelPaths, toggleDotFile),
-		helpMenu:        helpmenu.New(),
-		promptModal:     prompt.DefaultModel(prompt.PromptMinHeight, prompt.PromptMinWidth),
-		zoxideModal:     zoxideui.DefaultModel(zoxideui.ZoxideMinHeight, zoxideui.ZoxideMinWidth, zClient),
-		sortModal:       sortmodel.New(),
-		zClient:         zClient,
-		modelQuitState:  notQuitting,
-		toggleFooter:    toggleFooter,
-		firstUse:        firstUse,
-		hasTrash:        common.InitTrash(),
+		focusPanel:         nonePanelFocus,
+		processBarModel:    processbar.New(),
+		clipboardWriter:    clipboard.WriteAll,
+		sidebarModel:       sidebar.New(),
+		fileMetaData:       metadata.New(),
+		fileModel:          filemodel.New(firstPanelPaths, toggleDotFile),
+		helpMenu:           helpmenu.New(),
+		promptModal:        prompt.DefaultModel(prompt.PromptMinHeight, prompt.PromptMinWidth),
+		zoxideModal:        zoxideui.DefaultModel(zoxideui.ZoxideMinHeight, zoxideui.ZoxideMinWidth, zClient),
+		sortModal:          sortmodel.New(),
+		zClient:            zClient,
+		modelQuitState:     notQuitting,
+		toggleFooter:       toggleFooter,
+		firstUse:           firstUse,
+		hasTrash:           common.InitTrash(),
+		hasSystemClipboard: systemclipboard.Available(),
 	}
 }

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -346,6 +346,8 @@ func (m *model) getPasteFromSystemClipboardCmd() tea.Cmd {
 	}
 }
 
+// systemClipboardUnavailableHint explains how to enable file clipboard support
+// on Linux or reports that the current environment does not support it.
 func systemClipboardUnavailableHint() string {
 	if runtime.GOOS == "linux" {
 		return "Install wl-clipboard (Wayland) or xclip (X11) to copy/paste files to and from the system file manager."

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	variable "github.com/yorukot/superfile/src/config"
+	"github.com/yorukot/superfile/src/internal/systemclipboard"
 	"github.com/yorukot/superfile/src/internal/trash"
 	"github.com/yorukot/superfile/src/internal/ui/filepanel"
 	"github.com/yorukot/superfile/src/internal/ui/spferror"
@@ -265,6 +266,91 @@ func (m *model) copyMultipleItem(cut bool) {
 	slog.Debug("handle_file_operations.copyMultipleItem", "cut", cut,
 		"panel selected files", items)
 	m.clipboard.SetItems(items)
+}
+
+// systemClipboardSourcePaths returns the paths that a "copy to system
+// clipboard" action should act on: the selected items in select mode, otherwise
+// the focused item.
+func (m *model) systemClipboardSourcePaths() []string {
+	panel := m.getFocusedFilePanel()
+	if panel.Empty() {
+		return nil
+	}
+	if panel.PanelMode == filepanel.SelectMode && panel.SelectedCount() > 0 {
+		return panel.GetSelectedLocationsSortedAsVisible()
+	}
+	return []string{panel.GetFocusedItem().Location}
+}
+
+// getCopyToSystemClipboardCmd writes the current selection/focused item to the
+// OS clipboard as real file references, so they can be pasted into the native
+// file manager. Paths are gathered on the update loop; the (blocking) clipboard
+// write happens inside the returned command.
+func (m *model) getCopyToSystemClipboardCmd() tea.Cmd {
+	reqID := m.nextIoReqCnt()
+	if !m.hasSystemClipboard {
+		return func() tea.Msg {
+			return NewNotifyModalMsg(notify.New(true, "System clipboard unavailable",
+				systemClipboardUnavailableHint(), notify.NoAction), reqID)
+		}
+	}
+	paths := m.systemClipboardSourcePaths()
+	if len(paths) == 0 {
+		return nil
+	}
+	slog.Debug("getCopyToSystemClipboardCmd", "items cnt", len(paths))
+	return func() tea.Msg {
+		if err := systemclipboard.CopyFiles(paths, false); err != nil {
+			slog.Error("Error copying to system clipboard", "error", err)
+			return NewNotifyModalMsg(notify.New(true, "System clipboard copy failed",
+				err.Error(), notify.NoAction), reqID)
+		}
+		return nil
+	}
+}
+
+// getPasteFromSystemClipboardCmd reads file references from the OS clipboard and
+// pastes them into the focused panel, reusing the normal paste pipeline.
+func (m *model) getPasteFromSystemClipboardCmd() tea.Cmd {
+	reqID := m.nextIoReqCnt()
+	if !m.hasSystemClipboard {
+		return func() tea.Msg {
+			return NewNotifyModalMsg(notify.New(true, "System clipboard unavailable",
+				systemClipboardUnavailableHint(), notify.NoAction), reqID)
+		}
+	}
+	panelLocation := m.getFocusedFilePanel().Location
+	return func() tea.Msg {
+		paths, cut, err := systemclipboard.PasteFiles()
+		if err != nil {
+			slog.Error("Error pasting from system clipboard", "error", err)
+			return NewNotifyModalMsg(notify.New(true, "System clipboard paste failed",
+				err.Error(), notify.NoAction), reqID)
+		}
+		// Keep only items that still exist on disk.
+		existing := make([]string, 0, len(paths))
+		for _, p := range paths {
+			if _, statErr := os.Lstat(p); statErr == nil {
+				existing = append(existing, p)
+			}
+		}
+		if len(existing) == 0 {
+			return NewNotifyModalMsg(notify.New(true, "System clipboard paste failed",
+				systemclipboard.ErrNoFiles.Error(), notify.NoAction), reqID)
+		}
+		if vErr := validatePasteOperation(panelLocation, existing, cut); vErr != nil {
+			return NewNotifyModalMsg(notify.New(true, "Invalid paste location", vErr.Error(), notify.NoAction),
+				reqID)
+		}
+		return m.executePasteOperation(&m.processBarModel, panelLocation, existing, cut, reqID)
+	}
+}
+
+func systemClipboardUnavailableHint() string {
+	if runtime.GOOS == "linux" {
+		return "Install wl-clipboard (Wayland) or xclip (X11) to copy/paste files to and from the system file manager."
+	}
+	return "System clipboard file transfer is not supported in this environment."
 }
 
 func (m *model) getPasteItemCmd() tea.Cmd {

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -195,6 +195,8 @@ func (m *model) unfocusedFilePanelKey(msg string) {
 	}
 }
 
+// filePanelSelectModeKey handles selection changes and file actions in select
+// mode, returning a command when the action requires asynchronous work.
 func (m *model) filePanelSelectModeKey(msg string) tea.Cmd {
 	panel := m.getFocusedFilePanel()
 
@@ -223,6 +225,8 @@ func (m *model) filePanelSelectModeKey(msg string) tea.Cmd {
 	return nil
 }
 
+// filePanelNormalModeKey handles navigation and focused-item actions in normal
+// mode, returning a command when the action requires asynchronous work.
 func (m *model) filePanelNormalModeKey(msg string) tea.Cmd {
 	switch {
 	case slices.Contains(common.Hotkeys.Confirm, msg):

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -116,6 +116,9 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,go
 	case slices.Contains(common.Hotkeys.PasteItems, msg):
 		return m.getPasteItemCmd()
 
+	case slices.Contains(common.Hotkeys.PasteFromSystemClipboard, msg):
+		return m.getPasteFromSystemClipboardCmd()
+
 	case slices.Contains(common.Hotkeys.FilePanelItemCreate, msg):
 		m.panelCreateNewFile()
 	case slices.Contains(common.Hotkeys.PinnedDirectory, msg):
@@ -210,6 +213,8 @@ func (m *model) filePanelSelectModeKey(msg string) tea.Cmd {
 		m.copyMultipleItem(false)
 	case slices.Contains(common.Hotkeys.CutItems, msg):
 		m.copyMultipleItem(true)
+	case slices.Contains(common.Hotkeys.CopyToSystemClipboard, msg):
+		return m.getCopyToSystemClipboardCmd()
 	case slices.Contains(common.Hotkeys.CopyPath, msg):
 		m.copyPath()
 	case slices.Contains(common.Hotkeys.FilePanelSelectAllItem, msg):
@@ -232,6 +237,8 @@ func (m *model) filePanelNormalModeKey(msg string) tea.Cmd {
 		m.copySingleItem(false)
 	case slices.Contains(common.Hotkeys.CutItems, msg):
 		m.copySingleItem(true)
+	case slices.Contains(common.Hotkeys.CopyToSystemClipboard, msg):
+		return m.getCopyToSystemClipboardCmd()
 	case slices.Contains(common.Hotkeys.FilePanelItemRename, msg):
 		m.panelItemRename()
 	case slices.Contains(common.Hotkeys.SearchBar, msg):

--- a/src/internal/systemclipboard/systemclipboard.go
+++ b/src/internal/systemclipboard/systemclipboard.go
@@ -12,6 +12,10 @@
 //   - systemclipboard_linux.go         shells out to wl-clipboard / xclip
 //   - systemclipboard_unsupported.go   every other platform
 //
+// On Linux, CopyFiles currently publishes only x-special/gnome-copied-files;
+// it does not advertise text/uri-list. Multi-target clipboard support is deferred
+// because the available clipboard tools replace the selection per invocation.
+//
 // Each platform file implements the same three functions:
 //
 //	func Available() bool

--- a/src/internal/systemclipboard/systemclipboard.go
+++ b/src/internal/systemclipboard/systemclipboard.go
@@ -1,0 +1,35 @@
+// Package systemclipboard provides copy/paste of real files and directories
+// through the operating system clipboard, so that items copied inside superfile
+// can be pasted into the native file manager (Finder, Explorer, Nautilus, ...)
+// and vice-versa.
+//
+// The heavy lifting is platform specific and lives in the build-tagged files in
+// this package, mirroring the layout of the sibling `trash` package:
+//
+//   - systemclipboard_windows.go       CF_HDROP via Win32 syscalls (no cgo)
+//   - systemclipboard_darwin.go / .m   NSPasteboard file URLs via cgo
+//   - systemclipboard_darwin_nocgo.go  graceful fallback when built without cgo
+//   - systemclipboard_linux.go         shells out to wl-clipboard / xclip
+//   - systemclipboard_unsupported.go   every other platform
+//
+// Each platform file implements the same three functions:
+//
+//	func Available() bool
+//	func CopyFiles(paths []string, cut bool) error
+//	func PasteFiles() (paths []string, cut bool, err error)
+//
+// Notes on the `cut` flag: not every platform can represent a "cut" (move) on
+// the system clipboard. macOS Finder in particular has no notion of cutting
+// files, so on macOS a cut degrades to a copy. Callers should treat the `cut`
+// value returned by PasteFiles as advisory.
+package systemclipboard
+
+import "errors"
+
+// ErrUnsupported is returned when the current platform (or environment) cannot
+// transfer files through the system clipboard.
+var ErrUnsupported = errors.New("system clipboard file transfer is not supported on this platform")
+
+// ErrNoFiles is returned by PasteFiles when the system clipboard does not hold
+// any file references.
+var ErrNoFiles = errors.New("no files found on the system clipboard")

--- a/src/internal/systemclipboard/systemclipboard_darwin.go
+++ b/src/internal/systemclipboard/systemclipboard_darwin.go
@@ -24,6 +24,7 @@ import (
 	"unsafe"
 )
 
+// Available reports that this build includes the native macOS pasteboard backend.
 func Available() bool { return true }
 
 // CopyFiles writes the given paths to the macOS general pasteboard as file URLs.

--- a/src/internal/systemclipboard/systemclipboard_darwin.go
+++ b/src/internal/systemclipboard/systemclipboard_darwin.go
@@ -1,0 +1,98 @@
+//go:build darwin && cgo
+
+package systemclipboard
+
+/*
+#cgo LDFLAGS: -framework Foundation -framework AppKit
+#include <stdlib.h>
+
+typedef struct {
+	char *data;
+	char *errorMessage;
+} SPFClipResult;
+
+char *spf_clipboard_copy_files(const char **paths, int count);
+SPFClipResult spf_clipboard_paste_files(void);
+void spf_clip_free_string(char *value);
+*/
+import "C"
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"unsafe"
+)
+
+func Available() bool { return true }
+
+// CopyFiles writes the given paths to the macOS general pasteboard as file URLs.
+//
+// The cut flag is intentionally ignored: macOS Finder has no concept of cutting
+// files (paste is copy, "Move Item Here" is a separate action), and the
+// pasteboard cannot represent a move. A cut therefore degrades to a copy.
+func CopyFiles(paths []string, _ bool) error {
+	if len(paths) == 0 {
+		return ErrNoFiles
+	}
+	abs := make([]string, 0, len(paths))
+	for _, p := range paths {
+		a, err := filepath.Abs(p)
+		if err != nil {
+			return err
+		}
+		abs = append(abs, a)
+	}
+
+	cStrings := make([]*C.char, len(abs))
+	for i, p := range abs {
+		cStrings[i] = C.CString(p)
+	}
+	defer func() {
+		for _, cs := range cStrings {
+			C.free(unsafe.Pointer(cs))
+		}
+	}()
+
+	cErr := C.spf_clipboard_copy_files(
+		(**C.char)(unsafe.Pointer(&cStrings[0])),
+		C.int(len(cStrings)),
+	)
+	if cErr != nil {
+		defer C.spf_clip_free_string(cErr)
+		return errors.New(C.GoString(cErr))
+	}
+	return nil
+}
+
+// PasteFiles reads file paths from the macOS general pasteboard. The returned
+// cut flag is always false (see CopyFiles).
+func PasteFiles() ([]string, bool, error) {
+	result := C.spf_clipboard_paste_files()
+	defer C.spf_clip_free_string(result.data)
+	defer C.spf_clip_free_string(result.errorMessage)
+
+	if result.errorMessage != nil {
+		return nil, false, errors.New(C.GoString(result.errorMessage))
+	}
+
+	var joined string
+	if result.data != nil {
+		joined = C.GoString(result.data)
+	}
+	joined = strings.TrimSpace(joined)
+	if joined == "" {
+		return nil, false, ErrNoFiles
+	}
+
+	var paths []string
+	for _, line := range strings.Split(joined, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			paths = append(paths, line)
+		}
+	}
+	if len(paths) == 0 {
+		return nil, false, ErrNoFiles
+	}
+	return paths, false, nil
+}

--- a/src/internal/systemclipboard/systemclipboard_darwin.m
+++ b/src/internal/systemclipboard/systemclipboard_darwin.m
@@ -1,0 +1,76 @@
+//go:build darwin && cgo
+
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+	char *data;
+	char *errorMessage;
+} SPFClipResult;
+
+static NSString *spf_path_from_cstr(const char *path) {
+	if (path == NULL) {
+		return nil;
+	}
+	return [[NSFileManager defaultManager]
+		stringWithFileSystemRepresentation:path
+		length:strlen(path)];
+}
+
+// spf_clipboard_copy_files writes the given file paths to the general pasteboard
+// as file URLs. Returns an error string (caller frees) or NULL on success.
+char *spf_clipboard_copy_files(const char **paths, int count) {
+	@autoreleasepool {
+		if (paths == NULL || count <= 0) {
+			return strdup("no files to copy");
+		}
+		NSMutableArray<NSURL *> *urls = [NSMutableArray arrayWithCapacity:count];
+		for (int i = 0; i < count; i++) {
+			NSString *p = spf_path_from_cstr(paths[i]);
+			if (p == nil) {
+				return strdup("failed to create macOS file path");
+			}
+			[urls addObject:[NSURL fileURLWithPath:p]];
+		}
+		NSPasteboard *pb = [NSPasteboard generalPasteboard];
+		[pb clearContents];
+		if (![pb writeObjects:urls]) {
+			return strdup("failed to write file URLs to pasteboard");
+		}
+		return NULL;
+	}
+}
+
+// spf_clipboard_paste_files returns the file paths currently on the general
+// pasteboard, newline-separated. The result is empty (but non-NULL) when the
+// pasteboard holds no file URLs. Caller frees both fields.
+SPFClipResult spf_clipboard_paste_files(void) {
+	SPFClipResult result = {0};
+	@autoreleasepool {
+		NSPasteboard *pb = [NSPasteboard generalPasteboard];
+		NSDictionary *options = @{ NSPasteboardURLReadingFileURLsOnlyKey : @YES };
+		NSArray *classes = @[ [NSURL class] ];
+		NSArray<NSURL *> *urls = [pb readObjectsForClasses:classes options:options];
+
+		NSMutableString *joined = [NSMutableString string];
+		for (NSURL *url in urls) {
+			if (![url isFileURL]) {
+				continue;
+			}
+			if ([joined length] > 0) {
+				[joined appendString:@"\n"];
+			}
+			[joined appendString:[url path]];
+		}
+		result.data = strdup([joined UTF8String]);
+		return result;
+	}
+}
+
+void spf_clip_free_string(char *value) {
+	if (value != NULL) {
+		free(value);
+	}
+}

--- a/src/internal/systemclipboard/systemclipboard_darwin.m
+++ b/src/internal/systemclipboard/systemclipboard_darwin.m
@@ -10,6 +10,8 @@ typedef struct {
 	char *errorMessage;
 } SPFClipResult;
 
+// spf_path_from_cstr decodes a filesystem path using macOS conventions, returning
+// nil for a NULL pointer or a path that cannot be represented as an NSString.
 static NSString *spf_path_from_cstr(const char *path) {
 	if (path == NULL) {
 		return nil;
@@ -69,6 +71,8 @@ SPFClipResult spf_clipboard_paste_files(void) {
 	}
 }
 
+// spf_clip_free_string releases a string returned by the clipboard bridge;
+// passing NULL is safe.
 void spf_clip_free_string(char *value) {
 	if (value != NULL) {
 		free(value);

--- a/src/internal/systemclipboard/systemclipboard_darwin_nocgo.go
+++ b/src/internal/systemclipboard/systemclipboard_darwin_nocgo.go
@@ -4,12 +4,15 @@ package systemclipboard
 
 import "fmt"
 
+// Available reports false because the macOS pasteboard backend requires cgo.
 func Available() bool { return false }
 
+// CopyFiles returns ErrUnsupported with a hint to build with cgo enabled.
 func CopyFiles(_ []string, _ bool) error {
 	return fmt.Errorf("%w: macOS clipboard file transfer requires cgo (NSPasteboard)", ErrUnsupported)
 }
 
+// PasteFiles returns no paths and ErrUnsupported because cgo is disabled.
 func PasteFiles() ([]string, bool, error) {
 	return nil, false, fmt.Errorf("%w: macOS clipboard file transfer requires cgo (NSPasteboard)", ErrUnsupported)
 }

--- a/src/internal/systemclipboard/systemclipboard_darwin_nocgo.go
+++ b/src/internal/systemclipboard/systemclipboard_darwin_nocgo.go
@@ -1,0 +1,15 @@
+//go:build darwin && !cgo
+
+package systemclipboard
+
+import "fmt"
+
+func Available() bool { return false }
+
+func CopyFiles(_ []string, _ bool) error {
+	return fmt.Errorf("%w: macOS clipboard file transfer requires cgo (NSPasteboard)", ErrUnsupported)
+}
+
+func PasteFiles() ([]string, bool, error) {
+	return nil, false, fmt.Errorf("%w: macOS clipboard file transfer requires cgo (NSPasteboard)", ErrUnsupported)
+}

--- a/src/internal/systemclipboard/systemclipboard_linux.go
+++ b/src/internal/systemclipboard/systemclipboard_linux.go
@@ -135,14 +135,23 @@ func PasteFiles() ([]string, bool, error) {
 }
 
 func runCopy(tool linuxTool, mime string, payload []byte) error {
+	// A buffer would make os/exec wait for EOF on a pipe inherited by the
+	// background clipboard owner. A file lets Run return when the parent exits.
+	stderr, err := os.CreateTemp("", "superfile-clipboard-stderr-*")
+	if err != nil {
+		return fmt.Errorf("%s copy failed: %w", tool.name, err)
+	}
+	defer os.Remove(stderr.Name())
+	defer stderr.Close()
+
 	args := tool.copyArgs(mime)
 	// #nosec G204 -- args come from a fixed allow-list, only the payload is dynamic.
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdin = bytes.NewReader(payload)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
+	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%s copy failed: %w: %s", tool.name, err, strings.TrimSpace(stderr.String()))
+		diagnostic, _ := os.ReadFile(stderr.Name())
+		return fmt.Errorf("%s copy failed: %w: %s", tool.name, err, strings.TrimSpace(string(diagnostic)))
 	}
 	return nil
 }

--- a/src/internal/systemclipboard/systemclipboard_linux.go
+++ b/src/internal/systemclipboard/systemclipboard_linux.go
@@ -1,0 +1,249 @@
+//go:build linux
+
+package systemclipboard
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// MIME types used to exchange file references with Linux file managers.
+//
+// x-special/gnome-copied-files is understood by the GTK file managers
+// (Nautilus, Nemo, Caja, PCManFM, Thunar, ...) and, unlike text/uri-list, it
+// also encodes whether the operation was a copy or a cut. We use it as the
+// primary format and fall back to text/uri-list when reading.
+const (
+	gnomeCopiedFilesMime = "x-special/gnome-copied-files"
+	uriListMime          = "text/uri-list"
+)
+
+// linuxTool describes how to drive an external clipboard helper. On Linux the
+// clipboard is served by the owning process, so a short-lived TUI cannot hold a
+// selection itself. Both wl-copy and xclip fork into the background and keep
+// serving the selection after we return, which is exactly what we need.
+type linuxTool struct {
+	name      string
+	copyArgs  func(mime string) []string
+	pasteArgs func(mime string) []string
+}
+
+func waylandTool() linuxTool {
+	return linuxTool{
+		name: "wl-clipboard",
+		copyArgs: func(mime string) []string {
+			return []string{"wl-copy", "--type", mime}
+		},
+		pasteArgs: func(mime string) []string {
+			return []string{"wl-paste", "--no-newline", "--type", mime}
+		},
+	}
+}
+
+func xclipTool() linuxTool {
+	return linuxTool{
+		name: "xclip",
+		copyArgs: func(mime string) []string {
+			return []string{"xclip", "-selection", "clipboard", "-target", mime, "-in"}
+		},
+		pasteArgs: func(mime string) []string {
+			return []string{"xclip", "-selection", "clipboard", "-target", mime, "-out"}
+		},
+	}
+}
+
+// detectTool picks the best available clipboard helper for the current session.
+func detectTool() (linuxTool, error) {
+	waylandReady := hasBinary("wl-copy") && hasBinary("wl-paste")
+
+	// Prefer Wayland tooling when we are in a Wayland session.
+	if os.Getenv("WAYLAND_DISPLAY") != "" && waylandReady {
+		return waylandTool(), nil
+	}
+
+	if hasBinary("xclip") {
+		return xclipTool(), nil
+	}
+
+	// Fall back to wl-clipboard even without WAYLAND_DISPLAY (e.g. XWayland).
+	if waylandReady {
+		return waylandTool(), nil
+	}
+
+	return linuxTool{}, fmt.Errorf(
+		"%w: install wl-clipboard (Wayland) or xclip (X11) to enable system clipboard file transfer",
+		ErrUnsupported)
+}
+
+func hasBinary(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+// Available reports whether a supported clipboard helper is present.
+func Available() bool {
+	_, err := detectTool()
+	return err == nil
+}
+
+// CopyFiles places the given paths on the system clipboard using the
+// gnome-copied-files format, tagged as a cut or copy operation.
+func CopyFiles(paths []string, cut bool) error {
+	tool, err := detectTool()
+	if err != nil {
+		return err
+	}
+	abs, err := absPaths(paths)
+	if err != nil {
+		return err
+	}
+	if len(abs) == 0 {
+		return ErrNoFiles
+	}
+
+	payload := buildGnomeCopiedFiles(abs, cut)
+	return runCopy(tool, gnomeCopiedFilesMime, []byte(payload))
+}
+
+// PasteFiles reads file references from the system clipboard.
+func PasteFiles() ([]string, bool, error) {
+	tool, err := detectTool()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Primary: gnome-copied-files (carries the cut/copy flag).
+	if out, perr := runPaste(tool, gnomeCopiedFilesMime); perr == nil {
+		if paths, cut, ok := parseGnomeCopiedFiles(out); ok {
+			return paths, cut, nil
+		}
+	}
+
+	// Fallback: plain text/uri-list (copy semantics only).
+	if out, perr := runPaste(tool, uriListMime); perr == nil {
+		if paths := parseURIList(out); len(paths) > 0 {
+			return paths, false, nil
+		}
+	}
+
+	return nil, false, ErrNoFiles
+}
+
+func runCopy(tool linuxTool, mime string, payload []byte) error {
+	args := tool.copyArgs(mime)
+	// #nosec G204 -- args come from a fixed allow-list, only the payload is dynamic.
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = bytes.NewReader(payload)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s copy failed: %w: %s", tool.name, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func runPaste(tool linuxTool, mime string) ([]byte, error) {
+	args := tool.pasteArgs(mime)
+	// #nosec G204 -- args come from a fixed allow-list.
+	cmd := exec.Command(args[0], args[1:]...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+// --- payload formatting helpers (pure functions, unit tested) ---
+
+func absPaths(paths []string) ([]string, error) {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return nil, fmt.Errorf("resolving %q: %w", p, err)
+		}
+		out = append(out, abs)
+	}
+	return out, nil
+}
+
+// pathToURI converts an absolute filesystem path into a file:// URI with proper
+// percent-encoding.
+func pathToURI(abs string) string {
+	u := url.URL{Scheme: "file", Path: abs}
+	return u.String()
+}
+
+// uriToPath converts a file:// URI (or a bare path) back into a filesystem path.
+func uriToPath(uri string) string {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return ""
+	}
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme == "" {
+		// Not a URI; treat it as a raw path.
+		return uri
+	}
+	if u.Scheme != "file" {
+		return ""
+	}
+	return u.Path
+}
+
+func buildGnomeCopiedFiles(paths []string, cut bool) string {
+	op := "copy"
+	if cut {
+		op = "cut"
+	}
+	lines := make([]string, 0, len(paths)+1)
+	lines = append(lines, op)
+	for _, p := range paths {
+		lines = append(lines, pathToURI(p))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func parseGnomeCopiedFiles(data []byte) (paths []string, cut bool, ok bool) {
+	text := strings.TrimRight(string(data), "\x00\r\n")
+	if text == "" {
+		return nil, false, false
+	}
+	lines := strings.Split(text, "\n")
+	op := strings.TrimSpace(lines[0])
+	switch op {
+	case "cut":
+		cut = true
+	case "copy":
+		cut = false
+	default:
+		return nil, false, false
+	}
+	for _, line := range lines[1:] {
+		if p := uriToPath(line); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths, cut, len(paths) > 0
+}
+
+func parseURIList(data []byte) []string {
+	var paths []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimRight(line, "\r")
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if p := uriToPath(line); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}

--- a/src/internal/systemclipboard/systemclipboard_linux.go
+++ b/src/internal/systemclipboard/systemclipboard_linux.go
@@ -33,6 +33,7 @@ type linuxTool struct {
 	pasteArgs func(mime string) []string
 }
 
+// waylandTool configures wl-copy and wl-paste to exchange a specified MIME type.
 func waylandTool() linuxTool {
 	return linuxTool{
 		name: "wl-clipboard",
@@ -45,6 +46,7 @@ func waylandTool() linuxTool {
 	}
 }
 
+// xclipTool configures xclip to exchange a specified target on the X11 clipboard.
 func xclipTool() linuxTool {
 	return linuxTool{
 		name: "xclip",
@@ -80,6 +82,7 @@ func detectTool() (linuxTool, error) {
 		ErrUnsupported)
 }
 
+// hasBinary reports whether an executable can be resolved through PATH.
 func hasBinary(name string) bool {
 	_, err := exec.LookPath(name)
 	return err == nil
@@ -134,6 +137,8 @@ func PasteFiles() ([]string, bool, error) {
 	return nil, false, ErrNoFiles
 }
 
+// runCopy publishes payload using the helper's background clipboard owner and
+// returns after its parent exits, including stderr diagnostics on failure.
 func runCopy(tool linuxTool, mime string, payload []byte) error {
 	// A buffer would make os/exec wait for EOF on a pipe inherited by the
 	// background clipboard owner. A file lets Run return when the parent exits.
@@ -156,6 +161,7 @@ func runCopy(tool linuxTool, mime string, payload []byte) error {
 	return nil
 }
 
+// runPaste reads the requested MIME type from the helper's standard output.
 func runPaste(tool linuxTool, mime string) ([]byte, error) {
 	args := tool.pasteArgs(mime)
 	// #nosec G204 -- args come from a fixed allow-list.
@@ -170,6 +176,8 @@ func runPaste(tool linuxTool, mime string) ([]byte, error) {
 
 // --- payload formatting helpers (pure functions, unit tested) ---
 
+// absPaths resolves each path against the working directory, preserving order
+// and returning an error if any path cannot be resolved.
 func absPaths(paths []string) ([]string, error) {
 	out := make([]string, 0, len(paths))
 	for _, p := range paths {
@@ -206,6 +214,7 @@ func uriToPath(uri string) string {
 	return u.Path
 }
 
+// buildGnomeCopiedFiles encodes paths as file URIs preceded by a copy or cut marker.
 func buildGnomeCopiedFiles(paths []string, cut bool) string {
 	op := "copy"
 	if cut {
@@ -219,6 +228,8 @@ func buildGnomeCopiedFiles(paths []string, cut bool) string {
 	return strings.Join(lines, "\n")
 }
 
+// parseGnomeCopiedFiles decodes the operation marker and file references, reporting
+// success only when the marker is valid and at least one path is present.
 func parseGnomeCopiedFiles(data []byte) (paths []string, cut bool, ok bool) {
 	text := strings.TrimRight(string(data), "\x00\r\n")
 	if text == "" {
@@ -242,6 +253,8 @@ func parseGnomeCopiedFiles(data []byte) (paths []string, cut bool, ok bool) {
 	return paths, cut, len(paths) > 0
 }
 
+// parseURIList extracts file paths, ignoring blank lines, comments, and non-file
+// URIs while accepting bare paths for compatibility.
 func parseURIList(data []byte) []string {
 	var paths []string
 	for _, line := range strings.Split(string(data), "\n") {

--- a/src/internal/systemclipboard/systemclipboard_linux_test.go
+++ b/src/internal/systemclipboard/systemclipboard_linux_test.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package systemclipboard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathURIRoundTrip(t *testing.T) {
+	cases := []string{
+		"/home/user/file.txt",
+		"/home/user/with space/a b.txt",
+		"/tmp/weird#name?.txt",
+		"/tmp/ünïcode/файл",
+	}
+	for _, p := range cases {
+		got := uriToPath(pathToURI(p))
+		assert.Equal(t, p, got, "round trip for %q", p)
+	}
+}
+
+func TestPathToURIEncoding(t *testing.T) {
+	assert.Equal(t, "file:///home/user/a%20b.txt", pathToURI("/home/user/a b.txt"))
+	assert.Equal(t, "file:///plain/path", pathToURI("/plain/path"))
+}
+
+func TestBuildGnomeCopiedFiles(t *testing.T) {
+	payload := buildGnomeCopiedFiles([]string{"/a/b", "/c d"}, true)
+	assert.Equal(t, "cut\nfile:///a/b\nfile:///c%20d", payload)
+
+	payload = buildGnomeCopiedFiles([]string{"/a"}, false)
+	assert.Equal(t, "copy\nfile:///a", payload)
+}
+
+func TestParseGnomeCopiedFiles(t *testing.T) {
+	paths, cut, ok := parseGnomeCopiedFiles([]byte("cut\nfile:///a/b\nfile:///c%20d"))
+	require.True(t, ok)
+	assert.True(t, cut)
+	assert.Equal(t, []string{"/a/b", "/c d"}, paths)
+
+	paths, cut, ok = parseGnomeCopiedFiles([]byte("copy\nfile:///x\x00"))
+	require.True(t, ok)
+	assert.False(t, cut)
+	assert.Equal(t, []string{"/x"}, paths)
+
+	// Missing/invalid operation header.
+	_, _, ok = parseGnomeCopiedFiles([]byte("file:///a\nfile:///b"))
+	assert.False(t, ok)
+
+	// Empty payload.
+	_, _, ok = parseGnomeCopiedFiles([]byte(""))
+	assert.False(t, ok)
+}
+
+func TestParseURIList(t *testing.T) {
+	data := []byte("# comment\r\nfile:///a/b\r\nfile:///c%20d\r\n\r\n")
+	assert.Equal(t, []string{"/a/b", "/c d"}, parseURIList(data))
+
+	// Bare paths are tolerated.
+	assert.Equal(t, []string{"/plain/path"}, parseURIList([]byte("/plain/path")))
+}
+
+func TestParseGnomeCopiedFilesSkipsNonFileURIs(t *testing.T) {
+	paths, _, ok := parseGnomeCopiedFiles([]byte("copy\nhttp://example.com\nfile:///real"))
+	require.True(t, ok)
+	assert.Equal(t, []string{"/real"}, paths)
+}

--- a/src/internal/systemclipboard/systemclipboard_linux_test.go
+++ b/src/internal/systemclipboard/systemclipboard_linux_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestRunCopyReturnsWhileChildKeepsStderrOpen guards against inherited stderr
+// blocking helper completion and verifies that failure diagnostics are retained.
 func TestRunCopyReturnsWhileChildKeepsStderrOpen(t *testing.T) {
 	for _, exitCode := range []string{"0", "7"} {
 		t.Run("exit_"+exitCode, func(t *testing.T) {
@@ -62,6 +64,7 @@ exit "$4"
 	}
 }
 
+// TestPathURIRoundTrip checks that spaces, URI delimiters, and Unicode survive conversion.
 func TestPathURIRoundTrip(t *testing.T) {
 	cases := []string{
 		"/home/user/file.txt",
@@ -75,11 +78,13 @@ func TestPathURIRoundTrip(t *testing.T) {
 	}
 }
 
+// TestPathToURIEncoding checks percent-encoding without altering plain paths.
 func TestPathToURIEncoding(t *testing.T) {
 	assert.Equal(t, "file:///home/user/a%20b.txt", pathToURI("/home/user/a b.txt"))
 	assert.Equal(t, "file:///plain/path", pathToURI("/plain/path"))
 }
 
+// TestBuildGnomeCopiedFiles checks copy and cut markers and escaped file URIs.
 func TestBuildGnomeCopiedFiles(t *testing.T) {
 	payload := buildGnomeCopiedFiles([]string{"/a/b", "/c d"}, true)
 	assert.Equal(t, "cut\nfile:///a/b\nfile:///c%20d", payload)
@@ -88,6 +93,8 @@ func TestBuildGnomeCopiedFiles(t *testing.T) {
 	assert.Equal(t, "copy\nfile:///a", payload)
 }
 
+// TestParseGnomeCopiedFiles checks operation flags, trailing NULs, and rejection
+// of empty payloads or invalid operation markers.
 func TestParseGnomeCopiedFiles(t *testing.T) {
 	paths, cut, ok := parseGnomeCopiedFiles([]byte("cut\nfile:///a/b\nfile:///c%20d"))
 	require.True(t, ok)
@@ -108,6 +115,7 @@ func TestParseGnomeCopiedFiles(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// TestParseURIList checks CRLF handling, comment removal, and bare-path compatibility.
 func TestParseURIList(t *testing.T) {
 	data := []byte("# comment\r\nfile:///a/b\r\nfile:///c%20d\r\n\r\n")
 	assert.Equal(t, []string{"/a/b", "/c d"}, parseURIList(data))
@@ -116,6 +124,7 @@ func TestParseURIList(t *testing.T) {
 	assert.Equal(t, []string{"/plain/path"}, parseURIList([]byte("/plain/path")))
 }
 
+// TestParseGnomeCopiedFilesSkipsNonFileURIs prevents remote URLs from becoming file paths.
 func TestParseGnomeCopiedFilesSkipsNonFileURIs(t *testing.T) {
 	paths, _, ok := parseGnomeCopiedFiles([]byte("copy\nhttp://example.com\nfile:///real"))
 	require.True(t, ok)

--- a/src/internal/systemclipboard/systemclipboard_linux_test.go
+++ b/src/internal/systemclipboard/systemclipboard_linux_test.go
@@ -3,11 +3,64 @@
 package systemclipboard
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRunCopyReturnsWhileChildKeepsStderrOpen(t *testing.T) {
+	for _, exitCode := range []string{"0", "7"} {
+		t.Run("exit_"+exitCode, func(t *testing.T) {
+			dir := t.TempDir()
+			input := filepath.Join(dir, "input")
+			release := filepath.Join(dir, "release")
+			finished := filepath.Join(dir, "finished")
+			t.Cleanup(func() {
+				require.NoError(t, os.WriteFile(release, nil, 0o600))
+				require.Eventually(t, func() bool {
+					_, err := os.Stat(finished)
+					return err == nil
+				}, 3*time.Second, 10*time.Millisecond)
+			})
+			tool := linuxTool{
+				name: "test-helper",
+				copyArgs: func(string) []string {
+					return []string{"sh", "-c", `
+cat > "$1"
+(while [ ! -f "$2" ]; do sleep 0.05; done; touch "$3") < /dev/null &
+echo "helper diagnostic" >&2
+exit "$4"
+`, "test-helper", input, release, finished, exitCode}
+				},
+			}
+			done := make(chan error, 1)
+			go func() {
+				done <- runCopy(tool, gnomeCopiedFilesMime, []byte("copy\nfile:///tmp/example"))
+			}()
+
+			var err error
+			select {
+			case err = <-done:
+			case <-time.After(3 * time.Second):
+				t.Error("runCopy waited for the background child to close stderr")
+				require.NoError(t, os.WriteFile(release, nil, 0o600))
+				err = <-done
+			}
+			if exitCode == "0" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, "test-helper copy failed: exit status 7: helper diagnostic")
+			}
+			payload, readErr := os.ReadFile(input)
+			require.NoError(t, readErr)
+			assert.Equal(t, "copy\nfile:///tmp/example", string(payload))
+		})
+	}
+}
 
 func TestPathURIRoundTrip(t *testing.T) {
 	cases := []string{

--- a/src/internal/systemclipboard/systemclipboard_unsupported.go
+++ b/src/internal/systemclipboard/systemclipboard_unsupported.go
@@ -2,8 +2,11 @@
 
 package systemclipboard
 
+// Available reports false on platforms without a file clipboard backend.
 func Available() bool { return false }
 
+// CopyFiles returns ErrUnsupported without changing the system clipboard.
 func CopyFiles(_ []string, _ bool) error { return ErrUnsupported }
 
+// PasteFiles returns no paths and ErrUnsupported on this platform.
 func PasteFiles() ([]string, bool, error) { return nil, false, ErrUnsupported }

--- a/src/internal/systemclipboard/systemclipboard_unsupported.go
+++ b/src/internal/systemclipboard/systemclipboard_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin && !windows
+
+package systemclipboard
+
+func Available() bool { return false }
+
+func CopyFiles(_ []string, _ bool) error { return ErrUnsupported }
+
+func PasteFiles() ([]string, bool, error) { return nil, false, ErrUnsupported }

--- a/src/internal/systemclipboard/systemclipboard_windows.go
+++ b/src/internal/systemclipboard/systemclipboard_windows.go
@@ -50,6 +50,7 @@ type dropfiles struct {
 	fWide  int32 // 1 -> the file list is UTF-16
 }
 
+// Available reports that this build includes the native Windows clipboard backend.
 func Available() bool { return true }
 
 // CopyFiles places the given paths on the clipboard as a CF_HDROP payload and
@@ -78,6 +79,8 @@ func CopyFiles(paths []string, cut bool) error {
 	return <-errCh
 }
 
+// copyFiles publishes absolute paths and their preferred drop effect through
+// Win32. The caller must remain on one OS thread for the entire operation.
 func copyFiles(abs []string, cut bool) error {
 	hwnd, _, _ := procGetConsoleWindow.Call()
 	if hwnd == 0 {
@@ -145,6 +148,7 @@ func buildHDropBytes(paths []string) []byte {
 	return buf
 }
 
+// buildDropEffectBytes encodes the copy or move effect as a Win32 DWORD payload.
 func buildDropEffectBytes(cut bool) []byte {
 	effect := uint32(dropEffectCopy)
 	if cut {
@@ -193,6 +197,8 @@ func PasteFiles() ([]string, bool, error) {
 	return r.paths, r.cut, r.err
 }
 
+// pasteFiles reads dropped paths and their preferred move flag through Win32,
+// returning ErrNoFiles when none are available. The caller must pin its OS thread.
 func pasteFiles() ([]string, bool, error) {
 	if r, _, err := procOpenClipboard.Call(0); r == 0 {
 		return nil, false, fmt.Errorf("OpenClipboard failed: %w", err)
@@ -233,6 +239,8 @@ func pasteFiles() ([]string, bool, error) {
 	return paths, readDropEffectCut(), nil
 }
 
+// readDropEffectCut reports whether the open clipboard requests a move, defaulting
+// to copy semantics if the preferred drop effect cannot be read.
 func readDropEffectCut() bool {
 	cfEffect, err := registerFormat("Preferred DropEffect")
 	if err != nil {
@@ -252,6 +260,8 @@ func readDropEffectCut() bool {
 	return effect&dropEffectMove != 0
 }
 
+// registerFormat obtains the Win32 clipboard format identifier for name,
+// registering the format if it does not already exist.
 func registerFormat(name string) (uint32, error) {
 	u16, err := syscall.UTF16PtrFromString(name)
 	if err != nil {

--- a/src/internal/systemclipboard/systemclipboard_windows.go
+++ b/src/internal/systemclipboard/systemclipboard_windows.go
@@ -1,0 +1,255 @@
+//go:build windows
+
+package systemclipboard
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	cfHDROP = 15
+
+	gmemMoveable = 0x0002
+
+	dropEffectCopy = 0x00000001
+	dropEffectMove = 0x00000002
+)
+
+var (
+	user32   = syscall.NewLazyDLL("user32.dll")
+	kernel32 = syscall.NewLazyDLL("kernel32.dll")
+	shell32  = syscall.NewLazyDLL("shell32.dll")
+
+	procOpenClipboard            = user32.NewProc("OpenClipboard")
+	procCloseClipboard           = user32.NewProc("CloseClipboard")
+	procEmptyClipboard           = user32.NewProc("EmptyClipboard")
+	procGetClipboardData         = user32.NewProc("GetClipboardData")
+	procSetClipboardData         = user32.NewProc("SetClipboardData")
+	procRegisterClipboardFormatW = user32.NewProc("RegisterClipboardFormatW")
+
+	procGlobalAlloc  = kernel32.NewProc("GlobalAlloc")
+	procGlobalFree   = kernel32.NewProc("GlobalFree")
+	procGlobalLock   = kernel32.NewProc("GlobalLock")
+	procGlobalUnlock = kernel32.NewProc("GlobalUnlock")
+
+	procDragQueryFileW = shell32.NewProc("DragQueryFileW")
+)
+
+// dropfiles mirrors the Win32 DROPFILES structure that prefixes a CF_HDROP
+// payload. Total size is 20 bytes (DWORD + POINT + 2*BOOL).
+type dropfiles struct {
+	pFiles uint32 // offset (in bytes) to the file list
+	ptX    int32
+	ptY    int32
+	fNC    int32
+	fWide  int32 // 1 -> the file list is UTF-16
+}
+
+func Available() bool { return true }
+
+// CopyFiles places the given paths on the clipboard as a CF_HDROP payload and
+// sets the "Preferred DropEffect" so that a paste into Explorer performs a copy
+// or a move accordingly.
+func CopyFiles(paths []string, cut bool) error {
+	abs := make([]string, 0, len(paths))
+	for _, p := range paths {
+		a, err := filepath.Abs(p)
+		if err != nil {
+			return err
+		}
+		abs = append(abs, a)
+	}
+	if len(abs) == 0 {
+		return ErrNoFiles
+	}
+
+	// The clipboard is thread-affine; keep everything on one OS thread.
+	errCh := make(chan error, 1)
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		errCh <- copyFiles(abs, cut)
+	}()
+	return <-errCh
+}
+
+func copyFiles(abs []string, cut bool) error {
+	if r, _, err := procOpenClipboard.Call(0); r == 0 {
+		return fmt.Errorf("OpenClipboard failed: %w", err)
+	}
+	defer procCloseClipboard.Call()
+
+	if r, _, err := procEmptyClipboard.Call(); r == 0 {
+		return fmt.Errorf("EmptyClipboard failed: %w", err)
+	}
+
+	hDrop, err := globalFromBytes(buildHDropBytes(abs))
+	if err != nil {
+		return err
+	}
+	if r, _, e := procSetClipboardData.Call(cfHDROP, hDrop); r == 0 {
+		procGlobalFree.Call(hDrop)
+		return fmt.Errorf("SetClipboardData(CF_HDROP) failed: %w", e)
+	}
+
+	hEffect, err := globalFromBytes(buildDropEffectBytes(cut))
+	if err != nil {
+		return err
+	}
+	cfEffect, err := registerFormat("Preferred DropEffect")
+	if err != nil {
+		procGlobalFree.Call(hEffect)
+		return err
+	}
+	if r, _, e := procSetClipboardData.Call(uintptr(cfEffect), hEffect); r == 0 {
+		procGlobalFree.Call(hEffect)
+		return fmt.Errorf("SetClipboardData(Preferred DropEffect) failed: %w", e)
+	}
+	return nil
+}
+
+// buildHDropBytes builds the raw CF_HDROP payload: a DROPFILES header followed
+// by a double-null-terminated list of UTF-16 paths. Everything is assembled in
+// ordinary Go memory so no unsafe pointer arithmetic is required.
+func buildHDropBytes(paths []string) []byte {
+	var chars []uint16
+	for _, p := range paths {
+		// UTF16FromString errors only on embedded NULs, which absolute file
+		// paths cannot contain; ignore and fall back to a best-effort encode.
+		u16, err := syscall.UTF16FromString(p)
+		if err != nil {
+			continue
+		}
+		chars = append(chars, u16...) // includes the trailing NUL for this path
+	}
+	chars = append(chars, 0) // extra NUL to terminate the list
+
+	headerSize := int(unsafe.Sizeof(dropfiles{}))
+	buf := make([]byte, headerSize+len(chars)*2)
+
+	header := dropfiles{pFiles: uint32(headerSize), fWide: 1}
+	*(*dropfiles)(unsafe.Pointer(&buf[0])) = header
+
+	list := unsafe.Slice((*uint16)(unsafe.Pointer(&buf[headerSize])), len(chars))
+	copy(list, chars)
+	return buf
+}
+
+func buildDropEffectBytes(cut bool) []byte {
+	effect := uint32(dropEffectCopy)
+	if cut {
+		effect = dropEffectMove
+	}
+	buf := make([]byte, 4)
+	*(*uint32)(unsafe.Pointer(&buf[0])) = effect
+	return buf
+}
+
+// globalFromBytes copies buf into a freshly allocated moveable global memory
+// block suitable for SetClipboardData, returning its handle.
+func globalFromBytes(buf []byte) (uintptr, error) {
+	hMem, _, err := procGlobalAlloc.Call(gmemMoveable, uintptr(len(buf)))
+	if hMem == 0 {
+		return 0, fmt.Errorf("GlobalAlloc failed: %w", err)
+	}
+	ptr, _, _ := procGlobalLock.Call(hMem)
+	if ptr == 0 {
+		procGlobalFree.Call(hMem)
+		return 0, fmt.Errorf("GlobalLock failed")
+	}
+	// GlobalLock returns a stable pointer into non-movable locked memory.
+	dst := unsafe.Slice((*byte)(unsafe.Pointer(ptr)), len(buf)) //nolint:govet // uintptr from GlobalLock points to locked, non-movable memory
+	copy(dst, buf)
+	procGlobalUnlock.Call(hMem)
+	return hMem, nil
+}
+
+// PasteFiles reads a CF_HDROP payload from the clipboard and reports whether the
+// source marked it as a move (cut).
+func PasteFiles() ([]string, bool, error) {
+	type result struct {
+		paths []string
+		cut   bool
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		paths, cut, err := pasteFiles()
+		ch <- result{paths, cut, err}
+	}()
+	r := <-ch
+	return r.paths, r.cut, r.err
+}
+
+func pasteFiles() ([]string, bool, error) {
+	if r, _, err := procOpenClipboard.Call(0); r == 0 {
+		return nil, false, fmt.Errorf("OpenClipboard failed: %w", err)
+	}
+	defer procCloseClipboard.Call()
+
+	hDrop, _, _ := procGetClipboardData.Call(cfHDROP)
+	if hDrop == 0 {
+		return nil, false, ErrNoFiles
+	}
+
+	count, _, _ := procDragQueryFileW.Call(hDrop, 0xFFFFFFFF, 0, 0)
+	if count == 0 {
+		return nil, false, ErrNoFiles
+	}
+
+	var paths []string
+	buf := make([]uint16, syscall.MAX_PATH)
+	for i := uintptr(0); i < count; i++ {
+		n, _, _ := procDragQueryFileW.Call(
+			hDrop, i,
+			uintptr(unsafe.Pointer(&buf[0])),
+			uintptr(len(buf)),
+		)
+		if n == 0 {
+			continue
+		}
+		paths = append(paths, syscall.UTF16ToString(buf[:n]))
+	}
+	if len(paths) == 0 {
+		return nil, false, ErrNoFiles
+	}
+
+	return paths, readDropEffectCut(), nil
+}
+
+func readDropEffectCut() bool {
+	cfEffect, err := registerFormat("Preferred DropEffect")
+	if err != nil {
+		return false
+	}
+	hEffect, _, _ := procGetClipboardData.Call(uintptr(cfEffect))
+	if hEffect == 0 {
+		return false
+	}
+	ptr, _, _ := procGlobalLock.Call(hEffect)
+	if ptr == 0 {
+		return false
+	}
+	defer procGlobalUnlock.Call(hEffect)
+	// ptr comes from GlobalLock and points to locked, non-movable memory.
+	effect := *(*uint32)(unsafe.Pointer(ptr)) //nolint:govet // stable locked-memory pointer
+	return effect&dropEffectMove != 0
+}
+
+func registerFormat(name string) (uint32, error) {
+	u16, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return 0, err
+	}
+	r, _, e := procRegisterClipboardFormatW.Call(uintptr(unsafe.Pointer(u16)))
+	if r == 0 {
+		return 0, fmt.Errorf("RegisterClipboardFormat(%q) failed: %w", name, e)
+	}
+	return uint32(r), nil
+}

--- a/src/internal/systemclipboard/systemclipboard_windows.go
+++ b/src/internal/systemclipboard/systemclipboard_windows.go
@@ -31,10 +31,11 @@ var (
 	procSetClipboardData         = user32.NewProc("SetClipboardData")
 	procRegisterClipboardFormatW = user32.NewProc("RegisterClipboardFormatW")
 
-	procGlobalAlloc  = kernel32.NewProc("GlobalAlloc")
-	procGlobalFree   = kernel32.NewProc("GlobalFree")
-	procGlobalLock   = kernel32.NewProc("GlobalLock")
-	procGlobalUnlock = kernel32.NewProc("GlobalUnlock")
+	procGlobalAlloc      = kernel32.NewProc("GlobalAlloc")
+	procGlobalFree       = kernel32.NewProc("GlobalFree")
+	procGlobalLock       = kernel32.NewProc("GlobalLock")
+	procGlobalUnlock     = kernel32.NewProc("GlobalUnlock")
+	procGetConsoleWindow = kernel32.NewProc("GetConsoleWindow")
 
 	procDragQueryFileW = shell32.NewProc("DragQueryFileW")
 )
@@ -78,7 +79,11 @@ func CopyFiles(paths []string, cut bool) error {
 }
 
 func copyFiles(abs []string, cut bool) error {
-	if r, _, err := procOpenClipboard.Call(0); r == 0 {
+	hwnd, _, _ := procGetConsoleWindow.Call()
+	if hwnd == 0 {
+		return fmt.Errorf("GetConsoleWindow failed: no console window")
+	}
+	if r, _, err := procOpenClipboard.Call(hwnd); r == 0 {
 		return fmt.Errorf("OpenClipboard failed: %w", err)
 	}
 	defer procCloseClipboard.Call()
@@ -107,6 +112,7 @@ func copyFiles(abs []string, cut bool) error {
 	}
 	if r, _, e := procSetClipboardData.Call(uintptr(cfEffect), hEffect); r == 0 {
 		procGlobalFree.Call(hEffect)
+		procEmptyClipboard.Call()
 		return fmt.Errorf("SetClipboardData(Preferred DropEffect) failed: %w", e)
 	}
 	return nil
@@ -118,8 +124,8 @@ func copyFiles(abs []string, cut bool) error {
 func buildHDropBytes(paths []string) []byte {
 	var chars []uint16
 	for _, p := range paths {
-		// UTF16FromString errors only on embedded NULs, which absolute file
-		// paths cannot contain; ignore and fall back to a best-effort encode.
+		// UTF16FromString errors only on embedded NULs; skip the current path
+		// if it cannot be encoded.
 		u16, err := syscall.UTF16FromString(p)
 		if err != nil {
 			continue
@@ -204,9 +210,13 @@ func pasteFiles() ([]string, bool, error) {
 	}
 
 	var paths []string
-	buf := make([]uint16, syscall.MAX_PATH)
 	for i := uintptr(0); i < count; i++ {
-		n, _, _ := procDragQueryFileW.Call(
+		n, _, _ := procDragQueryFileW.Call(hDrop, i, 0, 0)
+		if n == 0 {
+			continue
+		}
+		buf := make([]uint16, n+1) // include the terminating NUL
+		n, _, _ = procDragQueryFileW.Call(
 			hDrop, i,
 			uintptr(unsafe.Pointer(&buf[0])),
 			uintptr(len(buf)),

--- a/src/internal/type.go
+++ b/src/internal/type.go
@@ -98,6 +98,9 @@ type model struct {
 
 	// whether usable trash directory exists or not
 	hasTrash bool
+
+	// whether the OS clipboard can transfer real files/directories
+	hasSystemClipboard bool
 }
 
 type typingModal struct {

--- a/src/internal/ui/helpmenu/data.go
+++ b/src/internal/ui/helpmenu/data.go
@@ -220,7 +220,7 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 		},
 		{
 			hotkey:         common.Hotkeys.CopyToSystemClipboard,
-			description:    "Copy selected items to the system clipboard (for the OS file manager)",
+			description:    "Copy focused or selected items to the system clipboard (for the OS file manager)",
 			hotkeyWorkType: globalType,
 		},
 		{

--- a/src/internal/ui/helpmenu/data.go
+++ b/src/internal/ui/helpmenu/data.go
@@ -219,6 +219,16 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 			hotkeyWorkType: globalType,
 		},
 		{
+			hotkey:         common.Hotkeys.CopyToSystemClipboard,
+			description:    "Copy selected items to the system clipboard (for the OS file manager)",
+			hotkeyWorkType: globalType,
+		},
+		{
+			hotkey:         common.Hotkeys.PasteFromSystemClipboard,
+			description:    "Paste files from the system clipboard into the current file panel",
+			hotkeyWorkType: globalType,
+		},
+		{
 			hotkey:         common.Hotkeys.DeleteItems,
 			description:    "Delete selected items",
 			hotkeyWorkType: globalType,

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -51,6 +51,10 @@ delete_items = ['ctrl+d', 'delete', '']
 paste_items = ['ctrl+v', 'ctrl+w', '']
 permanently_delete_items = ['D', '']
 
+#-- System Clipboard (interop with the OS file manager)
+copy_to_system_clipboard = ['C', '']
+paste_from_system_clipboard = ['V', '']
+
 #-- Archive Manipulation
 compress_file = ['ctrl+a', '']
 extract_file = ['ctrl+e', '']

--- a/src/superfile_config/vimHotkeys.toml
+++ b/src/superfile_config/vimHotkeys.toml
@@ -53,6 +53,10 @@ paste_items = ['p', '']
 delete_items = ['d', '']
 permanently_delete_items = ['D', '']
 
+#-- System Clipboard (interop with the OS file manager)
+copy_to_system_clipboard = ['C', '']
+paste_from_system_clipboard = ['V', '']
+
 #-- Archive Manipulation
 extract_file = ['ctrl+e', '']
 compress_file = ['ctrl+a', '']


### PR DESCRIPTION
Closes #741. Adds a `systemclipboard` package modeled on the existing `trash` package (per-platform build-tagged files, no new Go dependency) plus `copy_to_system_clipboard` (C) and `paste_from_system_clipboard` (V) hotkeys. Paste reuses the existing paste pipeline. Not yet manually verified on Windows/macOS hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for copying focused or selected files and folders to the system file manager.
  - Added support for pasting files and folders from the system clipboard.
  - Added configurable default and Vim-style hotkeys for clipboard transfers.
  - Added support across Windows, macOS, and Linux where available.
  - Added notifications for unavailable support, invalid destinations, empty clipboards, and transfer errors.

- **Documentation**
  - Updated help-menu descriptions for clipboard actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->