### PR TITLE
fix(navigation): stop blocking the event loop on directory and sidebar reads

### DIFF
--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -150,7 +150,9 @@ func (m *model) confirmRename() {
 	m.fileModel.Renaming = false
 	panel.Rename.Blur()
 	panel.Renaming = false
-	panel.MarkStale()
+	// Every panel, not just this one: another panel showing the same directory
+	// would otherwise be free to install a read that predates the rename.
+	m.fileModel.MarkPanelsStale()
 }
 
 func (m *model) confirmSortOptions() {

--- a/src/internal/handle_modal.go
+++ b/src/internal/handle_modal.go
@@ -150,6 +150,7 @@ func (m *model) confirmRename() {
 	m.fileModel.Renaming = false
 	panel.Rename.Blur()
 	panel.Renaming = false
+	panel.MarkStale()
 }
 
 func (m *model) confirmSortOptions() {

--- a/src/internal/handle_panel_navigation.go
+++ b/src/internal/handle_panel_navigation.go
@@ -13,6 +13,7 @@ func (m *model) pinnedDirectory() {
 	if err != nil {
 		slog.Error("Error while toggling pinned directory", "error", err)
 	}
+	m.sidebarModel.UpdateDirectoriesIfNeeded(true)
 }
 
 // Focus on sidebar

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -362,6 +362,7 @@ func (m *model) sidebarRenamingKey(msg string) {
 		m.sidebarModel.CancelSidebarRename()
 	case slices.Contains(common.Hotkeys.ConfirmTyping, msg):
 		m.sidebarModel.ConfirmSidebarRename()
+		m.sidebarModel.UpdateDirectoriesIfNeeded(true)
 	}
 }
 

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -121,7 +121,7 @@ func (m *model) handleMouseMsg(msg tea.MouseMsg) {
 }
 
 func (m *model) updateModelStateAfterMsg() tea.Cmd {
-	m.sidebarModel.UpdateDirectories()
+	m.sidebarModel.UpdateDirectoriesIfNeeded(false)
 	refreshCmd := m.filePanelsRefreshCmd()
 	// TODO: Move to utility
 	if m.focusPanel != metadataFocus {

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -102,13 +102,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// This is needed for blink, etc to work
 	panelCmd = m.updateComponentState(msg)
 
-	m.updateModelStateAfterMsg()
+	refreshCmd := m.updateModelStateAfterMsg()
 	filePreviewCmd = m.fileModel.GetFilePreviewCmd(false)
 
 	metadataCmd = m.getMetadataCmd()
 
 	return m, tea.Batch(sidebarCmd, helpMenuCmd, inputCmd, updateCmd,
-		panelCmd, metadataCmd, filePreviewCmd, resizeCmd)
+		panelCmd, metadataCmd, filePreviewCmd, resizeCmd, refreshCmd)
 }
 
 func (m *model) handleMouseMsg(msg tea.MouseMsg) {
@@ -120,9 +120,9 @@ func (m *model) handleMouseMsg(msg tea.MouseMsg) {
 	}
 }
 
-func (m *model) updateModelStateAfterMsg() {
+func (m *model) updateModelStateAfterMsg() tea.Cmd {
 	m.sidebarModel.UpdateDirectories()
-	m.fileModel.UpdateFilePanelsIfNeeded(false)
+	refreshCmd := m.filePanelsRefreshCmd()
 	// TODO: Move to utility
 	if m.focusPanel != metadataFocus {
 		m.fileMetaData.ResetRender()
@@ -132,6 +132,25 @@ func (m *model) updateModelStateAfterMsg() {
 	if !m.firstLoadingComplete {
 		m.firstLoadingComplete = true
 	}
+	return refreshCmd
+}
+
+// Re-read the file panels' directories off the event loop. Reads that a panel
+// cannot render without are still done inline by UpdateFilePanelsIfNeeded.
+func (m *model) filePanelsRefreshCmd() tea.Cmd {
+	reqs := m.fileModel.UpdateFilePanelsIfNeeded(false)
+	if len(reqs) == 0 {
+		return nil
+	}
+	cmds := make([]tea.Cmd, 0, len(reqs))
+	for _, req := range reqs {
+		reqCnt := m.nextIoReqCnt()
+		slog.Debug("Submitting file panel refresh request", "id", reqCnt, "path", req.Location)
+		cmds = append(cmds, func() tea.Msg {
+			return NewElementsRefreshMsg(req, req.Read(), reqCnt)
+		})
+	}
+	return tea.Batch(cmds...)
 }
 
 // Note : Maybe we should not trigger metadata fetch for updates

--- a/src/internal/model_file_operations_test.go
+++ b/src/internal/model_file_operations_test.go
@@ -178,6 +178,38 @@ func TestFileRename(t *testing.T) {
 		}, DefaultTestTimeout, DefaultTestTick, "File never got renamed")
 	})
 
+	t.Run("Rename is visible in a second panel on the same directory", func(t *testing.T) {
+		// A rename has to invalidate every panel, not only the focused one.
+		// Otherwise a background re-read dispatched before the rename can land
+		// afterwards and leave the other panel showing the old name.
+		renamed := filepath.Join(curTestDir, "file2_renamed.txt")
+		t.Cleanup(func() { _ = os.Rename(renamed, file2) })
+
+		m := defaultTestModel(curTestDir)
+		TeaUpdate(m, nil)
+		_, err := m.splitPanel()
+		require.NoError(t, err)
+		TeaUpdate(m, nil)
+		require.Equal(t, 2, m.fileModel.PanelCount())
+		for i := range m.fileModel.FilePanels {
+			require.NotEqual(t, -1, m.fileModel.FilePanels[i].FindElementIndexByLocation(file2),
+				"both panels should list file2 before the rename")
+		}
+
+		setFilePanelSelectedItemByName(t, m.getFocusedFilePanel(), filepath.Base(file2))
+		m.panelItemRename()
+		m.getFocusedFilePanel().Rename.SetValue(filepath.Base(renamed))
+		m.confirmRename()
+		TeaUpdate(m, nil)
+
+		for i := range m.fileModel.FilePanels {
+			assert.NotEqual(t, -1, m.fileModel.FilePanels[i].FindElementIndexByLocation(renamed),
+				"panel %d should show the renamed file", i)
+			assert.Equal(t, -1, m.fileModel.FilePanels[i].FindElementIndexByLocation(file2),
+				"panel %d should no longer show the old name", i)
+		}
+	})
+
 	t.Run("Rename confirmation for same name", func(t *testing.T) {
 		actualTest := func(doRename bool) {
 			m := defaultTestModel(curTestDir)

--- a/src/internal/model_msg.go
+++ b/src/internal/model_msg.go
@@ -40,6 +40,7 @@ func NewPasteOperationMsg(state processbar.ProcessState, reqID int) PasteOperati
 }
 
 func (msg PasteOperationMsg) ApplyToModel(m *model) tea.Cmd {
+	m.fileModel.MarkPanelsStale()
 	if (msg.state == processbar.Failed || msg.state == processbar.Successful) && m.clipboard.IsCut() {
 		m.clipboard.Reset(false)
 	}
@@ -62,6 +63,7 @@ func NewCreateOperationMsg(state processbar.ProcessState, reqID int) CreateOpera
 }
 
 func (msg CreateOperationMsg) ApplyToModel(m *model) tea.Cmd {
+	m.fileModel.MarkPanelsStale()
 	return nil
 }
 
@@ -81,6 +83,7 @@ func NewDeleteOperationMsg(state processbar.ProcessState, reqID int) DeleteOpera
 }
 
 func (msg DeleteOperationMsg) ApplyToModel(m *model) tea.Cmd {
+	m.fileModel.MarkPanelsStale()
 	// Remove selection
 	m.getFocusedFilePanel().ResetSelected()
 	return nil
@@ -115,7 +118,8 @@ func NewCompressOperationMsg(state processbar.ProcessState, reqID int) CompressO
 	}
 }
 
-func (msg CompressOperationMsg) ApplyToModel(_ *model) tea.Cmd {
+func (msg CompressOperationMsg) ApplyToModel(m *model) tea.Cmd {
+	m.fileModel.MarkPanelsStale()
 	return nil
 }
 
@@ -134,7 +138,8 @@ func NewExtractOperationMsg(state processbar.ProcessState, reqID int) ExtractOpe
 	}
 }
 
-func (msg ExtractOperationMsg) ApplyToModel(_ *model) tea.Cmd {
+func (msg ExtractOperationMsg) ApplyToModel(m *model) tea.Cmd {
+	m.fileModel.MarkPanelsStale()
 	return nil
 }
 

--- a/src/internal/model_msg.go
+++ b/src/internal/model_msg.go
@@ -5,6 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/yorukot/superfile/src/internal/ui/filepanel"
 	"github.com/yorukot/superfile/src/internal/ui/metadata"
 	"github.com/yorukot/superfile/src/internal/ui/notify"
 	"github.com/yorukot/superfile/src/internal/ui/processbar"
@@ -178,6 +179,31 @@ func (msg MetadataMsg) ApplyToModel(m *model) tea.Cmd {
 		return nil
 	}
 	m.fileMetaData.SetMetadata(msg.meta, msg.metadataFocused)
+	return nil
+}
+
+// ElementsRefreshMsg carries the result of a directory listing read off the
+// event loop.
+type ElementsRefreshMsg struct {
+	BaseMessage
+
+	req      filepanel.ElementsRequest
+	elements []filepanel.Element
+}
+
+func NewElementsRefreshMsg(req filepanel.ElementsRequest, elements []filepanel.Element,
+	reqID int) ElementsRefreshMsg {
+	return ElementsRefreshMsg{
+		req:      req,
+		elements: elements,
+		BaseMessage: BaseMessage{
+			reqID: reqID,
+		},
+	}
+}
+
+func (msg ElementsRefreshMsg) ApplyToModel(m *model) tea.Cmd {
+	m.fileModel.ApplyElementsRefresh(msg.req, msg.elements)
 	return nil
 }
 

--- a/src/internal/ui/filemodel/update.go
+++ b/src/internal/ui/filemodel/update.go
@@ -133,15 +133,29 @@ func (m *Model) ToggleDotFile() {
 	m.UpdateFilePanelsIfNeeded(true)
 }
 
-func (m *Model) UpdateFilePanelsIfNeeded(force bool) {
+// UpdateFilePanelsIfNeeded returns the listings that panels want re-read but that
+// they can keep rendering without, for the caller to read off the event loop.
+func (m *Model) UpdateFilePanelsIfNeeded(force bool) []filepanel.ElementsRequest {
+	var reqs []filepanel.ElementsRequest
 	for i := range m.FilePanels {
-		m.FilePanels[i].UpdateElementsIfNeeded(force, m.DisplayDotFiles)
+		if req := m.FilePanels[i].UpdateElementsIfNeeded(force, m.DisplayDotFiles); req != nil {
+			reqs = append(reqs, *req)
+		}
 	}
+	return reqs
 }
 
 // MarkPanelsStale forces every panel to re-read its listing on the next update.
 func (m *Model) MarkPanelsStale() {
 	for i := range m.FilePanels {
 		m.FilePanels[i].MarkStale()
+	}
+}
+
+// ApplyElementsRefresh offers a completed listing to every panel. Panels that did
+// not ask for it, or have moved on since, ignore it.
+func (m *Model) ApplyElementsRefresh(req filepanel.ElementsRequest, elements []filepanel.Element) {
+	for i := range m.FilePanels {
+		m.FilePanels[i].ApplyElements(req, elements, m.DisplayDotFiles)
 	}
 }

--- a/src/internal/ui/filemodel/update.go
+++ b/src/internal/ui/filemodel/update.go
@@ -138,3 +138,10 @@ func (m *Model) UpdateFilePanelsIfNeeded(force bool) {
 		m.FilePanels[i].UpdateElementsIfNeeded(force, m.DisplayDotFiles)
 	}
 }
+
+// MarkPanelsStale forces every panel to re-read its listing on the next update.
+func (m *Model) MarkPanelsStale() {
+	for i := range m.FilePanels {
+		m.FilePanels[i].MarkStale()
+	}
+}

--- a/src/internal/ui/filepanel/consts.go
+++ b/src/internal/ui/filepanel/consts.go
@@ -22,6 +22,10 @@ const (
 	ReRenderMaxDelay     = 3
 
 	nonFocussedPanelReRenderTime = 3 * time.Second
+	// Floor for how often a focused panel re-reads its directory. Without it the
+	// ReRenderChunkDivisor scaling truncates to zero for anything under
+	// ReRenderChunkDivisor entries, which meant a re-read on every message.
+	focussedPanelReRenderTime = 1 * time.Second
 
 	emptyCursor = " "
 )

--- a/src/internal/ui/filepanel/get_elements.go
+++ b/src/internal/ui/filepanel/get_elements.go
@@ -11,15 +11,20 @@ import (
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
-// ElementsRequest is everything a directory listing depends on. It is
-// comparable, which is how a panel tells whether the listing it is showing is
-// still the one it wants.
+// ElementsRequest is everything a directory listing depends on. It holds no
+// reference to Model, so Read() is safe to run off the event loop, and it is
+// comparable, which is how a panel tells whether a listing is the one it wants.
 type ElementsRequest struct {
 	Location       string
 	Search         string
 	SortKind       sortmodel.SortKind
 	SortReversed   bool
 	DisplayDotFile bool
+
+	// generation is bumped by MarkStale. Without it a read that started before
+	// superfile changed the directory would carry an identical request, and could
+	// land afterwards and replace the listing read after the change.
+	generation int
 }
 
 // Read performs the filesystem IO for the request.
@@ -98,6 +103,7 @@ func (m *Model) elementsRequest(displayDotFile bool) ElementsRequest {
 		SortKind:       m.SortKind,
 		SortReversed:   m.SortReversed,
 		DisplayDotFile: displayDotFile,
+		generation:     m.generation,
 	}
 }
 
@@ -112,23 +118,53 @@ func (m *Model) refreshInterval() time.Duration {
 	return min(max(scaled, focussedPanelReRenderTime), ReRenderMaxDelay*time.Second)
 }
 
-// UpdateElementsIfNeeded re-reads the panel's directory when it needs to.
+// UpdateElementsIfNeeded brings the panel's elements in line with what it wants
+// to display.
 //
 // A read the panel cannot render without - first load, directory change, new
-// search text, changed sort - happens right away. Otherwise the listing is only
-// re-read once per refreshInterval, to pick up changes made outside superfile.
-//
-// The interval used to be int(elemCount / ReRenderChunkDivisor) seconds, which
-// truncates to 0 for any directory with fewer than ReRenderChunkDivisor
-// entries. The panel therefore re-read on every message, so every keystroke
-// waited on the filesystem and navigating a network mount fell behind held keys.
-func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) {
+// search text, changed sort - is done synchronously. The periodic re-read that
+// only picks up outside changes is returned instead, for the caller to run off
+// the event loop. Doing that one inline made every message wait on the
+// filesystem, so on a network mount the cursor fell behind held keys and kept
+// moving long after they were released.
+func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) *ElementsRequest {
 	req := m.elementsRequest(displayDotFile)
-	if !force && req == m.loaded && time.Since(m.lastTimeGetElement) < m.refreshInterval() {
+	if force || m.loaded != req {
+		m.ApplyElements(req, req.Read(), displayDotFile)
+		return nil
+	}
+	if m.refreshPending || time.Since(m.lastTimeGetElement) < m.refreshInterval() {
+		return nil
+	}
+	m.refreshPending = true
+	return &req
+}
+
+// MarkStale forces the panel to re-read its listing synchronously on the next
+// update, and invalidates any read already in flight. Use it when superfile
+// itself changes a directory's contents, so the change is visible right away
+// instead of at the next poll.
+func (m *Model) MarkStale() {
+	// Bumping the generation makes `loaded` differ from what the panel now wants,
+	// which takes the synchronous path below, and makes a read dispatched before
+	// this point fail the check in ApplyElements.
+	m.generation++
+}
+
+// ApplyElements installs a listing, ignoring a result for a request the panel has
+// since moved on from - a different directory, search or sort, or a generation
+// bumped by MarkStale while the read was in flight.
+func (m *Model) ApplyElements(req ElementsRequest, elements []Element, displayDotFile bool) {
+	if req != m.elementsRequest(displayDotFile) {
+		slog.Debug("Ignoring elements of a stale request", "reqLocation", req.Location,
+			"location", m.Location, "reqGeneration", req.generation,
+			"generation", m.generation)
 		return
 	}
-
-	m.element = req.Read()
+	// Every request change goes through the synchronous path above, so this also
+	// clears the flag for a pending refresh whose result will never be applied.
+	m.refreshPending = false
+	m.element = elements
 	m.loaded = req
 	m.lastTimeGetElement = time.Now()
 
@@ -141,11 +177,4 @@ func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) {
 	if m.ValidateCursorAndRenderIndex() != nil {
 		m.scrollToCursor(0)
 	}
-}
-
-// MarkStale forces the panel to re-read its listing on the next update. Use it
-// when superfile itself changes a directory's contents, so the change is visible
-// right away instead of at the next refresh.
-func (m *Model) MarkStale() {
-	m.loaded = ElementsRequest{}
 }

--- a/src/internal/ui/filepanel/get_elements.go
+++ b/src/internal/ui/filepanel/get_elements.go
@@ -7,37 +7,57 @@ import (
 	"strings"
 	"time"
 
+	"github.com/yorukot/superfile/src/internal/ui/sortmodel"
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
+
+// ElementsRequest is everything a directory listing depends on. It is
+// comparable, which is how a panel tells whether the listing it is showing is
+// still the one it wants.
+type ElementsRequest struct {
+	Location       string
+	Search         string
+	SortKind       sortmodel.SortKind
+	SortReversed   bool
+	DisplayDotFile bool
+}
+
+// Read performs the filesystem IO for the request.
+func (r ElementsRequest) Read() []Element {
+	if r.Search != "" {
+		return getDirectoryElementsBySearch(r)
+	}
+	return getDirectoryElements(r)
+}
 
 // TODO : Take common.Config.CaseSensitiveSort as a function parameter
 // and also consider testing this caseSensitive with both true and false in
 // our unit_test TestReturnDirElement
-// getDirectoryElements returns the directory elements for the panel's current location
-func (m *Model) getDirectoryElements(displayDotFile bool) []Element {
-	dirEntries, err := os.ReadDir(m.Location)
+// getDirectoryElements returns the directory elements for the requested location
+func getDirectoryElements(r ElementsRequest) []Element {
+	dirEntries, err := os.ReadDir(r.Location)
 	if err != nil {
 		slog.Error("Error while returning folder elements", "error", err)
 		return nil
 	}
 
-	dirEntries = slices.DeleteFunc(dirEntries, func(e os.DirEntry) bool {
-		// Entries not needed to be considered
-		_, err := e.Info()
-		return err != nil || (strings.HasPrefix(e.Name(), ".") && !displayDotFile)
-	})
+	if !r.DisplayDotFile {
+		dirEntries = slices.DeleteFunc(dirEntries, func(e os.DirEntry) bool {
+			return strings.HasPrefix(e.Name(), ".")
+		})
+	}
 
 	// No files/directories to process
 	if len(dirEntries) == 0 {
 		return nil
 	}
-	return sortFileElement(m.SortKind, m.SortReversed, dirEntries, m.Location)
+	// Entries whose Info() fails get dropped by sortFileElement
+	return sortFileElement(r.SortKind, r.SortReversed, dirEntries, r.Location)
 }
 
 // getDirectoryElementsBySearch returns filtered directory elements based on search string
-func (m *Model) getDirectoryElementsBySearch(displayDotFile bool) []Element {
-	searchString := m.SearchBar.Value()
-	items, err := os.ReadDir(m.Location)
+func getDirectoryElementsBySearch(r ElementsRequest) []Element {
+	items, err := os.ReadDir(r.Location)
 	if err != nil {
 		slog.Error("Error while return folder element function", "error", err)
 		return nil
@@ -51,11 +71,7 @@ func (m *Model) getDirectoryElementsBySearch(displayDotFile bool) []Element {
 	fileAndDirectories := []string{}
 
 	for _, item := range items {
-		fileInfo, err := item.Info()
-		if err != nil {
-			continue
-		}
-		if !displayDotFile && strings.HasPrefix(fileInfo.Name(), ".") {
+		if !r.DisplayDotFile && strings.HasPrefix(item.Name(), ".") {
 			continue
 		}
 
@@ -64,52 +80,72 @@ func (m *Model) getDirectoryElementsBySearch(displayDotFile bool) []Element {
 	}
 	// https://github.com/reinhrst/fzf-lib/blob/main/core.go#L43
 	// fzf returns matches ordered by score; we subsequently sort by the chosen sort option.
-	fzfResults := utils.FzfSearch(searchString, fileAndDirectories)
+	fzfResults := utils.FzfSearch(r.Search, fileAndDirectories)
 	dirElements := make([]os.DirEntry, 0, len(fzfResults))
 	for _, item := range fzfResults {
 		resultItem := folderElementMap[item.Key]
 		dirElements = append(dirElements, resultItem)
 	}
 
-	return sortFileElement(m.SortKind, m.SortReversed, dirElements, m.Location)
+	return sortFileElement(r.SortKind, r.SortReversed, dirElements, r.Location)
 }
 
-// Helper to decide whether to skip updating a panel this tick.
-func (m *Model) shouldSkipPanelUpdate(nowTime time.Time) bool {
+// elementsRequest is the listing the panel wants to be displaying right now.
+func (m *Model) elementsRequest(displayDotFile bool) ElementsRequest {
+	return ElementsRequest{
+		Location:       m.Location,
+		Search:         m.SearchBar.Value(),
+		SortKind:       m.SortKind,
+		SortReversed:   m.SortReversed,
+		DisplayDotFile: displayDotFile,
+	}
+}
+
+// refreshInterval is how long a panel keeps a listing before re-reading it to
+// pick up changes made outside superfile. Bigger directories cost more to read,
+// so they get polled less often.
+func (m *Model) refreshInterval() time.Duration {
 	if !m.IsFocused {
-		return nowTime.Sub(m.LastTimeGetElement) < nonFocussedPanelReRenderTime
+		return nonFocussedPanelReRenderTime
 	}
-
-	reRenderTime := int(float64(m.ElemCount()) / ReRenderChunkDivisor)
-	reRenderTime = min(reRenderTime, ReRenderMaxDelay)
-	return !m.NeedsReRender() &&
-		nowTime.Sub(m.LastTimeGetElement) < time.Duration(reRenderTime)*time.Second
+	scaled := time.Duration(m.ElemCount()/ReRenderChunkDivisor) * time.Second
+	return min(max(scaled, focussedPanelReRenderTime), ReRenderMaxDelay*time.Second)
 }
 
+// UpdateElementsIfNeeded re-reads the panel's directory when it needs to.
+//
+// A read the panel cannot render without - first load, directory change, new
+// search text, changed sort - happens right away. Otherwise the listing is only
+// re-read once per refreshInterval, to pick up changes made outside superfile.
+//
+// The interval used to be int(elemCount / ReRenderChunkDivisor) seconds, which
+// truncates to 0 for any directory with fewer than ReRenderChunkDivisor
+// entries. The panel therefore re-read on every message, so every keystroke
+// waited on the filesystem and navigating a network mount fell behind held keys.
 func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) {
-	nowTime := time.Now()
-	if force || !m.shouldSkipPanelUpdate(nowTime) {
-		// Load elements for this panel (with/without search filter)
-		m.element = m.getElements(displayDotFile)
-		// Update file panel list
-		m.LastTimeGetElement = nowTime
+	req := m.elementsRequest(displayDotFile)
+	if !force && req == m.loaded && time.Since(m.lastTimeGetElement) < m.refreshInterval() {
+		return
+	}
 
-		// For hover to file on first time loading
-		if m.TargetFile != "" {
-			m.applyTargetFileCursor()
-		}
+	m.element = req.Read()
+	m.loaded = req
+	m.lastTimeGetElement = time.Now()
 
-		// If cursor becomes invalid due to element update, reset
-		if m.ValidateCursorAndRenderIndex() != nil {
-			m.scrollToCursor(0)
-		}
+	// For hover to file on first time loading
+	if m.TargetFile != "" {
+		m.applyTargetFileCursor()
+	}
+
+	// If cursor becomes invalid due to element update, reset
+	if m.ValidateCursorAndRenderIndex() != nil {
+		m.scrollToCursor(0)
 	}
 }
 
-// Retrieves elements for a panel based on search bar value and sort options.
-func (m *Model) getElements(displayDotFile bool) []Element {
-	if m.SearchBar.Value() != "" {
-		return m.getDirectoryElementsBySearch(displayDotFile)
-	}
-	return m.getDirectoryElements(displayDotFile)
+// MarkStale forces the panel to re-read its listing on the next update. Use it
+// when superfile itself changes a directory's contents, so the change is visible
+// right away instead of at the next refresh.
+func (m *Model) MarkStale() {
+	m.loaded = ElementsRequest{}
 }

--- a/src/internal/ui/filepanel/get_elements.go
+++ b/src/internal/ui/filepanel/get_elements.go
@@ -21,9 +21,9 @@ type ElementsRequest struct {
 	SortReversed   bool
 	DisplayDotFile bool
 
-	// generation is bumped by MarkStale. Without it a read that started before
-	// superfile changed the directory would carry an identical request, and could
-	// land afterwards and replace the listing read after the change.
+	// generation is bumped whenever a synchronous read supersedes what is in
+	// flight. Without it such a read would carry an identical request, and could
+	// land afterwards and replace the newer listing.
 	generation int
 }
 
@@ -130,6 +130,12 @@ func (m *Model) refreshInterval() time.Duration {
 func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) *ElementsRequest {
 	req := m.elementsRequest(displayDotFile)
 	if force || m.loaded != req {
+		// This read supersedes anything already in flight. Those carry an older
+		// generation, and would otherwise match again whenever the panel returns to
+		// a request it has been on before - leaving a directory and coming back, or
+		// clearing search text - and replace this newer listing.
+		m.generation++
+		req.generation = m.generation
 		m.ApplyElements(req, req.Read(), displayDotFile)
 		return nil
 	}
@@ -146,14 +152,14 @@ func (m *Model) UpdateElementsIfNeeded(force bool, displayDotFile bool) *Element
 // instead of at the next poll.
 func (m *Model) MarkStale() {
 	// Bumping the generation makes `loaded` differ from what the panel now wants,
-	// which takes the synchronous path below, and makes a read dispatched before
+	// which takes the synchronous path above, and makes a read dispatched before
 	// this point fail the check in ApplyElements.
 	m.generation++
 }
 
 // ApplyElements installs a listing, ignoring a result for a request the panel has
 // since moved on from - a different directory, search or sort, or a generation
-// bumped by MarkStale while the read was in flight.
+// left behind by a synchronous read while this one was in flight.
 func (m *Model) ApplyElements(req ElementsRequest, elements []Element, displayDotFile bool) {
 	if req != m.elementsRequest(displayDotFile) {
 		slog.Debug("Ignoring elements of a stale request", "reqLocation", req.Location,

--- a/src/internal/ui/filepanel/get_elements_test.go
+++ b/src/internal/ui/filepanel/get_elements_test.go
@@ -294,10 +294,47 @@ func TestUpdateElementsIfNeededThrottlesRereads(t *testing.T) {
 	panel.UpdateElementsIfNeeded(false, false)
 	assert.Equal(t, 1, panel.ElemCount(), "must not re-read the directory on every update")
 
-	// Past the interval, outside changes get picked up
+	// Past the interval, the read is handed back to be run off the event loop
 	panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
-	panel.UpdateElementsIfNeeded(false, false)
+	req := panel.UpdateElementsIfNeeded(false, false)
+	require.NotNil(t, req)
+	assert.Equal(t, 1, panel.ElemCount(), "the periodic refresh must not read inline")
+
+	// While one is in flight, no duplicate is dispatched
+	panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
+	assert.Nil(t, panel.UpdateElementsIfNeeded(false, false))
+
+	panel.ApplyElements(*req, req.Read(), false)
 	assert.Equal(t, 2, panel.ElemCount())
+}
+
+// A result that arrives after the panel has moved on must not be installed, and
+// must not leave the panel unable to refresh again.
+func TestApplyElementsDropsStaleResults(t *testing.T) {
+	curTestDir := t.TempDir()
+	otherDir := filepath.Join(curTestDir, "other")
+	utils.SetupDirectories(t, otherDir)
+	utils.SetupFiles(t, filepath.Join(curTestDir, "file1.txt"))
+
+	panel := testModel(0, 0, 12, BrowserMode, nil)
+	panel.Location = curTestDir
+	panel.IsFocused = true
+	require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
+	require.Equal(t, 2, panel.ElemCount())
+
+	panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
+	req := panel.UpdateElementsIfNeeded(false, false)
+	require.NotNil(t, req)
+
+	panel.Location = otherDir
+	require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
+	require.Equal(t, 0, panel.ElemCount())
+
+	panel.ApplyElements(*req, req.Read(), false)
+	assert.Equal(t, 0, panel.ElemCount(), "a listing for the previous directory must be dropped")
+
+	panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
+	assert.NotNil(t, panel.UpdateElementsIfNeeded(false, false))
 }
 
 // A changed request is something the panel cannot render without, so it must be
@@ -312,18 +349,18 @@ func TestUpdateElementsIfNeededReadsChangedRequestAtOnce(t *testing.T) {
 	panel := testModel(0, 0, 12, BrowserMode, nil)
 	panel.Location = curTestDir
 	panel.IsFocused = true
-	panel.UpdateElementsIfNeeded(false, false)
+	require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
 	require.Equal(t, 2, panel.ElemCount())
 
 	// Directory change, well within the refresh interval
 	panel.Location = otherDir
-	panel.UpdateElementsIfNeeded(false, false)
+	require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
 	assert.Equal(t, 2, panel.ElemCount())
 	assert.Equal(t, "a.txt", panel.GetElementAtIdx(0).Name)
 
 	// Search text change, also within the interval
 	panel.SearchBar.SetValue("b")
-	panel.UpdateElementsIfNeeded(false, false)
+	require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
 	assert.Equal(t, 1, panel.ElemCount())
 	assert.Equal(t, "b.txt", panel.GetElementAtIdx(0).Name)
 }
@@ -342,6 +379,41 @@ func TestMarkStaleForcesReread(t *testing.T) {
 	utils.SetupFiles(t, filepath.Join(curTestDir, "file2.txt"))
 	panel.MarkStale()
 
-	panel.UpdateElementsIfNeeded(false, false)
+	assert.Nil(t, panel.UpdateElementsIfNeeded(false, false))
 	assert.Equal(t, 2, panel.ElemCount())
+}
+
+// A read that started before superfile changed the directory must not land
+// afterwards and replace the listing read after the change - otherwise a file
+// superfile just created briefly disappears again.
+func TestMarkStaleInvalidatesInFlightRead(t *testing.T) {
+	curTestDir := t.TempDir()
+	utils.SetupFiles(t, filepath.Join(curTestDir, "file1.txt"))
+
+	panel := testModel(0, 0, 12, BrowserMode, nil)
+	panel.Location = curTestDir
+	panel.IsFocused = true
+	require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
+	require.Equal(t, 1, panel.ElemCount())
+
+	// A background refresh is dispatched and reads the pre-operation state
+	panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
+	req := panel.UpdateElementsIfNeeded(false, false)
+	require.NotNil(t, req)
+	staleElements := req.Read()
+
+	// superfile itself adds a file, e.g. a compress finishing
+	utils.SetupFiles(t, filepath.Join(curTestDir, "made.zip"))
+	panel.MarkStale()
+	require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
+	require.Equal(t, 2, panel.ElemCount(), "the read after MarkStale must see both files")
+
+	// The older background read now lands and must be ignored
+	panel.ApplyElements(*req, staleElements, false)
+	assert.Equal(t, 2, panel.ElemCount(),
+		"a read from before the change must not replace the listing read after it")
+
+	// and the panel must still be able to refresh afterwards
+	panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
+	assert.NotNil(t, panel.UpdateElementsIfNeeded(false, false))
 }

--- a/src/internal/ui/filepanel/get_elements_test.go
+++ b/src/internal/ui/filepanel/get_elements_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yorukot/superfile/src/pkg/utils"
 
@@ -202,12 +203,7 @@ func TestReturnDirElement(t *testing.T) {
 			panel.SortKind = tt.sortKind
 			panel.SortReversed = tt.reversed
 			panel.SearchBar.SetValue(tt.searchString)
-			var res []Element
-			if tt.searchString == "" {
-				res = panel.getDirectoryElements(tt.dotFiles)
-			} else {
-				res = panel.getDirectoryElementsBySearch(tt.dotFiles)
-			}
+			res := panel.elementsRequest(tt.dotFiles).Read()
 
 			assert.Len(t, res, len(tt.expectedElemNames))
 			actualNames := []string{}
@@ -275,4 +271,77 @@ func TestSingleItemSelect(t *testing.T) {
 			assert.Equal(t, tt.expectedSelected, tt.panel.selected)
 		})
 	}
+}
+
+// Cursor movement must not touch the filesystem. Re-reading on every message
+// made each keystroke wait on IO, which desynced the cursor from held keys on
+// network mounts.
+func TestUpdateElementsIfNeededThrottlesRereads(t *testing.T) {
+	curTestDir := t.TempDir()
+	utils.SetupFiles(t, filepath.Join(curTestDir, "file1.txt"))
+
+	panel := testModel(0, 0, 12, BrowserMode, nil)
+	panel.Location = curTestDir
+	panel.IsFocused = true
+
+	// First load has nothing to render without, so it reads right away
+	panel.UpdateElementsIfNeeded(false, false)
+	require.Equal(t, 1, panel.ElemCount())
+
+	utils.SetupFiles(t, filepath.Join(curTestDir, "file2.txt"))
+
+	// Within the interval, no re-read at all
+	panel.UpdateElementsIfNeeded(false, false)
+	assert.Equal(t, 1, panel.ElemCount(), "must not re-read the directory on every update")
+
+	// Past the interval, outside changes get picked up
+	panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
+	panel.UpdateElementsIfNeeded(false, false)
+	assert.Equal(t, 2, panel.ElemCount())
+}
+
+// A changed request is something the panel cannot render without, so it must be
+// read immediately rather than waiting for the interval.
+func TestUpdateElementsIfNeededReadsChangedRequestAtOnce(t *testing.T) {
+	curTestDir := t.TempDir()
+	otherDir := filepath.Join(curTestDir, "other")
+	utils.SetupDirectories(t, otherDir)
+	utils.SetupFiles(t, filepath.Join(curTestDir, "file1.txt"),
+		filepath.Join(otherDir, "a.txt"), filepath.Join(otherDir, "b.txt"))
+
+	panel := testModel(0, 0, 12, BrowserMode, nil)
+	panel.Location = curTestDir
+	panel.IsFocused = true
+	panel.UpdateElementsIfNeeded(false, false)
+	require.Equal(t, 2, panel.ElemCount())
+
+	// Directory change, well within the refresh interval
+	panel.Location = otherDir
+	panel.UpdateElementsIfNeeded(false, false)
+	assert.Equal(t, 2, panel.ElemCount())
+	assert.Equal(t, "a.txt", panel.GetElementAtIdx(0).Name)
+
+	// Search text change, also within the interval
+	panel.SearchBar.SetValue("b")
+	panel.UpdateElementsIfNeeded(false, false)
+	assert.Equal(t, 1, panel.ElemCount())
+	assert.Equal(t, "b.txt", panel.GetElementAtIdx(0).Name)
+}
+
+// Changes superfile makes itself have to show up at once, not at the next refresh.
+func TestMarkStaleForcesReread(t *testing.T) {
+	curTestDir := t.TempDir()
+	utils.SetupFiles(t, filepath.Join(curTestDir, "file1.txt"))
+
+	panel := testModel(0, 0, 12, BrowserMode, nil)
+	panel.Location = curTestDir
+	panel.IsFocused = true
+	panel.UpdateElementsIfNeeded(false, false)
+	require.Equal(t, 1, panel.ElemCount())
+
+	utils.SetupFiles(t, filepath.Join(curTestDir, "file2.txt"))
+	panel.MarkStale()
+
+	panel.UpdateElementsIfNeeded(false, false)
+	assert.Equal(t, 2, panel.ElemCount())
 }

--- a/src/internal/ui/filepanel/get_elements_test.go
+++ b/src/internal/ui/filepanel/get_elements_test.go
@@ -417,3 +417,72 @@ func TestMarkStaleInvalidatesInFlightRead(t *testing.T) {
 	panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
 	assert.NotNil(t, panel.UpdateElementsIfNeeded(false, false))
 }
+
+// A panel can return to a request it has already been on - leaving a directory
+// and coming back, or clearing search text. The read it does on returning is
+// newer than anything dispatched before, so those must not land afterwards and
+// replace it, even though their request matches again.
+func TestApplyElementsDropsResultFromSupersededRead(t *testing.T) {
+	testdata := []struct {
+		name string
+		// leaveAndReturn moves the panel off its current request and back again,
+		// with each move read synchronously.
+		leaveAndReturn func(t *testing.T, panel *Model, otherDir string)
+	}{
+		{
+			name: "directory left and re-entered",
+			leaveAndReturn: func(t *testing.T, panel *Model, otherDir string) {
+				t.Helper()
+				location := panel.Location
+				panel.Location = otherDir
+				require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
+				panel.Location = location
+			},
+		},
+		{
+			name: "search text typed and cleared",
+			leaveAndReturn: func(t *testing.T, panel *Model, _ string) {
+				t.Helper()
+				panel.SearchBar.SetValue("file1")
+				require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
+				panel.SearchBar.SetValue("")
+			},
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			curTestDir := t.TempDir()
+			otherDir := filepath.Join(curTestDir, "other")
+			utils.SetupDirectories(t, otherDir)
+			utils.SetupFiles(t, filepath.Join(curTestDir, "file1.txt"))
+
+			panel := testModel(0, 0, 12, BrowserMode, nil)
+			panel.Location = curTestDir
+			panel.IsFocused = true
+			require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
+			require.Equal(t, 2, panel.ElemCount())
+
+			// A background refresh is dispatched and reads the directory as it is now
+			panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
+			req := panel.UpdateElementsIfNeeded(false, false)
+			require.NotNil(t, req)
+			supersededElements := req.Read()
+
+			// The panel moves off that request, the directory changes, and it returns
+			tt.leaveAndReturn(t, &panel, otherDir)
+			utils.SetupFiles(t, filepath.Join(curTestDir, "file2.txt"))
+			require.Nil(t, panel.UpdateElementsIfNeeded(false, false))
+			require.Equal(t, 3, panel.ElemCount(), "returning must read the directory again")
+
+			// The earlier read now lands and must be ignored
+			panel.ApplyElements(*req, supersededElements, false)
+			assert.Equal(t, 3, panel.ElemCount(),
+				"a superseded read must not replace the listing read after it")
+
+			// and the panel must still be able to refresh afterwards
+			panel.lastTimeGetElement = time.Now().Add(-2 * focussedPanelReRenderTime)
+			assert.NotNil(t, panel.UpdateElementsIfNeeded(false, false))
+		})
+	}
+}

--- a/src/internal/ui/filepanel/render.go
+++ b/src/internal/ui/filepanel/render.go
@@ -2,7 +2,6 @@ package filepanel
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/yorukot/superfile/src/config/icon"
@@ -140,12 +139,4 @@ func (m *Model) renderSelectBox(isSelected bool) string {
 		return common.CheckboxChecked
 	}
 	return common.CheckboxEmpty
-}
-
-// Checks whether a panel needs re-render due to being invalid or due to directory change
-func (m *Model) NeedsReRender() bool {
-	if !m.EmptyOrInvalid() {
-		return filepath.Dir(m.GetFirstElement().Location) != m.Location
-	}
-	return true
 }

--- a/src/internal/ui/filepanel/types.go
+++ b/src/internal/ui/filepanel/types.go
@@ -45,6 +45,10 @@ type Model struct {
 	// panel currently wants means the listing has to be re-read before rendering.
 	loaded             ElementsRequest
 	lastTimeGetElement time.Time
+	// refreshPending is set while an off-loop re-read of `loaded` is in flight.
+	refreshPending bool
+	// generation is bumped by MarkStale to invalidate in-flight reads.
+	generation int
 }
 
 // Record for directory navigation

--- a/src/internal/ui/filepanel/types.go
+++ b/src/internal/ui/filepanel/types.go
@@ -38,9 +38,13 @@ type Model struct {
 	Rename             textinput.Model
 	Renaming           bool
 	SearchBar          textinput.Model
-	LastTimeGetElement time.Time
 	TargetFile         string             // filename to position cursor on after load
 	columns            []columnDefinition // columns for rendering
+
+	// loaded is the request that produced `element`. A mismatch with what the
+	// panel currently wants means the listing has to be re-read before rendering.
+	loaded             ElementsRequest
+	lastTimeGetElement time.Time
 }
 
 // Record for directory navigation

--- a/src/internal/ui/filepanel/types.go
+++ b/src/internal/ui/filepanel/types.go
@@ -47,7 +47,8 @@ type Model struct {
 	lastTimeGetElement time.Time
 	// refreshPending is set while an off-loop re-read of `loaded` is in flight.
 	refreshPending bool
-	// generation is bumped by MarkStale to invalidate in-flight reads.
+	// generation is bumped by a synchronous read and by MarkStale, to invalidate
+	// reads already in flight.
 	generation int
 }
 

--- a/src/internal/ui/sidebar/consts.go
+++ b/src/internal/ui/sidebar/consts.go
@@ -1,8 +1,14 @@
 package sidebar
 
 import (
+	"time"
+
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
+
+// How often the sidebar re-reads the pinned file, stats the well known
+// directories and enumerates mounts.
+const sidebarRefreshInterval = 2 * time.Second
 
 // These are effectively consts
 // Had to use `var` as go doesn't allows const structs

--- a/src/internal/ui/sidebar/sidebar.go
+++ b/src/internal/ui/sidebar/sidebar.go
@@ -3,6 +3,7 @@ package sidebar
 import (
 	"log/slog"
 	"slices"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -83,7 +84,31 @@ func (s *Model) HandleSearchBarKey(msg string) {
 	}
 }
 
+// UpdateDirectoriesIfNeeded refreshes the sidebar, at most once every
+// sidebarRefreshInterval. A changed search query, or an explicit force after
+// pinning or renaming, is reflected at once - the rest is only polling for pins
+// and mounts changed outside superfile, and doing that on every message made
+// every keystroke wait on the filesystem.
+func (s *Model) UpdateDirectoriesIfNeeded(force bool) {
+	if s.Disabled() {
+		return
+	}
+	query := s.searchBar.Value()
+	if !force && query == s.loadedQuery && time.Since(s.lastRefresh) < sidebarRefreshInterval {
+		return
+	}
+	s.loadedQuery = query
+	s.UpdateDirectories()
+	// Stamped after the read, not before: a read that takes as long as the
+	// interval would otherwise leave the stamp already expired on return, and the
+	// next message would start another one straight away.
+	s.lastRefresh = time.Now()
+}
+
 // UpdateDirectories refreshes the list of directories based on the search query or section configuration.
+// ponytail: still synchronous. Move it to a tea.Cmd if a stat of a pinned
+// directory on a hung mount starts blocking the UI - that needs Load() to stop
+// saving the cleaned list back, otherwise it races Toggle() over the same file.
 func (s *Model) UpdateDirectories() {
 	if s.Disabled() {
 		return

--- a/src/internal/ui/sidebar/sidebar_test.go
+++ b/src/internal/ui/sidebar/sidebar_test.go
@@ -3,6 +3,7 @@ package sidebar
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,4 +94,95 @@ func sidebarWithPinnedDir(t *testing.T) (PinnedManager, Model) {
 		pinnedMgr: &pinnedMgr,
 		sections:  []string{utils.SidebarSectionPinned},
 	}
+}
+
+// A sidebar refresh re-reads the pinned file, stats the well known directories
+// and enumerates mounts. Doing that on every message made every keystroke wait
+// on the filesystem, so it is throttled - but what the user just did still has
+// to show up at once.
+func TestUpdateDirectoriesIfNeededThrottlesRefresh(t *testing.T) {
+	pinnedMgr, sidebar, dirA, dirB := sidebarWithPinnedSection(t)
+	require.NoError(t, pinnedMgr.Save([]directory{{Location: dirA, Name: "alpha"}}))
+
+	sidebar.UpdateDirectoriesIfNeeded(false)
+	require.Equal(t, []string{"alpha"}, pinnedNames(&sidebar))
+
+	// Another superfile instance pins a second directory
+	require.NoError(t, pinnedMgr.Save([]directory{
+		{Location: dirA, Name: "alpha"},
+		{Location: dirB, Name: "beta"},
+	}))
+
+	sidebar.UpdateDirectoriesIfNeeded(false)
+	assert.Equal(t, []string{"alpha"}, pinnedNames(&sidebar),
+		"must not re-read the pinned file on every update")
+
+	// force is for what the user just did - pinning, renaming - which cannot wait
+	// out the interval
+	sidebar.UpdateDirectoriesIfNeeded(true)
+	assert.Equal(t, []string{"alpha", "beta"}, pinnedNames(&sidebar))
+
+	require.NoError(t, pinnedMgr.Save([]directory{{Location: dirB, Name: "beta"}}))
+	sidebar.UpdateDirectoriesIfNeeded(false)
+	require.Equal(t, []string{"alpha", "beta"}, pinnedNames(&sidebar),
+		"the force must have restarted the interval")
+
+	// Past the interval, outside changes are picked up
+	sidebar.lastRefresh = time.Now().Add(-2 * sidebarRefreshInterval)
+	sidebar.UpdateDirectoriesIfNeeded(false)
+	assert.Equal(t, []string{"beta"}, pinnedNames(&sidebar))
+}
+
+// A changed search query is something the sidebar cannot render without, so it
+// is applied at once rather than at the next refresh.
+func TestUpdateDirectoriesIfNeededAppliesQueryChangeAtOnce(t *testing.T) {
+	pinnedMgr, sidebar, dirA, dirB := sidebarWithPinnedSection(t)
+	require.NoError(t, pinnedMgr.Save([]directory{
+		{Location: dirA, Name: "alpha"},
+		{Location: dirB, Name: "beta"},
+	}))
+
+	sidebar.UpdateDirectoriesIfNeeded(false)
+	require.Equal(t, []string{"alpha", "beta"}, pinnedNames(&sidebar))
+
+	// Well within the interval, and not forced
+	sidebar.searchBar.SetValue("alp")
+	sidebar.UpdateDirectoriesIfNeeded(false)
+	assert.Equal(t, []string{"alpha"}, pinnedNames(&sidebar))
+
+	sidebar.searchBar.SetValue("")
+	sidebar.UpdateDirectoriesIfNeeded(false)
+	assert.Equal(t, []string{"alpha", "beta"}, pinnedNames(&sidebar))
+}
+
+// sidebarWithPinnedSection returns a sidebar showing the pinned section only, so
+// what it displays depends solely on the pinned file, along with that file's
+// manager and two directories available to pin.
+func sidebarWithPinnedSection(t *testing.T) (PinnedManager, Model, string, string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	dirA := filepath.Join(tempDir, "alpha")
+	dirB := filepath.Join(tempDir, "beta")
+	utils.SetupDirectories(t, dirA, dirB)
+
+	pinnedMgr := PinnedManager{filePath: filepath.Join(tempDir, "pinned.json")}
+	utils.SetupFilesWithData(t, []byte("[]"), pinnedMgr.filePath)
+
+	return pinnedMgr, Model{
+		pinnedMgr: &pinnedMgr,
+		sections:  []string{utils.SidebarSectionPinned},
+	}, dirA, dirB
+}
+
+// pinnedNames returns the names of the actual directories the sidebar is showing,
+// skipping section dividers.
+func pinnedNames(s *Model) []string {
+	names := []string{}
+	for _, d := range s.directories {
+		if !d.isDivider() {
+			names = append(names, d.Name)
+		}
+	}
+	return names
 }

--- a/src/internal/ui/sidebar/type.go
+++ b/src/internal/ui/sidebar/type.go
@@ -1,6 +1,10 @@
 package sidebar
 
-import "charm.land/bubbles/v2/textinput"
+import (
+	"time"
+
+	"charm.land/bubbles/v2/textinput"
+)
 
 type directory struct {
 	Location string `json:"location"`
@@ -21,4 +25,8 @@ type Model struct {
 	height      int
 	disabled    bool
 	sections    []string
+
+	// loadedQuery is the search query `directories` was built for
+	loadedQuery string
+	lastRefresh time.Time
 }


### PR DESCRIPTION
# Description

Closes #1048, #727.

On a network mount (NFS/NAS, sshfs), the cursor desyncs from key input: holding `j` to scroll and releasing it keeps scrolling for a long time afterwards. The input is not lost, it is queued.

`model.Update()` performs synchronous filesystem IO on **every** `tea.Msg`, on bubbletea's single event-loop goroutine. While it is blocked, incoming keypresses sit in the input buffer. Three things compound:

1. **The re-read throttle never fires.** `filepanel.shouldSkipPanelUpdate` computed its interval as `int(float64(m.ElemCount()) / ReRenderChunkDivisor)` seconds. With `ReRenderChunkDivisor = 100` that truncates to `0` for any directory under 100 entries, so the focused panel re-read on every message.
2. **Every entry was `lstat`ed twice.** `getDirectoryElements` called `e.Info()` inside a `slices.DeleteFunc` only to test for an error and discarded the result; `sortFileElement` then called `item.Info()` again.
3. **Async replies re-triggered the sync work.** Metadata and preview are already `tea.Cmd`s, but their *replies* are messages, so one keypress produced three `Update` calls and three full directory reads. Debug log: 3 keypresses → 10 `model.Update()` calls (4 key, 3 `preview.UpdateMsg`, 3 `MetadataMsg`).

Separately, `sidebar.UpdateDirectories()` had no throttle at all — every message it re-read the pinned-directories JSON, `stat`ed ~10 well-known directories plus every pinned one, and enumerated mounts via gopsutil.

On a 60-file directory that is **399 filesystem syscalls per keypress**, 362 of them in the browsed directory. Locally these hit the page cache and cost nothing; on a network mount each is a round trip.

## Changes

Three commits, each self-contained:

**1. `fix(filepanel)`: stop re-reading the directory on every message**

Track what the loaded listing was read for in a comparable `ElementsRequest` (location, search text, sort kind, sort reversed, dotfiles). A mismatch means the panel cannot render without a read — first load, `cd`, new search text, changed sort — and happens immediately. An unchanged request only re-reads once per interval, which now has a one-second floor. **Pure cursor movement does zero filesystem IO.** Also drops the duplicate `lstat`.

`NeedsReRender()` is removed rather than left unused: it returned true for any empty-or-invalid panel, so a genuinely empty directory re-read on every message too. The request comparison covers the directory-change case it was used for and handles empty directories correctly.

Because that unthrottled re-read is what used to make superfile's *own* changes appear, operations that modify a directory (paste, create, delete, compress, extract, rename) now mark panels stale so their results still show up immediately. Without this the existing compress tests fail, which is how I noticed.

**2. `refactor(filepanel)`: run the periodic directory re-read off the event loop**

Throttling bounds how *often* the event loop waits on the filesystem, not how *long*. The read cost grows with entry count while the interval cannot drop below one read per second. Only the read a panel cannot render without has to be synchronous; the periodic one is returned as an `ElementsRequest` and run as a `tea.Cmd`, applied back via `ElementsRefreshMsg` — mirroring how `preview.UpdateMsg` and `MetadataMsg` already work. The request is a plain value and `Read()` touches no `Model` state, so the goroutine shares nothing with the event loop. Stale results are dropped by comparing the request against what the panel currently wants.

The case for this one is structural rather than empirical. Commit 1 bounds how often a read happens but cannot bound what a single read costs, and that cost grows with the entry count. This removes the last unbounded filesystem IO from the event loop, which is what keeps the fix from degrading again on larger directories or slower mounts.

**3. `fix(sidebar)`: throttle the sidebar refresh**

Re-read at most once every 2s. A changed search query, or an explicit force after pinning or renaming, still refreshes immediately. Kept **synchronous on purpose**: moving it to a `tea.Cmd` would have `PinnedManager.Load()` call `Clean()`, which writes the pruned list back, from a goroutine racing `Toggle()` over the same file. Not worth risking the pinned file to save ~15 stats every two seconds; noted in a comment with the upgrade path.

## Measured

Browsing a 60-file directory, comparing binaries built from `main` and from this branch. Latency is injected with `strace` fault injection so this reproduces without a network mount:

```sh
strace -f -qq -e trace=newfstatat,statx,getdents64 \
  -e inject=newfstatat,statx,getdents64:delay_enter=1000 \
  -o /dev/null spf /tmp/spftest
```

| | fs syscalls per keypress | runaway scroll after 2s of held `j` @1ms/stat |
|---|---|---|
| `main` | 399 | **+36.7s** |
| this branch | 44 | **+0.44s** |

An 11-check terminal-emulated end-to-end suite (initial listing, dotfile toggle, externally-created file, navigation in/out, search filter and clear, file created by superfile) passes **identically** on the old and new binary, so user-visible behaviour is unchanged and only the IO cost differs.

Per-commit attribution, for what it is worth: commit 1 alone gets 399 → 70 and 36.7s → 2.1s; adding commit 3 gets it to 44 and ~0.8s; commit 2 is not separately measurable.

---

# ✅ Pre-Submission Checklist

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues — 0 issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I'm not committing any debug logs or TODOs
- [x] I have checked that the PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

`go test ./...` passes except `TestGetMetadata`, which fails identically on unmodified `main` because the `exiftool` binary is not installed on my machine. Four added unit tests cover the new contract: no re-read within the interval, outside changes picked up past it, a changed request (`cd` and search text) read at once, stale async results dropped without wedging the panel, and `MarkStale` forcing a re-read.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File panels now refresh after renaming, file operations, pinning directories, and sidebar changes.
  * Outdated directory results no longer replace current listings.
  * Listings update immediately when the viewed location or search changes.

* **Performance**
  * Reduced unnecessary file-panel and sidebar rereads through timed refresh intervals.
  * Directory updates now run asynchronously to keep the interface responsive.
  * Stale in-progress refreshes are safely discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->