### PR TITLE
fix: Add check in fzf at the right place for element search

### DIFF
--- a/src/internal/ui/filepanel/get_elements.go
+++ b/src/internal/ui/filepanel/get_elements.go
@@ -43,10 +43,6 @@ func (m *Model) getDirectoryElementsBySearch(displayDotFile bool) []Element {
 		return nil
 	}
 
-	if len(items) == 0 {
-		return nil
-	}
-
 	folderElementMap := map[string]os.DirEntry{}
 	fileAndDirectories := []string{}
 
@@ -61,6 +57,9 @@ func (m *Model) getDirectoryElementsBySearch(displayDotFile bool) []Element {
 
 		fileAndDirectories = append(fileAndDirectories, item.Name())
 		folderElementMap[item.Name()] = item
+	}
+	if len(fileAndDirectories) == 0 {
+		return nil
 	}
 	// https://github.com/reinhrst/fzf-lib/blob/main/core.go#L43
 	// fzf returns matches ordered by score; we subsequently sort by the chosen sort option.

--- a/src/internal/ui/filepanel/get_elements_test.go
+++ b/src/internal/ui/filepanel/get_elements_test.go
@@ -17,6 +17,7 @@ func TestReturnDirElement(t *testing.T) {
 	dir1 := filepath.Join(curTestDir, "dir1")
 	dir2 := filepath.Join(curTestDir, "dir2")
 	dirNatural := filepath.Join(curTestDir, "dirNatural")
+	hiddenOnlyDir := t.TempDir()
 	utils.SetupDirectories(t, curTestDir, dir1, dir2, dirNatural)
 
 	creationDelay := time.Millisecond * 5
@@ -52,6 +53,7 @@ func TestReturnDirElement(t *testing.T) {
 		{filepath.Join(dirNatural, "file2.txt"), []byte("b")},
 		{filepath.Join(dirNatural, "file10.txt"), []byte("c")},
 		{filepath.Join(dirNatural, "file20.txt"), []byte("d")},
+		{filepath.Join(hiddenOnlyDir, ".hidden"), []byte("hidden")},
 	}
 
 	for _, f := range fileSetup {
@@ -74,6 +76,14 @@ func TestReturnDirElement(t *testing.T) {
 			dotFiles:          false,
 			sortKind:          sortmodel.SortByName,
 			reversed:          false,
+			expectedElemNames: []string{},
+		},
+		{
+			name:              "Search in directory with only hidden files",
+			location:          hiddenOnlyDir,
+			dotFiles:          false,
+			sortKind:          sortmodel.SortByName,
+			searchString:      "/",
 			expectedElemNames: []string{},
 		},
 		{


### PR DESCRIPTION
Prevent a panic when searching in a directory whose entries are all excluded from the file panel, such as a directory containing only hidden files while dotfiles are disabled.

# Issue

Create a directory with only dotfiles, hide the dotfiles, and then try to search.
<img width="739" height="386" alt="image" src="https://github.com/user-attachments/assets/61d72633-aebe-48be-b19d-6d043e1360d8" />

Reported in discord - https://discord.com/channels/1338415256875307110/1338415257453985815/1533394275621011558

The search path checked whether the raw result from `os.ReadDir` was empty before filtering entries.

A directory containing only hidden files was nonempty at that point, so the check passed. After hidden files were filtered out, Superfile passed an empty source to `fzf-lib` causing panic

Now, we only Check the filtered file list - the actual source passed to `fzf-lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed directory search behavior when all entries are filtered out.
  * Searches that exclude hidden files now correctly show no results when only hidden files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->