### PR TITLE
feat(mouse): add mouse click panel focus, item selection, and scroll support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ testsuite/.venv/
 
 # Agent configs
 CLAUDE.md
+.basemem.code.db

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -76,7 +76,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		resizeCmd = m.handleWindowResize(msg)
 	case tea.MouseMsg:
-		m.handleMouseMsg(msg)
+		inputCmd = m.handleMouseMsg(msg)
 	case tea.KeyPressMsg:
 		inputCmd = m.handleKeyInput(msg)
 
@@ -109,15 +109,6 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	return m, tea.Batch(sidebarCmd, helpMenuCmd, inputCmd, updateCmd,
 		panelCmd, metadataCmd, filePreviewCmd, resizeCmd)
-}
-
-func (m *model) handleMouseMsg(msg tea.MouseMsg) {
-	msgStr := msg.String()
-	if msgStr == "wheelup" || msgStr == "wheeldown" {
-		wheelMainAction(msgStr, m)
-	} else {
-		slog.Debug("Mouse event of type that is not handled", "msg", msgStr)
-	}
 }
 
 func (m *model) updateModelStateAfterMsg() {

--- a/src/internal/mouse_function.go
+++ b/src/internal/mouse_function.go
@@ -91,8 +91,9 @@ func (m *model) handleSidebarClick(y int) {
 	}
 	targetIndex := y - headerLines
 	if targetIndex >= 0 {
-		m.sidebarModel.SetCursor(targetIndex)
-		m.sidebarSelectDirectory()
+		if m.sidebarModel.SetCursor(targetIndex) {
+			m.sidebarSelectDirectory()
+		}
 	}
 }
 

--- a/src/internal/mouse_function.go
+++ b/src/internal/mouse_function.go
@@ -1,0 +1,122 @@
+package internal
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/yorukot/superfile/src/internal/common"
+)
+
+var (
+	lastClickTime time.Time
+	lastClickPos  [2]int
+)
+
+func (m *model) handleMouseMsg(msg tea.MouseMsg) tea.Cmd {
+	mouse := msg.Mouse()
+	msgStr := msg.String()
+
+	if msgStr == "wheelup" || msgStr == "wheeldown" {
+		m.updateFocusByCoords(mouse.X, mouse.Y)
+		wheelMainAction(msgStr, m)
+		return nil
+	}
+
+	if mouse.Button == tea.MouseLeft {
+		return m.handleLeftClick(mouse.X, mouse.Y)
+	}
+
+	return nil
+}
+
+func (m *model) handleLeftClick(x, y int) tea.Cmd {
+	m.updateFocusByCoords(x, y)
+
+	now := time.Now()
+	isDoubleClick := now.Sub(lastClickTime) < 400*time.Millisecond && lastClickPos[0] == x && lastClickPos[1] == y
+	lastClickTime = now
+	lastClickPos = [2]int{x, y}
+
+	if m.focusPanel == sidebarFocus {
+		m.handleSidebarClick(y)
+	} else if m.focusPanel == nonePanelFocus {
+		return m.handleFilePanelClick(x, y, isDoubleClick)
+	}
+
+	return nil
+}
+
+func (m *model) updateFocusByCoords(x, y int) {
+	// Click in footer
+	if m.toggleFooter && y >= m.mainPanelHeight {
+		processWidth := m.processBarModel.GetWidth()
+		if x < processWidth {
+			m.focusOnProcessBar()
+		} else {
+			m.focusOnMetadata()
+		}
+		return
+	}
+
+	// Click in sidebar
+	if x < common.Config.SidebarWidth {
+		m.focusOnSideBar()
+		return
+	}
+
+	// Click in main file panels
+	m.focusPanel = nonePanelFocus
+	relX := x - common.Config.SidebarWidth
+	panelCount := m.fileModel.PanelCount()
+
+	accumX := 0
+	for i := 0; i < panelCount; i++ {
+		pw := m.fileModel.FilePanels[i].GetWidth()
+		if relX >= accumX && relX < accumX+pw {
+			m.fileModel.SetFocusedPanelIndex(i)
+			break
+		}
+		accumX += pw
+	}
+}
+
+func (m *model) handleSidebarClick(y int) {
+	// Line 0: top border
+	// Line 1: superfile title
+	// Line 2: blank line
+	// Line 3: searchbar (if rendered)
+	headerLines := 3
+	if m.sidebarModel.SearchBarFocused() {
+		headerLines = 4
+	}
+	targetIndex := y - headerLines
+	if targetIndex >= 0 {
+		m.sidebarModel.SetCursor(targetIndex)
+		m.sidebarSelectDirectory()
+	}
+}
+
+func (m *model) handleFilePanelClick(x, y int, isDoubleClick bool) tea.Cmd {
+	panel := m.getFocusedFilePanel()
+	// Line 0: top border
+	// Line 1: path title
+	// Line 2: section divider
+	// Line 3: search bar
+	topOffset := 4
+	if panel.NeedRenderHeaders() {
+		topOffset = 5
+	}
+
+	targetRow := y - topOffset
+	if targetRow >= 0 {
+		targetIndex := panel.RenderIndex() + targetRow
+		if targetIndex >= 0 && targetIndex < panel.ElemCount() {
+			if panel.GetCursor() == targetIndex && isDoubleClick {
+				m.enterPanel()
+			} else {
+				panel.SetCursorPosition(targetIndex)
+			}
+		}
+	}
+	return nil
+}

--- a/src/internal/mouse_function_test.go
+++ b/src/internal/mouse_function_test.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/yorukot/superfile/src/internal/common"
+)
+
+func TestMouseLeftClickFocusPanel(t *testing.T) {
+	testPaths := []string{t.TempDir()}
+	m := defaultModelConfig(true, true, false, testPaths, nil)
+	m.fullWidth = 120
+	m.fullHeight = 40
+	m.setHeightValues()
+	m.updateComponentDimensions()
+	m.firstLoadingComplete = true
+
+	// Click sidebar header area
+	m.updateFocusByCoords(5, 0)
+	assert.Equal(t, sidebarFocus, m.focusPanel)
+
+	// Click file panel area (x=common.Config.SidebarWidth + 10, y=5)
+	mouseMsg := tea.MouseClickMsg{
+		X:      common.Config.SidebarWidth + 10,
+		Y:      5,
+		Button: tea.MouseLeft,
+	}
+
+	_ = m.handleMouseMsg(mouseMsg)
+	assert.Equal(t, nonePanelFocus, m.focusPanel)
+}

--- a/src/internal/ui/filemodel/navigation.go
+++ b/src/internal/ui/filemodel/navigation.go
@@ -19,3 +19,11 @@ func (m *Model) MoveFocusedPanelBy(delta int) {
 	m.FocusedPanelIndex = (m.FocusedPanelIndex + delta + m.PanelCount()) % m.PanelCount()
 	m.FilePanels[m.FocusedPanelIndex].IsFocused = true
 }
+
+func (m *Model) SetFocusedPanelIndex(index int) {
+	if index >= 0 && index < m.PanelCount() {
+		m.GetFocusedFilePanel().IsFocused = false
+		m.FocusedPanelIndex = index
+		m.FilePanels[m.FocusedPanelIndex].IsFocused = true
+	}
+}

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -147,6 +147,10 @@ func (m *Model) SetCursorPosition(cursor int) {
 	m.scrollToCursor(cursor)
 }
 
+func (m *Model) RenderIndex() int {
+	return m.renderIndex
+}
+
 func (m *Model) FindElementIndexByName(name string) int {
 	for i, elem := range m.element {
 		if elem.Name == name {

--- a/src/internal/ui/sidebar/navigation.go
+++ b/src/internal/ui/sidebar/navigation.go
@@ -127,13 +127,15 @@ func (s *Model) updateRenderIndex() {
 		"renderIndex", s.renderIndex, "directory count", len(s.directories))
 }
 
-func (s *Model) SetCursor(idx int) {
+func (s *Model) SetCursor(idx int) bool {
 	if idx >= 0 && idx < len(s.directories) {
 		s.cursor = idx
 		s.updateRenderIndex()
 		if s.directories[s.cursor].isDivider() {
 			s.ListDown()
 		}
+		return true
 	}
+	return false
 }
 

--- a/src/internal/ui/sidebar/navigation.go
+++ b/src/internal/ui/sidebar/navigation.go
@@ -126,3 +126,14 @@ func (s *Model) updateRenderIndex() {
 	slog.Error("Unexpected situation in updateRenderIndex", "cursor", s.cursor,
 		"renderIndex", s.renderIndex, "directory count", len(s.directories))
 }
+
+func (s *Model) SetCursor(idx int) {
+	if idx >= 0 && idx < len(s.directories) {
+		s.cursor = idx
+		s.updateRenderIndex()
+		if s.directories[s.cursor].isDivider() {
+			s.ListDown()
+		}
+	}
+}
+


### PR DESCRIPTION
This PR adds full mouse support for superfile, including panel focus switching on click, sidebar directory selection, file panel item    
  cursor movement / double-click navigation, and wheel scrolling.                                                                            
  
### Key Changes
   - **Mouse Event Handling**: Updated `m.handleMouseMsg` in `model.go` to capture mouse events and return execution commands.
   - **Click Coordinate Routing (`mouse_function.go`)**:
     - `updateFocusByCoords`: Automatically focuses sidebar, process bar, metadata, or the corresponding file panel index based on click `(x, y)` position and panel widths.
      - `handleLeftClick`: Supports single click for item highlight/selection and double click (< 400ms threshold) for directory             
  navigation/file opening (`enterPanel`).
      - `wheelup` / `wheeldown` mouse wheel support to scroll focused panel items.
    - **Sidebar & File Panel Integrations**:
      - `handleSidebarClick`: Translates click `y` position into sidebar index selection.
      - Added helper methods: `SetFocusedPanelIndex()` in `filemodel`, `RenderIndex()` in `filepanel`, and `SetCursor()` in `sidebar`.       
    - **Unit Tests**: Added `TestMouseLeftClickFocusPanel` in `mouse_function_test.go`.
  
  # Related Issues
   Fixes #1559
  
 #  Pre-Submission Checklist
   - [x] I have run `go fmt ./...` to format the code
   - [x] I have run `golangci-lint run` and verified reported issues
   - [x] I have run `go test ./...` and verified test cases pass
   - [x] I have tested my changes manually and verified they work as expected
   - [x] I have reviewed the diff to ensure no debug logs are committed
   - [x] I have checked that the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mouse-wheel scrolling for navigating panels.
  - Added left-click support for selecting directories, moving through files, and switching focus between the sidebar, file panel, and footer.
  - Added double-click navigation to enter the focused directory or panel item.
  - Improved selection and focus behavior across the interface.

- **Bug Fixes**
  - Ensured mouse actions are processed consistently with other input commands.

- **Tests**
  - Added coverage for sidebar and file-panel focus changes when clicking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->