### PR TITLE
feat(config): add open_file_with_default_app option

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -95,6 +95,7 @@ type ConfigType struct {
 	FilePreviewWidth        int      `toml:"file_preview_width"         comment:"\nFile preview width allow '0' (this mean same as file panel),'x' x must be less than 10 and greater than 1 (This means that the width of the file preview will be one xth of the total width.)"`
 	EnableFilePreviewBorder bool     `toml:"enable_file_preview_border" comment:"\nEnable border around the file preview panel (default: false)"`
 	CodePreviewer           string   `toml:"code_previewer"             comment:"\nWhether to use the builtin syntax highlighting with chroma or use bat. Values: \"\" for builtin chroma, \"bat\" for bat"`
+	OpenFileWithDefaultApp  bool     `toml:"open_file_with_default_app" comment:"\nWhether pressing confirm (Enter/right/l) on a file opens it with the system default application. Set to false to disable launching external programs (e.g. open/xdg-open); the file will just be selected. Directories are still entered. (default: true)"`
 	SidebarWidth            int      `toml:"sidebar_width"              comment:"\nThe length of the sidebar(excluding borders). If you don't find to display the sidebar, you can input 0 directly. If you want to display the value, please place it in the range of 5-20."`
 	SidebarSections         []string `toml:"sidebar_sections"           comment:"\nOrder of sidebar sections (valid values: \"home\", \"pinned\", \"disks\").\nOnly sections included in this list will be displayed."`
 

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -64,6 +64,11 @@ func (m *model) enterPanel() {
 		// Continue with preview if file is not writable
 		slog.Error("Error while writing to chooser file, continuing with file open", "error", chooserErr)
 	}
+	if !common.Config.OpenFileWithDefaultApp {
+		// User disabled launching external programs on confirm. The file is
+		// just selected; preview panel still shows its content.
+		return
+	}
 	m.executeOpenCommand()
 }
 

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -64,15 +64,15 @@ func (m *model) enterPanel() {
 		// Continue with preview if file is not writable
 		slog.Error("Error while writing to chooser file, continuing with file open", "error", chooserErr)
 	}
-	if !common.Config.OpenFileWithDefaultApp {
-		// User disabled launching external programs on confirm. The file is
-		// just selected; preview panel still shows its content.
-		return
-	}
 	m.executeOpenCommand()
 }
 
 func (m *model) executeOpenCommand() {
+	if !common.Config.OpenFileWithDefaultApp {
+		// User disabled launching external programs. The file is just
+		// selected; preview panel still shows its content.
+		return
+	}
 	panel := m.getFocusedFilePanel()
 
 	filePath := panel.GetFocusedItem().Location

--- a/src/superfile_config/config.toml
+++ b/src/superfile_config/config.toml
@@ -126,6 +126,14 @@ file_preview_width = 0
 # Default: false (no border)
 enable_file_preview_border = false
 
+#-- Open File With Default App
+# Whether pressing confirm (Enter/right/l) on a file opens it with the
+# system default application (open on macOS, xdg-open on Linux, etc.).
+# Set to false to disable launching external programs; the file will just
+# be selected and its preview shown. Directories are still entered.
+# Default: true
+open_file_with_default_app = true
+
 #-- Sidebar Width
 # If you don't want to display the sidebar, you can input 0 directly.
 # Values recommended to be in 5–20.


### PR DESCRIPTION
Add a new boolean config `open_file_with_default_app` (default: true) that controls whether pressing confirm (Enter/right/l) on a file launches the system default application (open/xdg-open/rundll32).

Set to false to disable launching external programs — the file is just selected and its preview shown. Directories are still entered, and the chooser mode is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control whether selected files open with the system’s default application.
  * When disabled, files are selected and previewed without launching another application.
  * Directory navigation continues to work as before.
  * The option is enabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->