### PR TITLE
feat(navigation): add Home/End list scrolling for the focused panel

### DIFF
--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -129,6 +129,8 @@ type HotkeysType struct {
 	ListDown []string `toml:"list_down"`
 	PageUp   []string `toml:"page_up"`
 	PageDown []string `toml:"page_down"`
+	ListHome []string `toml:"list_home"`
+	ListEnd  []string `toml:"list_end"`
 
 	CloseFilePanel         []string `toml:"close_file_panel"          comment:"file panel control"`
 	CreateNewFilePanel     []string `toml:"create_new_file_panel"`

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -22,7 +22,7 @@ import (
 // check the state of model m and handle properly.
 // TODO: This function has grown too big. It needs to be fixed, via major
 // updates and fixes in key handling code
-func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,gocognit // See above
+func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,gocognit,maintidx // See above
 	switch {
 	// If move up Key is pressed, check the current state and executes
 	case slices.Contains(common.Hotkeys.ListUp, msg):
@@ -68,6 +68,26 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,go
 			m.getFocusedFilePanel().PgDown()
 		case processBarFocus, sidebarFocus:
 			// These panels have no page scrolling, so page keys do nothing.
+		}
+
+	case slices.Contains(common.Hotkeys.ListHome, msg):
+		switch m.focusPanel {
+		case metadataFocus:
+			m.fileMetaData.Home()
+		case nonePanelFocus:
+			m.getFocusedFilePanel().Home()
+		case processBarFocus, sidebarFocus:
+			// These panels have no home/end scrolling, so home/end keys do nothing.
+		}
+
+	case slices.Contains(common.Hotkeys.ListEnd, msg):
+		switch m.focusPanel {
+		case metadataFocus:
+			m.fileMetaData.End()
+		case nonePanelFocus:
+			m.getFocusedFilePanel().End()
+		case processBarFocus, sidebarFocus:
+			// These panels have no home/end scrolling, so home/end keys do nothing.
 		}
 
 	case slices.Contains(common.Hotkeys.ChangePanelMode, msg):

--- a/src/internal/model_navigation_test.go
+++ b/src/internal/model_navigation_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -290,4 +291,53 @@ func TestCursorRemembersParentPosition(t *testing.T) {
 			assert.Equal(t, originalRenderIndex, m.getFocusedFilePanel().GetRenderIndex())
 		})
 	}
+}
+
+// Home/End keys must be context aware. When a non-file panel (e.g. metadata)
+// is focused, they must not move the file browser panel.
+func TestHomeEndKeysAreContextAware(t *testing.T) {
+	dir := t.TempDir()
+	files := make([]string, 10)
+	for i := range files {
+		files[i] = filepath.Join(dir, fmt.Sprintf("file%02d.txt", i))
+	}
+	utils.SetupFiles(t, files...)
+
+	endKey := common.Hotkeys.ListEnd[0]
+	homeKey := common.Hotkeys.ListHome[0]
+
+	t.Run("jumps to end of the file panel when a file panel is focused", func(t *testing.T) {
+		m := defaultTestModel(dir)
+		require.Equal(t, nonePanelFocus, m.focusPanel)
+		require.Equal(t, 0, m.getFocusedFilePanel().GetCursor())
+
+		m.mainKey(endKey)
+
+		assert.Equal(t, 9, m.getFocusedFilePanel().GetCursor(),
+			"file panel should jump to last item when it is focused")
+	})
+
+	t.Run("jumps to home of the file panel when a file panel is focused", func(t *testing.T) {
+		m := defaultTestModel(dir)
+		require.Equal(t, nonePanelFocus, m.focusPanel)
+		m.getFocusedFilePanel().End()
+		require.Equal(t, 9, m.getFocusedFilePanel().GetCursor())
+
+		m.mainKey(homeKey)
+
+		assert.Equal(t, 0, m.getFocusedFilePanel().GetCursor(),
+			"file panel should jump to first item when it is focused")
+	})
+
+	t.Run("does not move the file panel when metadata is focused", func(t *testing.T) {
+		m := defaultTestModel(dir)
+		m.focusPanel = metadataFocus
+		m.getFocusedFilePanel().IsFocused = false
+		require.Equal(t, 0, m.getFocusedFilePanel().GetCursor())
+
+		m.mainKey(endKey)
+
+		assert.Equal(t, 0, m.getFocusedFilePanel().GetCursor(),
+			"file panel must not move when the metadata panel is focused")
+	})
 }

--- a/src/internal/ui/filepanel/navigation.go
+++ b/src/internal/ui/filepanel/navigation.go
@@ -62,6 +62,20 @@ func (m *Model) PgDown() {
 	m.pageScrollBy(m.getPageScrollSize())
 }
 
+// Home jumps the cursor to the first item in the file panel.
+func (m *Model) Home() {
+	if !m.Empty() {
+		m.scrollToCursor(0)
+	}
+}
+
+// End jumps the cursor to the last item in the file panel.
+func (m *Model) End() {
+	if !m.Empty() {
+		m.scrollToCursor(m.ElemCount() - 1)
+	}
+}
+
 // Handles the action of selecting an item in the file panel upwards. (only work on select mode)
 // This basically just toggles the "selected" status of element that is pointed by the cursor
 // and then moves the cursor up

--- a/src/internal/ui/filepanel/navigation_test.go
+++ b/src/internal/ui/filepanel/navigation_test.go
@@ -189,6 +189,78 @@ func TestPgUpDown(t *testing.T) {
 	}
 }
 
+func TestHomeEnd(t *testing.T) {
+	testdata := []struct {
+		name           string
+		panel          Model
+		toEnd          bool
+		expectedCursor int
+		expectedRender int
+	}{
+		{
+			name:           "Home from middle jumps to first item",
+			panel:          testModelWithElemCount(10, 4, 12, 20),
+			toEnd:          false,
+			expectedCursor: 0,
+			expectedRender: 0,
+		},
+		{
+			name:           "End from middle jumps to last item",
+			panel:          testModelWithElemCount(5, 0, 12, 20),
+			toEnd:          true,
+			expectedCursor: 19,
+			expectedRender: 13, // 19 - 7 + 1
+		},
+		{
+			name:           "Home at top stays at top",
+			panel:          testModelWithElemCount(0, 0, 12, 20),
+			toEnd:          false,
+			expectedCursor: 0,
+			expectedRender: 0,
+		},
+		{
+			name:           "End at bottom stays at bottom",
+			panel:          testModelWithElemCount(19, 13, 12, 20),
+			toEnd:          true,
+			expectedCursor: 19,
+			expectedRender: 13,
+		},
+		{
+			name:           "Home on empty panel",
+			panel:          testModelWithElemCount(0, 0, 12, 0),
+			toEnd:          false,
+			expectedCursor: 0,
+			expectedRender: 0,
+		},
+		{
+			name:           "End on empty panel",
+			panel:          testModelWithElemCount(0, 0, 12, 0),
+			toEnd:          true,
+			expectedCursor: 0,
+			expectedRender: 0,
+		},
+		{
+			name:           "End on short list that fits in view",
+			panel:          testModelWithElemCount(1, 0, 12, 5),
+			toEnd:          true,
+			expectedCursor: 4,
+			expectedRender: 0,
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.toEnd {
+				tt.panel.End()
+			} else {
+				tt.panel.Home()
+			}
+			assert.Equal(t, tt.expectedCursor, tt.panel.GetCursor())
+			assert.Equal(t, tt.expectedRender, tt.panel.GetRenderIndex())
+		})
+	}
+}
+
 func TestItemSelectUpDown(t *testing.T) {
 	testdata := []struct {
 		name             string

--- a/src/internal/ui/helpmenu/data.go
+++ b/src/internal/ui/helpmenu/data.go
@@ -151,6 +151,16 @@ func getData() []hotkeydata { //nolint: funlen // This should be self contained
 			hotkeyWorkType: globalType,
 		},
 		{
+			hotkey:         common.Hotkeys.ListHome,
+			description:    "Home",
+			hotkeyWorkType: globalType,
+		},
+		{
+			hotkey:         common.Hotkeys.ListEnd,
+			description:    "End",
+			hotkeyWorkType: globalType,
+		},
+		{
 			hotkey:         common.Hotkeys.ParentDirectory,
 			description:    "Return to parent folder",
 			hotkeyWorkType: globalType,

--- a/src/internal/ui/metadata/model.go
+++ b/src/internal/ui/metadata/model.go
@@ -102,6 +102,23 @@ func (m *Model) PgDown() {
 	m.moveRenderIndexBy(m.getPageScrollSize())
 }
 
+// Home jumps the metadata panel scroll to the first row.
+func (m *Model) Home() {
+	if m.MetadataLen() == 0 {
+		return
+	}
+	m.renderIndex = 0
+}
+
+// End jumps the metadata panel scroll to the last row.
+func (m *Model) End() {
+	l := m.MetadataLen()
+	if l == 0 {
+		return
+	}
+	m.renderIndex = l - 1
+}
+
 func (m *Model) SetBlank() {
 	m.metadata.filepath = ""
 	m.metadata.data = m.metadata.data[:0]

--- a/src/internal/ui/metadata/navigation_test.go
+++ b/src/internal/ui/metadata/navigation_test.go
@@ -78,3 +78,63 @@ func TestPgUpDown(t *testing.T) {
 		})
 	}
 }
+
+func TestHomeEnd(t *testing.T) {
+	tenItems := Metadata{
+		data: make([][2]string, 10),
+	}
+	testdata := []struct {
+		name                string
+		m                   Model
+		toEnd               bool
+		expectedRenderIndex int
+	}{
+		{
+			name:                "Home from middle jumps to first row",
+			m:                   Model{metadata: tenItems, renderIndex: 5},
+			toEnd:               false,
+			expectedRenderIndex: 0,
+		},
+		{
+			name:                "End from middle jumps to last row",
+			m:                   Model{metadata: tenItems, renderIndex: 3},
+			toEnd:               true,
+			expectedRenderIndex: 9,
+		},
+		{
+			name:                "Home at top stays at top",
+			m:                   Model{metadata: tenItems, renderIndex: 0},
+			toEnd:               false,
+			expectedRenderIndex: 0,
+		},
+		{
+			name:                "End at bottom stays at bottom",
+			m:                   Model{metadata: tenItems, renderIndex: 9},
+			toEnd:               true,
+			expectedRenderIndex: 9,
+		},
+		{
+			name:                "Home on empty panel stays put",
+			m:                   Model{metadata: Metadata{data: nil}, renderIndex: 0},
+			toEnd:               false,
+			expectedRenderIndex: 0,
+		},
+		{
+			name:                "End on empty panel stays put",
+			m:                   Model{metadata: Metadata{data: nil}, renderIndex: 0},
+			toEnd:               true,
+			expectedRenderIndex: 0,
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.toEnd {
+				tt.m.End()
+			} else {
+				tt.m.Home()
+			}
+			assert.Equal(t, tt.expectedRenderIndex, tt.m.renderIndex)
+		})
+	}
+}

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -23,6 +23,8 @@ list_down = ['down', 'j']
 list_up = ['up', 'k']
 page_down = ['pgdown','']
 page_up = ['pgup','']
+list_home = ['home','']
+list_end = ['end','']
 
 #-- File Panel Controls
 close_file_panel = ['w', '']

--- a/src/superfile_config/vimHotkeys.toml
+++ b/src/superfile_config/vimHotkeys.toml
@@ -26,6 +26,8 @@ list_up = ['k', '']
 list_down = ['j', '']
 page_up = ['pgup','']
 page_down = ['pgdown','']
+list_home = ['home','g']
+list_end = ['end','G']
 
 #-- File Panel Controls
 create_new_file_panel = ['n', '']

--- a/website/src/content/docs/list/hotkey-list.mdx
+++ b/website/src/content/docs/list/hotkey-list.mdx
@@ -58,6 +58,8 @@ Quit superfile and cd to current folder "cd_quit" requires the same setup as ["c
 | Down                                               | `down`, `j`                 | `list_down`                                                      |
 | Page up                                            | `pgup`                      | `page_up`                                                        |
 | Page down                                          | `pgdown`                    | `page_down`                                                      |
+| Home                                               | `home`                      | `list_home`                                                      |
+| End                                                | `end`                       | `list_end`                                                       |
 | Return to parent folder                            | `h`, `left`, `backspace`    | `parent_directory`                                               |
 | Select all items in focused file panel             | `A` (shift+a)               | `file_panel_select_all_items` (selection mode only)              |
 | Select up from your cursor                         | `shift+up`, `K` (shift+k)   | `file_panel_select_mode_items_select_up` (selection mode only)   |

--- a/website/src/content/docs/zh-tw/list/hotkey-list.mdx
+++ b/website/src/content/docs/zh-tw/list/hotkey-list.mdx
@@ -58,6 +58,8 @@ head:
 | 向下                                         | `down`, `j`                 | `list_down`                                              |
 | 向上翻頁                                     | `pgup`                      | `page_up`                                                |
 | 向下翻頁                                     | `pgdown`                    | `page_down`                                              |
+| 移到開頭                                     | `home`                      | `list_home`                                              |
+| 移到結尾                                     | `end`                       | `list_end`                                               |
 | 返回父資料夾                                 | `h`, `left`, `backspace`    | `parent_directory`                                       |
 | 選取目前檔案面板中的所有項目                 | `A` (shift+a)               | `file_panel_select_all_items`（僅選取模式）              |
 | 從游標向上選取                               | `shift+up`, `K` (shift+k)   | `file_panel_select_mode_items_select_up`（僅選取模式）   |


### PR DESCRIPTION


# Description

I recently started using Superfile and was sorely missing Home/End support.
I added support based on the Page Up/Down code.

`golangci-lint` reported `maintidx` error in `func (m *model) mainKey(msg string) tea.Cmd` but considering the size of this function, it's nothing I could avoid without rewriting key input handling. I took the liberty of adding it to ignore for this function.

I can't vouch for the translation file into Chinese.

---

# ✅ Pre-Submission Checklist

Please go through the following steps **before** submitting this PR.  
You can delete this section after confirming everything is done.

- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I’m not committing any debug logs or TODOs
- [x] I have checked that the PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

---

LLM disclaimer: Help from an LLM was used during development (especially in tests), but all changes were carefully checked by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Home/End navigation for list panels and metadata views, letting you jump to the first or last item quickly.
  * Added new configurable hotkeys for these actions, including alternate Vim-style bindings.

* **Bug Fixes**
  * Improved context-aware behavior so Home/End only affect the active panel and are ignored where not applicable.

* **Documentation**
  * Updated hotkey help and reference docs to include the new navigation shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->