### PR TITLE
feat(navigation): add list top/bottom jump shortcuts and select all toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ testsuite/.venv/
 
 # Agent configs
 CLAUDE.md
+.basemem.code.db

--- a/src/internal/common/config_type.go
+++ b/src/internal/common/config_type.go
@@ -125,10 +125,12 @@ type HotkeysType struct {
 	CdQuit  []string `toml:"cd_quit"`
 
 	// movement
-	ListUp   []string `toml:"list_up"   comment:"movement"`
-	ListDown []string `toml:"list_down"`
-	PageUp   []string `toml:"page_up"`
-	PageDown []string `toml:"page_down"`
+	ListUp     []string `toml:"list_up"   comment:"movement"`
+	ListDown   []string `toml:"list_down"`
+	ListTop    []string `toml:"list_top"`
+	ListBottom []string `toml:"list_bottom"`
+	PageUp     []string `toml:"page_up"`
+	PageDown   []string `toml:"page_down"`
 
 	CloseFilePanel         []string `toml:"close_file_panel"          comment:"file panel control"`
 	CreateNewFilePanel     []string `toml:"create_new_file_panel"`

--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -50,6 +50,30 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,go
 			m.getFocusedFilePanel().ListDown()
 		}
 
+	case slices.Contains(common.Hotkeys.ListTop, msg):
+		switch m.focusPanel {
+		case sidebarFocus:
+			m.sidebarModel.ListTop()
+		case processBarFocus:
+			m.processBarModel.ListTop()
+		case metadataFocus:
+			m.fileMetaData.ListTop()
+		case nonePanelFocus:
+			m.getFocusedFilePanel().ListTop()
+		}
+
+	case slices.Contains(common.Hotkeys.ListBottom, msg):
+		switch m.focusPanel {
+		case sidebarFocus:
+			m.sidebarModel.ListBottom()
+		case processBarFocus:
+			m.processBarModel.ListBottom()
+		case metadataFocus:
+			m.fileMetaData.ListBottom()
+		case nonePanelFocus:
+			m.getFocusedFilePanel().ListBottom()
+		}
+
 	case slices.Contains(common.Hotkeys.PageUp, msg):
 		switch m.focusPanel {
 		case metadataFocus:

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -76,7 +76,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		resizeCmd = m.handleWindowResize(msg)
 	case tea.MouseMsg:
-		m.handleMouseMsg(msg)
+		inputCmd = m.handleMouseMsg(msg)
 	case tea.KeyPressMsg:
 		inputCmd = m.handleKeyInput(msg)
 
@@ -109,15 +109,6 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	return m, tea.Batch(sidebarCmd, helpMenuCmd, inputCmd, updateCmd,
 		panelCmd, metadataCmd, filePreviewCmd, resizeCmd)
-}
-
-func (m *model) handleMouseMsg(msg tea.MouseMsg) {
-	msgStr := msg.String()
-	if msgStr == "wheelup" || msgStr == "wheeldown" {
-		wheelMainAction(msgStr, m)
-	} else {
-		slog.Debug("Mouse event of type that is not handled", "msg", msgStr)
-	}
 }
 
 func (m *model) updateModelStateAfterMsg() {

--- a/src/internal/mouse_function.go
+++ b/src/internal/mouse_function.go
@@ -91,8 +91,9 @@ func (m *model) handleSidebarClick(y int) {
 	}
 	targetIndex := y - headerLines
 	if targetIndex >= 0 {
-		m.sidebarModel.SetCursor(targetIndex)
-		m.sidebarSelectDirectory()
+		if m.sidebarModel.SetCursor(targetIndex) {
+			m.sidebarSelectDirectory()
+		}
 	}
 }
 

--- a/src/internal/mouse_function.go
+++ b/src/internal/mouse_function.go
@@ -1,0 +1,122 @@
+package internal
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/yorukot/superfile/src/internal/common"
+)
+
+var (
+	lastClickTime time.Time
+	lastClickPos  [2]int
+)
+
+func (m *model) handleMouseMsg(msg tea.MouseMsg) tea.Cmd {
+	mouse := msg.Mouse()
+	msgStr := msg.String()
+
+	if msgStr == "wheelup" || msgStr == "wheeldown" {
+		m.updateFocusByCoords(mouse.X, mouse.Y)
+		wheelMainAction(msgStr, m)
+		return nil
+	}
+
+	if mouse.Button == tea.MouseLeft {
+		return m.handleLeftClick(mouse.X, mouse.Y)
+	}
+
+	return nil
+}
+
+func (m *model) handleLeftClick(x, y int) tea.Cmd {
+	m.updateFocusByCoords(x, y)
+
+	now := time.Now()
+	isDoubleClick := now.Sub(lastClickTime) < 400*time.Millisecond && lastClickPos[0] == x && lastClickPos[1] == y
+	lastClickTime = now
+	lastClickPos = [2]int{x, y}
+
+	if m.focusPanel == sidebarFocus {
+		m.handleSidebarClick(y)
+	} else if m.focusPanel == nonePanelFocus {
+		return m.handleFilePanelClick(x, y, isDoubleClick)
+	}
+
+	return nil
+}
+
+func (m *model) updateFocusByCoords(x, y int) {
+	// Click in footer
+	if m.toggleFooter && y >= m.mainPanelHeight {
+		processWidth := m.processBarModel.GetWidth()
+		if x < processWidth {
+			m.focusOnProcessBar()
+		} else {
+			m.focusOnMetadata()
+		}
+		return
+	}
+
+	// Click in sidebar
+	if x < common.Config.SidebarWidth {
+		m.focusOnSideBar()
+		return
+	}
+
+	// Click in main file panels
+	m.focusPanel = nonePanelFocus
+	relX := x - common.Config.SidebarWidth
+	panelCount := m.fileModel.PanelCount()
+
+	accumX := 0
+	for i := 0; i < panelCount; i++ {
+		pw := m.fileModel.FilePanels[i].GetWidth()
+		if relX >= accumX && relX < accumX+pw {
+			m.fileModel.SetFocusedPanelIndex(i)
+			break
+		}
+		accumX += pw
+	}
+}
+
+func (m *model) handleSidebarClick(y int) {
+	// Line 0: top border
+	// Line 1: superfile title
+	// Line 2: blank line
+	// Line 3: searchbar (if rendered)
+	headerLines := 3
+	if m.sidebarModel.SearchBarFocused() {
+		headerLines = 4
+	}
+	targetIndex := y - headerLines
+	if targetIndex >= 0 {
+		m.sidebarModel.SetCursor(targetIndex)
+		m.sidebarSelectDirectory()
+	}
+}
+
+func (m *model) handleFilePanelClick(x, y int, isDoubleClick bool) tea.Cmd {
+	panel := m.getFocusedFilePanel()
+	// Line 0: top border
+	// Line 1: path title
+	// Line 2: section divider
+	// Line 3: search bar
+	topOffset := 4
+	if panel.NeedRenderHeaders() {
+		topOffset = 5
+	}
+
+	targetRow := y - topOffset
+	if targetRow >= 0 {
+		targetIndex := panel.RenderIndex() + targetRow
+		if targetIndex >= 0 && targetIndex < panel.ElemCount() {
+			if panel.GetCursor() == targetIndex && isDoubleClick {
+				m.enterPanel()
+			} else {
+				panel.SetCursorPosition(targetIndex)
+			}
+		}
+	}
+	return nil
+}

--- a/src/internal/mouse_function_test.go
+++ b/src/internal/mouse_function_test.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/yorukot/superfile/src/internal/common"
+)
+
+func TestMouseLeftClickFocusPanel(t *testing.T) {
+	testPaths := []string{t.TempDir()}
+	m := defaultModelConfig(true, true, false, testPaths, nil)
+	m.fullWidth = 120
+	m.fullHeight = 40
+	m.setHeightValues()
+	m.updateComponentDimensions()
+	m.firstLoadingComplete = true
+
+	// Click sidebar header area
+	m.updateFocusByCoords(5, 0)
+	assert.Equal(t, sidebarFocus, m.focusPanel)
+
+	// Click file panel area (x=common.Config.SidebarWidth + 10, y=5)
+	mouseMsg := tea.MouseClickMsg{
+		X:      common.Config.SidebarWidth + 10,
+		Y:      5,
+		Button: tea.MouseLeft,
+	}
+
+	_ = m.handleMouseMsg(mouseMsg)
+	assert.Equal(t, nonePanelFocus, m.focusPanel)
+}

--- a/src/internal/ui/filemodel/navigation.go
+++ b/src/internal/ui/filemodel/navigation.go
@@ -19,3 +19,11 @@ func (m *Model) MoveFocusedPanelBy(delta int) {
 	m.FocusedPanelIndex = (m.FocusedPanelIndex + delta + m.PanelCount()) % m.PanelCount()
 	m.FilePanels[m.FocusedPanelIndex].IsFocused = true
 }
+
+func (m *Model) SetFocusedPanelIndex(index int) {
+	if index >= 0 && index < m.PanelCount() {
+		m.GetFocusedFilePanel().IsFocused = false
+		m.FocusedPanelIndex = index
+		m.FilePanels[m.FocusedPanelIndex].IsFocused = true
+	}
+}

--- a/src/internal/ui/filepanel/navigation.go
+++ b/src/internal/ui/filepanel/navigation.go
@@ -54,6 +54,20 @@ func (m *Model) ListDown() {
 	m.moveCursorBy(1)
 }
 
+func (m *Model) ListTop() {
+	if m.Empty() {
+		return
+	}
+	m.scrollToCursor(0)
+}
+
+func (m *Model) ListBottom() {
+	if m.Empty() {
+		return
+	}
+	m.scrollToCursor(m.ElemCount() - 1)
+}
+
 func (m *Model) PgUp() {
 	m.pageScrollBy(-m.getPageScrollSize())
 }

--- a/src/internal/ui/filepanel/navigation_test.go
+++ b/src/internal/ui/filepanel/navigation_test.go
@@ -442,3 +442,36 @@ func TestPageScrollSizeConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestListTopBottom(t *testing.T) {
+	m := testModelWithElemCount(5, 2, 12, 20)
+
+	m.ListTop()
+	assert.Equal(t, 0, m.GetCursor())
+	assert.Equal(t, 0, m.GetRenderIndex())
+
+	m.ListBottom()
+	assert.Equal(t, 19, m.GetCursor())
+
+	// Test empty model
+	emptyModel := testModelWithElemCount(0, 0, 12, 0)
+	emptyModel.ListTop()
+	assert.Equal(t, 0, emptyModel.GetCursor())
+	emptyModel.ListBottom()
+	assert.Equal(t, 0, emptyModel.GetCursor())
+}
+
+func TestSelectAllItemToggle(t *testing.T) {
+	m := testModel(0, 0, 12, SelectMode, []Element{
+		{Name: "file1.txt", Location: "/tmp/file1.txt"},
+		{Name: "file2.txt", Location: "/tmp/file2.txt"},
+	})
+
+	// Select all
+	m.SelectAllItem()
+	assert.Equal(t, uint(2), m.SelectedCount())
+
+	// Calling SelectAllItem when all are selected should deselect all
+	m.SelectAllItem()
+	assert.Equal(t, uint(0), m.SelectedCount())
+}

--- a/src/internal/ui/filepanel/update.go
+++ b/src/internal/ui/filepanel/update.go
@@ -80,9 +80,13 @@ func (m *Model) ParentDirectory() error {
 	return m.UpdateCurrentFilePanelDir("..")
 }
 
-// Select all item in the file panel (only work on select mode)
+// Select all or deselect all items in the file panel (only work on select mode)
 func (m *Model) SelectAllItem() {
-	for _, item := range m.element {
-		m.SetSelected(item.Location)
+	if m.SelectedCount() == uint(len(m.element)) {
+		m.ResetSelected()
+	} else {
+		for _, item := range m.element {
+			m.SetSelected(item.Location)
+		}
 	}
 }

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -147,6 +147,10 @@ func (m *Model) SetCursorPosition(cursor int) {
 	m.scrollToCursor(cursor)
 }
 
+func (m *Model) RenderIndex() int {
+	return m.renderIndex
+}
+
 func (m *Model) FindElementIndexByName(name string) int {
 	for i, elem := range m.element {
 		if elem.Name == name {

--- a/src/internal/ui/metadata/model.go
+++ b/src/internal/ui/metadata/model.go
@@ -92,6 +92,21 @@ func (m *Model) ListDown() {
 	m.moveRenderIndexBy(1)
 }
 
+func (m *Model) ListTop() {
+	if m.MetadataLen() == 0 {
+		return
+	}
+	m.renderIndex = 0
+}
+
+func (m *Model) ListBottom() {
+	l := m.MetadataLen()
+	if l == 0 {
+		return
+	}
+	m.renderIndex = l - 1
+}
+
 // Control metadata panel page up
 func (m *Model) PgUp() {
 	m.moveRenderIndexBy(-m.getPageScrollSize())

--- a/src/internal/ui/processbar/model_navigation.go
+++ b/src/internal/ui/processbar/model_navigation.go
@@ -42,6 +42,23 @@ func (m *Model) ListDown() {
 	}
 }
 
+func (m *Model) ListTop() {
+	if m.cntProcesses() == 0 {
+		return
+	}
+	m.cursor = 0
+	m.renderIndex = 0
+}
+
+func (m *Model) ListBottom() {
+	cntP := m.cntProcesses()
+	if cntP == 0 {
+		return
+	}
+	m.cursor = cntP - 1
+	m.renderIndex = max(0, cntP-m.cntRenderableProcess())
+}
+
 func (m *Model) cntRenderableProcess() int {
 	footerHeight := m.height - common.BorderPadding
 	return cntRenderableProcess(footerHeight)

--- a/src/internal/ui/sidebar/navigation.go
+++ b/src/internal/ui/sidebar/navigation.go
@@ -55,6 +55,28 @@ func (s *Model) ListDown() {
 	}
 }
 
+func (s *Model) ListTop() {
+	if s.NoActualDir() {
+		return
+	}
+	s.cursor = 0
+	s.updateRenderIndex()
+	if s.directories[s.cursor].isDivider() {
+		s.ListDown()
+	}
+}
+
+func (s *Model) ListBottom() {
+	if s.NoActualDir() {
+		return
+	}
+	s.cursor = len(s.directories) - 1
+	s.updateRenderIndex()
+	if s.directories[s.cursor].isDivider() {
+		s.ListUp()
+	}
+}
+
 // Return till what indexes we will render, if we start from startIndex
 // if returned value is `startIndex - 1`, that means nothing can be rendered
 // This could be made constant time by keeping Indexes ot special directories saved,

--- a/src/internal/ui/sidebar/navigation.go
+++ b/src/internal/ui/sidebar/navigation.go
@@ -127,13 +127,15 @@ func (s *Model) updateRenderIndex() {
 		"renderIndex", s.renderIndex, "directory count", len(s.directories))
 }
 
-func (s *Model) SetCursor(idx int) {
+func (s *Model) SetCursor(idx int) bool {
 	if idx >= 0 && idx < len(s.directories) {
 		s.cursor = idx
 		s.updateRenderIndex()
 		if s.directories[s.cursor].isDivider() {
 			s.ListDown()
 		}
+		return true
 	}
+	return false
 }
 

--- a/src/internal/ui/sidebar/navigation.go
+++ b/src/internal/ui/sidebar/navigation.go
@@ -126,3 +126,14 @@ func (s *Model) updateRenderIndex() {
 	slog.Error("Unexpected situation in updateRenderIndex", "cursor", s.cursor,
 		"renderIndex", s.renderIndex, "directory count", len(s.directories))
 }
+
+func (s *Model) SetCursor(idx int) {
+	if idx >= 0 && idx < len(s.directories) {
+		s.cursor = idx
+		s.updateRenderIndex()
+		if s.directories[s.cursor].isDivider() {
+			s.ListDown()
+		}
+	}
+}
+

--- a/src/superfile_config/hotkeys.toml
+++ b/src/superfile_config/hotkeys.toml
@@ -21,6 +21,8 @@ quit = ['q', 'esc']
 #-- Navigation
 list_down = ['down', 'j']
 list_up = ['up', 'k']
+list_top = ['g', 'home']
+list_bottom = ['G', 'end']
 page_down = ['pgdown','']
 page_up = ['pgup','']
 


### PR DESCRIPTION
# Description

This PR adds keyboard shortcuts for:
1. **Top () / Bottom () List Navigation**: Jump directly to the top or bottom item across file panels, sidebar, metadata, and processbar panels.
2. **Select All / Deselect All Toggle ()**: In file panel selection mode, pressing `A` toggles selecting all items if not all are selected, or deselecting all items if all are currently selected.

# Related Issues
Fixes #1614
Partially addresses #300

# ✅ Pre-Submission Checklist
- [x] I have run `go fmt ./...` to format the code
- [x] I have run `golangci-lint run` and fixed any reported issues
- [x] I have tested my changes and verified they work as expected
- [x] I have reviewed the diff to make sure I’m not committing any debug logs
- [x] I have checked that the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Home and End hotkeys to jump directly to the top or bottom of file lists, sidebars, process lists, and metadata panels.
  * Added mouse support for scrolling, focusing panels, selecting sidebar items, moving through files, and double-clicking directories.
  * Clicking different interface areas now updates focus more intuitively.
  * “Select all” now toggles between selecting and deselecting all files.

* **Bug Fixes**
  * Improved navigation and focus handling for empty lists and panel boundaries.

* **Tests**
  * Added coverage for mouse focus, boundary navigation, and selection toggling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->