### PR TITLE
fix: slow / cpu intensive thumbnail generation for video files

### DIFF
--- a/src/internal/ui/prompt/tokenize_test.go
+++ b/src/internal/ui/prompt/tokenize_test.go
@@ -83,15 +83,18 @@ func Test_tokenizePromptCommand(t *testing.T) {
 	}
 }
 
-// Note : resolving shell subsitution is flaky in windows.
-// It usually times out, and environment variables sometimes dont work.
+// Note: shell startup is slower on Windows, especially on hosted CI runners.
+// Keep regular substitution tests above the production timeout so the tests
+// validate substitution behavior rather than runner startup latency.
+// Timeout behavior is covered separately with a short timeout below.
 func Test_resolveShellSubstitution(t *testing.T) {
 	timeout := shellSubTimeoutInTests
+	timeoutTestTimeout := shellSubTimeoutInTests
 	newLineSuffix := "\n"
 	noopCommand := "true"
 	if runtime.GOOS == "windows" {
-		// Substitution is slow in windows
-		timeout = 2 * time.Second
+		timeout = 5 * time.Second
+		timeoutTestTimeout = 500 * time.Millisecond
 		// Windows uses \r\n as new line for echo
 		newLineSuffix = "\r\n"
 		noopCommand = "cd ."
@@ -195,7 +198,7 @@ func Test_resolveShellSubstitution(t *testing.T) {
 	}
 
 	t.Run("Testing shell substitution timeout", func(t *testing.T) {
-		result, err := resolveShellSubstitution(timeout, "$(sleep 2)", defaultTestCwd)
+		result, err := resolveShellSubstitution(timeoutTestTimeout, "$(sleep 2)", defaultTestCwd)
 		assert.Empty(t, result)
 		require.Error(t, err)
 		require.ErrorIs(t, err, context.DeadlineExceeded)

--- a/src/pkg/file_preview/constants.go
+++ b/src/pkg/file_preview/constants.go
@@ -32,7 +32,7 @@ const (
 
 	videoThumbSeekRatio           = 0.05
 	videoThumbFallbackSeekSeconds = 5
-	videoThumbMaxWidth            = 600
-	videoThumbMaxHeight           = 900
-	videoThumbQuality             = 9
+	videoThumbMaxWidth            = 1024
+	videoThumbMaxHeight           = 720
+	videoThumbQuality             = 5
 )

--- a/src/pkg/file_preview/constants.go
+++ b/src/pkg/file_preview/constants.go
@@ -29,4 +29,10 @@ const (
 	maxVideoFileSizeForThumb = "104857600" // 100MB limit
 	thumbOutputExt           = ".jpg"
 	thumbGenerationTimeout   = 30 * time.Second
+
+	videoThumbSeekRatio           = 0.05
+	videoThumbFallbackSeekSeconds = 5
+	videoThumbMaxWidth            = 600
+	videoThumbMaxHeight           = 900
+	videoThumbQuality             = 9
 )

--- a/src/pkg/file_preview/constants.go
+++ b/src/pkg/file_preview/constants.go
@@ -29,10 +29,11 @@ const (
 	maxVideoFileSizeForThumb = "104857600" // 100MB limit
 	thumbOutputExt           = ".jpg"
 	thumbGenerationTimeout   = 30 * time.Second
+	videoProbeTimeout        = 2 * time.Second
 
-	videoThumbSeekRatio           = 0.05
-	videoThumbFallbackSeekSeconds = 5
-	videoThumbMaxWidth            = 1024
-	videoThumbMaxHeight           = 720
-	videoThumbQuality             = 5
+	videoThumbSeekRatio              = 0.05
+	videoThumbSeekTimestampPrecision = 3
+	videoThumbMaxWidth               = 1024
+	videoThumbMaxHeight              = 720
+	videoThumbQuality                = 5
 )

--- a/src/pkg/file_preview/thumbnail_generator.go
+++ b/src/pkg/file_preview/thumbnail_generator.go
@@ -365,6 +365,7 @@ func isFFmpegInstalled() bool {
 	return err == nil
 }
 
+// ffprobe is packaged with ffmpeg but still checking in case
 func isFFprobeInstalled() bool {
 	_, err := exec.LookPath("ffprobe")
 	return err == nil

--- a/src/pkg/file_preview/thumbnail_generator.go
+++ b/src/pkg/file_preview/thumbnail_generator.go
@@ -2,12 +2,14 @@ package filepreview
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -20,18 +22,71 @@ type thumbnailGeneratorInterface interface {
 	generateThumbnail(inputPath string, outputPathWithoutExt string) (string, error)
 }
 
-type VideoGenerator struct{}
+type VideoGenerator struct {
+	ffprobeAvailable bool
+}
 
 func newVideoGenerator() (*VideoGenerator, error) {
 	if !isFFmpegInstalled() {
 		return nil, errors.New("ffmpeg is not installed")
 	}
 
-	return &VideoGenerator{}, nil
+	return &VideoGenerator{ffprobeAvailable: isFFprobeInstalled()}, nil
 }
 
 func (g *VideoGenerator) supportsExt(ext string) bool {
 	return common.VideoExtensions[strings.ToLower(ext)]
+}
+
+type videoMetadata struct {
+	Format struct {
+		Duration string `json:"duration"`
+	} `json:"format"`
+}
+
+func getVideoDuration(ctx context.Context, inputPath string) (float64, error) {
+	ffprobe := exec.CommandContext(ctx, "ffprobe",
+		"-v", "quiet",
+		"-show_entries", "format=duration",
+		"-of", "json=c=1",
+		inputPath,
+	)
+
+	output, err := ffprobe.Output()
+	if err != nil {
+		return 0, fmt.Errorf("error probing video duration: %w", err)
+	}
+
+	var metadata videoMetadata
+	if err := json.Unmarshal(output, &metadata); err != nil {
+		return 0, fmt.Errorf("error parsing ffprobe output: %w", err)
+	}
+
+	if metadata.Format.Duration == "" {
+		return 0, errors.New("ffprobe output missing duration")
+	}
+
+	duration, err := strconv.ParseFloat(metadata.Format.Duration, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing video duration %q: %w", metadata.Format.Duration, err)
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("invalid video duration: %f", duration)
+	}
+
+	return duration, nil
+}
+
+func videoThumbnailSeekSeconds(duration float64) int {
+	return int(duration * videoThumbSeekRatio)
+}
+
+func videoThumbnailScaleFilter() string {
+	return fmt.Sprintf(
+		"scale='min(%d,iw)':'min(%d,ih)':force_original_aspect_ratio=decrease:flags=fast_bilinear",
+		videoThumbMaxWidth,
+		videoThumbMaxHeight,
+	)
 }
 
 func (g *VideoGenerator) generateThumbnail(inputPath string, outputPathWithoutExt string) (string, error) {
@@ -39,22 +94,38 @@ func (g *VideoGenerator) generateThumbnail(inputPath string, outputPathWithoutEx
 	defer cancel()
 	outputPath := outputPathWithoutExt + thumbOutputExt
 
-	// ffmpeg -v warning -t 60 -hwaccel auto -an -sn -dn -skip_frame nokey -i input.mkv -vf scale='min(1024,iw)':'min(720,ih)':force_original_aspect_ratio=decrease:flags=fast_bilinear -vf "thumbnail" -frames:v 1 -y thumb.jpg
-	ffmpeg := exec.CommandContext(ctx, "ffmpeg",
+	seekSeconds := videoThumbFallbackSeekSeconds
+	if g.ffprobeAvailable {
+		if duration, err := getVideoDuration(ctx, inputPath); err == nil {
+			seekSeconds = videoThumbnailSeekSeconds(duration)
+		} else {
+			slog.Debug("Error probing video duration, using fallback seek", "error", err)
+		}
+	}
+
+	ffmpegArgs := []string{
 		"-v", "warning", // set log level to warning
-		"-an",       // disable Audio stream
-		"-sn",       // disable Subtitle stream
-		"-dn",       // disable data stream
-		"-t", "180", // process maximum 180s of the video (the first 3 min)
 		"-hwaccel", "auto", // Use Hardware Acceleration if available
+		"-threads", "1", // limit CPU spikes from video decoding
+		"-an", // disable Audio stream
+		"-sn", // disable Subtitle stream
+		"-dn", // disable data stream
+	}
+	if seekSeconds > 0 {
+		ffmpegArgs = append(ffmpegArgs, "-ss", strconv.Itoa(seekSeconds))
+	}
+	ffmpegArgs = append(ffmpegArgs,
 		"-skip_frame", "nokey", // skip non-key frames
 		"-i", inputPath, // set input file
-		"-vf", "thumbnail", // use ffmpeg default thumbnail filter
-		"-frames:v", "1", // output only one frame (one image)
+		"-vframes", "1", // output only one frame (one image)
+		"-q:v", strconv.Itoa(videoThumbQuality), // set JPEG quality
+		"-vf", videoThumbnailScaleFilter(), // scale down for terminal preview
 		"-f", "image2", // set format to image2
 		"-fs", maxVideoFileSizeForThumb, // limit the max file size to match image previewer limit
 		"-y", outputPath, // set the outputFile and overwrite it without confirmation if already exists
 	)
+
+	ffmpeg := exec.CommandContext(ctx, "ffmpeg", ffmpegArgs...)
 
 	err := ffmpeg.Run()
 	if err != nil {
@@ -267,5 +338,10 @@ func isGhostscriptInstalled() bool {
 
 func isFFmpegInstalled() bool {
 	_, err := exec.LookPath("ffmpeg")
+	return err == nil
+}
+
+func isFFprobeInstalled() bool {
+	_, err := exec.LookPath("ffprobe")
 	return err == nil
 }

--- a/src/pkg/file_preview/thumbnail_generator.go
+++ b/src/pkg/file_preview/thumbnail_generator.go
@@ -58,7 +58,8 @@ func getVideoDuration(ctx context.Context, inputPath string) (float64, error) {
 	}
 
 	var metadata videoMetadata
-	if err := json.Unmarshal(output, &metadata); err != nil {
+	err = json.Unmarshal(output, &metadata)
+	if err != nil {
 		return 0, fmt.Errorf("error parsing ffprobe output: %w", err)
 	}
 

--- a/src/pkg/file_preview/thumbnail_generator.go
+++ b/src/pkg/file_preview/thumbnail_generator.go
@@ -45,7 +45,10 @@ type videoMetadata struct {
 }
 
 func getVideoDuration(ctx context.Context, inputPath string) (float64, error) {
-	ffprobe := exec.CommandContext(ctx, "ffprobe",
+	probeCtx, cancel := context.WithTimeout(ctx, videoProbeTimeout)
+	defer cancel()
+
+	ffprobe := exec.CommandContext(probeCtx, "ffprobe",
 		"-v", "quiet",
 		"-show_entries", "format=duration",
 		"-of", "json=c=1",
@@ -71,6 +74,7 @@ func getVideoDuration(ctx context.Context, inputPath string) (float64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("error parsing video duration %q: %w", metadata.Format.Duration, err)
 	}
+
 	if duration <= 0 {
 		return 0, fmt.Errorf("invalid video duration: %f", duration)
 	}
@@ -78,8 +82,8 @@ func getVideoDuration(ctx context.Context, inputPath string) (float64, error) {
 	return duration, nil
 }
 
-func videoThumbnailSeekSeconds(duration float64) int {
-	return int(duration * videoThumbSeekRatio)
+func formatVideoThumbnailSeekSeconds(seekSeconds float64) string {
+	return strconv.FormatFloat(seekSeconds, 'f', videoThumbSeekTimestampPrecision, 64)
 }
 
 func videoThumbnailScaleFilter() string {
@@ -90,20 +94,7 @@ func videoThumbnailScaleFilter() string {
 	)
 }
 
-func (g *VideoGenerator) generateThumbnail(inputPath string, outputPathWithoutExt string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), thumbGenerationTimeout)
-	defer cancel()
-	outputPath := outputPathWithoutExt + thumbOutputExt
-
-	seekSeconds := videoThumbFallbackSeekSeconds
-	if g.ffprobeAvailable {
-		if duration, err := getVideoDuration(ctx, inputPath); err == nil {
-			seekSeconds = videoThumbnailSeekSeconds(duration)
-		} else {
-			slog.Debug("Error probing video duration, using fallback seek", "error", err)
-		}
-	}
-
+func runVideoThumbnailFFmpeg(ctx context.Context, inputPath string, outputPath string, seekSeconds float64) error {
 	ffmpegArgs := []string{
 		"-v", "warning", // set log level to warning
 		"-hwaccel", "auto", // Use Hardware Acceleration if available
@@ -112,9 +103,11 @@ func (g *VideoGenerator) generateThumbnail(inputPath string, outputPathWithoutEx
 		"-sn", // disable Subtitle stream
 		"-dn", // disable data stream
 	}
+
 	if seekSeconds > 0 {
-		ffmpegArgs = append(ffmpegArgs, "-ss", strconv.Itoa(seekSeconds))
+		ffmpegArgs = append(ffmpegArgs, "-ss", formatVideoThumbnailSeekSeconds(seekSeconds))
 	}
+
 	ffmpegArgs = append(ffmpegArgs,
 		"-skip_frame", "nokey", // skip non-key frames
 		"-i", inputPath, // set input file
@@ -127,8 +120,38 @@ func (g *VideoGenerator) generateThumbnail(inputPath string, outputPathWithoutEx
 	)
 
 	ffmpeg := exec.CommandContext(ctx, "ffmpeg", ffmpegArgs...)
+	if err := ffmpeg.Run(); err != nil {
+		return err
+	}
 
-	err := ffmpeg.Run()
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		return fmt.Errorf("generated thumbnail is missing: %w", err)
+	}
+
+	if info.Size() == 0 {
+		return errors.New("generated thumbnail is empty")
+	}
+
+	return nil
+}
+
+func (g *VideoGenerator) generateThumbnail(inputPath string, outputPathWithoutExt string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), thumbGenerationTimeout)
+	defer cancel()
+	outputPath := outputPathWithoutExt + thumbOutputExt
+
+	seekSeconds := 0.0
+
+	if g.ffprobeAvailable {
+		videoDuration, err := getVideoDuration(ctx, inputPath)
+		if err != nil {
+			slog.Debug("Error probing video duration, thumbnail generation starts at beginning of video", "error", err)
+		}
+		seekSeconds = videoDuration * videoThumbSeekRatio
+	}
+
+	err := runVideoThumbnailFFmpeg(ctx, inputPath, outputPath, seekSeconds)
 	if err != nil {
 		return "", fmt.Errorf("error generating video thumbnail, outputPath: %s : %w", outputPath, err)
 	}


### PR DESCRIPTION
 # Description

This PR improves video thumbnail generation performance by changing the `ffmpeg` strategy used for video previews. 

Fixes: #1354 
Further helps alleviate resource use mentioned here: #1618
Does **not** fix: #1620

Previously, video thumbnails were generated by scanning up to the first 180 seconds of the video with the `thumbnail` filter and writing a full-resolution image:

   ```sh
   ffmpeg \
     -v warning \
     -an \
     -sn \
     -dn \
     -t 180 \
     -hwaccel auto \
     -skip_frame nokey \
     -i input \
     -vf thumbnail \
     -frames:v 1 \
     -f image2 \
     -fs 104857600 \
     -y output.jpg
 ```

For large 4K/8K videos, this can create high CPU spikes and high memory usage because ffmpeg is decoding/scanning large frames and writing a full-resolution thumbnail that Superfile later scales down for terminal preview.

 This PR changes video thumbnail generation to:

 - use ffprobe to get video duration when available
 - get thumbnail at around %5 of duration
 - limit ffmpeg to one decoding thread with -threads 1
 - scale the generated thumbnail inside ffmpeg to a preview-sized image
 - write a smaller JPEG thumbnail using `-q:v 5`
 - avoid the expensive thumbnail filter

 New command shape:

 ```sh
   ffprobe \
     -v quiet \
     -show_entries format=duration \
     -of json=c=1 \
     input
 ```

 Then:

 ```sh
   ffmpeg \
     -v warning \
     -hwaccel auto \
     -threads 1 \
     -an \
     -sn \
     -dn \
     -ss <5_percent_of_duration_or_0> \
     -skip_frame nokey \
     -i input \
     -vframes 1 \
     -q:v 5 \
     -vf "scale='min(1024,iw)':'min(720,ih)':force_original_aspect_ratio=decrease:flags=fast_bilinear" \
     -f image2 \
     -fs 104857600 \
     -y output.jpg
 ```

 ffprobe is optional. If it is missing, video thumbnails still works. It just starts at the beginning of the video and searches for first key frame.

This is intentionally scoped to video thumbnail generation only. It does not address preview job cancellation/debouncing or the separate show_image_preview = false behavior.

 ## Benchmark

 Local benchmark against six large videos in ~/Downloads:

 ```text
   641M  8K _ NEW ZEALAND ASCENDING_original.mp4
   3.1G  First-8K-Video-from-Space_modified (1).mp4
   3.1G  First-8K-Video-from-Space_modified.mp4
   2.2G  First 8K Video From Space~Orig.mkv
   1.0G  japan night 8k hevc.mkv
   1.3G  new zealand 8k hevc.mkv
 ```

 Environment:

 ```text
   macOS / Apple M1
   ffmpeg 8.1.2
   ffprobe 8.1.2
   Measured with /usr/bin/time -lp
 ```

 CPU percentage below is calculated as:

 ```text
   (user time + sys time) / real time * 100
 ```
   | Metric                           | Old Method     | New Method   |
   |----------------------------------|----------------|--------------|
   | Mean real time                   | 3.04s          | 0.30s        |
   | Max real time                    | 4.39s          | 0.40s        |
   | Mean CPU                         | 245%           | 53%          |
   | Max CPU                          | 630%           | 100%         |
   | Mean peak memory                 | 3503 MB        | 209 MB       |
   | Max peak memory                  | 4702 MB        | 412 MB       |
   | Mean output size of ffmpeg frame | 898 KB         | 60 KB        |
   | Output dimensions                | full 8K frames | ~1024px wide |

 Per-file result with the new command:

 ```text
  8K _ NEW ZEALAND ASCENDING_original.mp4     seek=20s  real=0.40s  cpu=100%  peak=124MB  out=70KB  dims=1024x576
   First 8K Video From Space~Orig.mkv          seek=9s   real=0.24s  cpu=33%   peak=105MB  out=46KB  dims=1024x512
   First-8K-Video-from-Space_modified (1).mp4  seek=9s   real=0.33s  cpu=36%   peak=137MB  out=46KB  dims=1024x512
   First-8K-Video-from-Space_modified.mp4      seek=9s   real=0.33s  cpu=36%   peak=143MB  out=46KB  dims=1024x512
   japan night 8k hevc.mkv                     seek=13s  real=0.21s  cpu=57%   peak=334MB  out=96KB  dims=1024x458
   new zealand 8k hevc.mkv                     seek=14s  real=0.30s  cpu=57%   peak=412MB  out=55KB  dims=1024x576
 ```

 Approximate improvement from the local benchmark:

 ```text
  ~10x faster wall time
   ~4.6x lower mean CPU
   ~6.3x lower max CPU spike
   ~17x lower mean peak memory
   ~11x lower max peak memory
   ~15x smaller output image
 ```

 Related Issues

 Relates to #1618

 The issue reports high memory usage and CPU spikes while navigating folders containing large video files. Local testing showed the CPU spike can come from child ffmpeg processes spawned by Superfile during video thumbnail generation. This PR reduces the CPU and memory cost of each video thumbnail generation.

 Relates to #1354

 This directly improves the video thumbnail generation path discussed in #1354 by changing how Superfile invokes ffmpeg, using a Yazi-style approach: seek to a representative point, extract one frame, and scale during ffmpeg output instead of generating a full-resolution thumbnail first.

# Screenshots 

Old Version             |  New Version
:-------------------------:|:-------------------------:
[old-v-20260806-213043.webm](https://github.com/user-attachments/assets/c3754218-cdfe-4293-bf5e-386fbd0c0d89)  |  [new-v-20260806-213101.webm](https://github.com/user-attachments/assets/95b1eabb-3b3a-4b4c-b32a-7c3258fe9e1d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved video thumbnails by selecting a representative frame based on video duration.
  * Added automatic fallback behavior when video metadata is unavailable.
  * Enhanced thumbnail output with bounded dimensions, preserved aspect ratio, and improved image quality.

* **Bug Fixes**
  * Reduced unnecessary processing by excluding unused audio, subtitle, and data streams during thumbnail creation.
  * Improved handling of videos with unavailable or invalid metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->