### PR TITLE
fix(common): truncate middle text by rune, not byte, to keep UTF-8 valid

### DIFF
--- a/src/internal/common/string_function.go
+++ b/src/internal/common/string_function.go
@@ -66,16 +66,21 @@ func TruncateTextBeginning(text string, maxChars int, tails string) string {
 }
 
 func TruncateMiddleText(text string, maxChars int, tails string) string {
-	if utf8.RuneCountInString(text) <= maxChars {
+	// Slice by rune, not by byte: text[:n] indexes bytes, which splits
+	// multi-byte UTF-8 runes in half and emits invalid UTF-8. See
+	// TruncateTextBeginning in this file for the same []rune pattern.
+	runes := []rune(text)
+	if len(runes) <= maxChars {
 		return text
 	}
 
-	//nolint:mnd // standard halving for center truncation
-	halfEllipsisLength := (maxChars - 3) / 2
+	//nolint:mnd // standard halving for center truncation (subtract tails rune count)
+	halfEllipsisLength := (maxChars - utf8.RuneCountInString(tails)) / 2
+	if halfEllipsisLength < 0 {
+		halfEllipsisLength = 0
+	}
 	// TODO : Use ansi.Substring to correctly handle ANSI escape codes
-	truncatedText := text[:halfEllipsisLength] + tails + text[utf8.RuneCountInString(text)-halfEllipsisLength:]
-
-	return truncatedText
+	return string(runes[:halfEllipsisLength]) + tails + string(runes[len(runes)-halfEllipsisLength:])
 }
 
 func FilePanelItemRenderWithIcon(

--- a/src/internal/common/string_function_test.go
+++ b/src/internal/common/string_function_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,10 @@ func TestStringTruncate(t *testing.T) {
 		{TruncateMiddleText, "TruncateMiddleText", "Hello world", 5, "...", "H...d"},
 		{TruncateMiddleText, "TruncateMiddleText", "Hello world", 7, "...", "He...ld"},
 		{TruncateMiddleText, "TruncateMiddleText", "Hello", 100, "...", "Hello"},
+		// multibyte UTF-8 must not be sliced mid-rune (regression for byte-vs-rune bug)
+		{TruncateMiddleText, "TruncateMiddleText", "éééééé", 5, "...", "é...é"},
+		{TruncateMiddleText, "TruncateMiddleText", "日本語のファイル", 7, "...", "日本...イル"},
+		{TruncateMiddleText, "TruncateMiddleText", "😀😁😂😃😄😅", 5, "...", "😀...😅"}, // 4-byte runes
 	}
 
 	for _, tt := range inputs {
@@ -41,6 +46,26 @@ func TestStringTruncate(t *testing.T) {
 			}
 		})
 	}
+
+	// Regression guard: even if an expected literal above is mis-edited,
+	// multibyte inputs must never yield invalid UTF-8. The original bug
+	// indexed multi-byte runes by byte offset, slicing them in half.
+	t.Run("TruncateMiddleText multibyte produces valid UTF-8", func(t *testing.T) {
+		multibyte := []struct {
+			text     string
+			maxChars int
+		}{
+			{"éééééé", 5},
+			{"日本語のファイル", 7},
+			{"😀😁😂😃😄😅", 5}, // 4-byte runes
+		}
+		for _, c := range multibyte {
+			result := TruncateMiddleText(c.text, c.maxChars, "...")
+			if !utf8.ValidString(result) {
+				t.Errorf("TruncateMiddleText(%q, %d) produced invalid UTF-8: %q", c.text, c.maxChars, result)
+			}
+		}
+	})
 }
 
 func TestFileNameWithoutExtensionText(t *testing.T) {


### PR DESCRIPTION
## Summary
`TruncateMiddleText` corrupted non-ASCII filenames in the metadata panel: it sliced the string by byte offset (`text[:n]`) using a rune-count index, splitting multi-byte UTF-8 runes in half and emitting invalid UTF-8 for accents, CJK, and emoji.

## Root cause
`halfEllipsisLength` is a rune count, but `text[:halfEllipsisLength]` and `text[len-halfEllipsisLength:]` index bytes. For a string like `"éééééé"` (each `é` is 2 bytes), a byte slice at a rune-count offset lands mid-rune and produces invalid UTF-8.

## Fix
Slice by `[]rune` instead, mirroring the sibling `TruncateTextBeginning` in the same file. Also derive `halfEllipsisLength` from the actual `tails` rune count (not a hardcoded `3`) so a non-`...` tails renders correctly, and guard against a negative half when `tails` is long.

## Tests
New multibyte cases in `TestStringTruncate`: `éééééé` (5 → `é...é`), a Japanese filename, an emoji run, plus an assertion that the result is valid UTF-8. All pass; existing ASCII cases unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text truncation so accented characters, CJK text, and emoji are not split or corrupted.
  * Truncated strings now consistently remain valid UTF-8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->