### PR TITLE
fix(utils): guard DirSize against nil DirEntry on walk errors

### DIFF
--- a/src/pkg/utils/file_utils.go
+++ b/src/pkg/utils/file_utils.go
@@ -215,13 +215,16 @@ func ResolveAbsPath(currentDir string, path string) string {
 }
 
 // Get directory total size
-// TODO: Uni test this
 func DirSize(path string) int64 {
 	var size int64
 	// Its named walkErr to prevent shadowing
 	walkErr := filepath.WalkDir(path, func(_ string, entry os.DirEntry, err error) error {
+		// On a walk error (e.g. root does not exist, permission denied) WalkDir
+		// invokes the callback with err != nil and a nil entry. Return before
+		// touching entry to avoid a nil-pointer dereference.
 		if err != nil {
 			slog.Error("Dir size function error", "error", err)
+			return err
 		}
 		if !entry.IsDir() {
 			info, infoErr := entry.Info()
@@ -229,7 +232,7 @@ func DirSize(path string) int64 {
 				size += info.Size()
 			}
 		}
-		return err
+		return nil
 	})
 	if walkErr != nil {
 		slog.Error("errors during WalkDir", "error", walkErr)

--- a/src/pkg/utils/file_utils_dirsize_test.go
+++ b/src/pkg/utils/file_utils_dirsize_test.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDirSize covers the directory-size walker. It pins down two things:
+//   - the sum across nested files (including an empty subdir and a regular
+//     file at the root) is correct;
+//   - an inaccessible root (non-existent path) returns 0 without panicking.
+//     WalkDir delivers err != nil with a nil entry there; the walker must
+//     return before dereferencing entry (regression for a nil-pointer panic).
+func TestDirSize(t *testing.T) {
+	root := t.TempDir()
+
+	// Two regular files of known sizes in different subdirectories.
+	subDir := filepath.Join(root, "sub")
+	require.NoError(t, os.Mkdir(subDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "top.txt"),
+		make([]byte, 512), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "leaf.txt"),
+		make([]byte, 128), 0o644))
+
+	// An empty directory contributes nothing; it must not break the walk.
+	require.NoError(t, os.Mkdir(filepath.Join(root, "empty"), 0o755))
+
+	got := DirSize(root)
+	assert.Equal(t, int64(640), got)
+
+	// An empty directory on its own sums to zero.
+	assert.Equal(t, int64(0), DirSize(filepath.Join(root, "empty")))
+}
+
+// TestDirSizeNonExistentRoot is the regression case for the nil-entry panic:
+// WalkDir invokes the callback with err != nil and a nil os.DirEntry when the
+// root cannot be walked. Previously DirSize dereferenced entry unconditionally
+// and crashed here; it must now return 0 cleanly.
+func TestDirSizeNonExistentRoot(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	// The parent temp dir exists, the child does not, so the first WalkDir
+	// callback is exactly the (err != nil, entry == nil) case.
+	if runtime.GOOS == "windows" {
+		missing = `C:\superfile-does-not-exist-dirsize`
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("DirSize panicked on non-existent root: %v", r)
+		}
+	}()
+	assert.Equal(t, int64(0), DirSize(missing))
+}


### PR DESCRIPTION
## Description

`utils.DirSize` walked a directory with `filepath.WalkDir` but dereferenced `entry.IsDir()` unconditionally. `filepath.WalkDir` invokes its callback with `err != nil` **and a nil `os.DirEntry`** when the root path cannot be walked (it does not exist, or is inaccessible due to permissions). In that case `entry.IsDir()` panicked with a nil-pointer dereference instead of returning a size of `0`.

This is reachable from the metadata panel when the cached path disappears between selection and the size read, or when the user lacks read permission on a directory — any `lstat` failure on the root crashes the TUI.

## Root cause

```go
walkErr := filepath.WalkDir(path, func(_ string, entry os.DirEntry, err error) error {
    if err != nil {
        slog.Error("Dir size function error", "error", err)
    }
    if !entry.IsDir() {   // <-- entry is nil here when err != nil
        ...
    }
    return err
})
```

The Go stdlib documents this contract: *"If there was a problem walking to the file or directory named by path … the corresponding os.DirEntry will be nil."*

## Changes

- `src/pkg/utils/file_utils.go`: return the error before touching `entry`, mirroring the canonical `filepath.WalkDir` callback pattern. On the no-error path `entry` is guaranteed non-nil, so the subsequent `entry.IsDir()` / `entry.Info()` calls are safe.
- `src/pkg/utils/file_utils_dirsize_test.go`: new `TestDirSize` (table-style, nested files of known sizes plus an empty subdir, asserting the summed size) and `TestDirSizeNonExistentRoot` regression case that previously panicked and now returns `0`.

## Reproducer

```go
// Before this change: panics with nil pointer dereference.
// After: returns 0.
size := utils.DirSize("/this/path/does/not/exist")
```

## Test plan

- [x] `go test ./src/pkg/utils/ -run TestDirSize -count=1` — green (both panics-free and correct sum)
- [x] `gofmt -l src/pkg/utils/` — empty
- [x] `golangci-lint run ./src/pkg/utils/...` (v2.12.2) — `0 issues.`
- [x] `go test ./src/pkg/utils/ -count=1` — full package green
- [x] `go build ./...` — clean

## Checklist

- [x] PR title is valid Conventional Commits (`fix(utils): …`)
- [x] `go fmt` / `golangci-lint` clean, targeted tests green
- [x] No debug logs or TODOs introduced; the pre-existing `// TODO: Uni test this` is removed because the function is now tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory-size handling when a directory cannot be accessed.
  * Prevented errors from causing unexpected crashes during directory scanning.
  * Ensured invalid or missing directories return a safe zero size.

* **Tests**
  * Added coverage for nested files, root-level files, empty directories, and non-existent directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->