### PR TITLE
fix(cache): do not evict when Set overwrites an existing key

### DIFF
--- a/src/pkg/cache/cache.go
+++ b/src/pkg/cache/cache.go
@@ -69,8 +69,11 @@ func (c *Cache[T]) Set(key string, obj T) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	// Check if we need to evict entries
-	if len(c.cache) >= c.maxEntries {
+	// Only evict when we are about to insert a NEW entry. Overwriting an
+	// existing key does not grow the cache, so running evictOldest in that
+	// case would drop an unrelated entry (e.g. refreshing the newest key at
+	// capacity used to evict its oldest sibling).
+	if _, exists := c.cache[key]; !exists && len(c.cache) >= c.maxEntries {
 		c.evictOldest()
 	}
 

--- a/src/pkg/cache/cache_test.go
+++ b/src/pkg/cache/cache_test.go
@@ -1,0 +1,100 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestCache returns a cache without exercising the periodic-cleanup
+// goroutine's expiration math; tests control eviction directly.
+func newTestCache(maxEntries int) *Cache[string] {
+	return New[string](maxEntries, time.Hour)
+}
+
+func TestCacheSetAndGet(t *testing.T) {
+	c := newTestCache(4)
+	_, ok := c.Get("missing")
+	assert.False(t, ok, "Get on a missing key should report miss")
+
+	c.Set("a", "a1")
+	v, ok := c.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, "a1", v)
+
+	// Overwrite updates the value in place.
+	c.Set("a", "a2")
+	v, ok = c.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, "a2", v)
+}
+
+func TestCacheRemove(t *testing.T) {
+	c := newTestCache(4)
+	c.Set("a", "a1")
+	c.Remove("a")
+	_, ok := c.Get("a")
+	assert.False(t, ok, "Get after Remove should miss")
+
+	// Removing a missing key is a no-op (no panic).
+	c.Remove("never-set")
+}
+
+func TestCacheEvictsOldestWhenFull(t *testing.T) {
+	c := newTestCache(2)
+	c.Set("a", "a1")
+	time.Sleep(2 * time.Millisecond)
+	c.Set("b", "b1")
+	// A brand-new third key must evict the oldest entry ("a").
+	c.Set("c", "c1")
+
+	_, aOk := c.Get("a")
+	assert.False(t, aOk, "oldest key should be evicted once capacity is reached")
+	_, bOk := c.Get("b")
+	assert.True(t, bOk)
+	_, cOk := c.Get("c")
+	assert.True(t, cOk)
+}
+
+// TestCacheSetOverwriteDoesNotEvictSibling is the regression case: refreshing
+// an existing key at capacity must not evict an unrelated entry. Before the
+// fix, Set ran evictOldest whenever len>=maxEntries, so overwriting the newest
+// key dropped its oldest sibling.
+func TestCacheSetOverwriteDoesNotEvictSibling(t *testing.T) {
+	c := newTestCache(2)
+	c.Set("a", "a1") // oldest
+	time.Sleep(2 * time.Millisecond)
+	c.Set("b", "b1") // newest
+
+	// Refresh the newest entry at capacity. The cache size is unchanged, so
+	// nothing should be evicted.
+	time.Sleep(2 * time.Millisecond)
+	c.Set("b", "b2")
+
+	v, ok := c.Get("b")
+	assert.True(t, ok)
+	assert.Equal(t, "b2", v)
+	_, aOk := c.Get("a")
+	assert.True(t, aOk, "overwriting an existing key must not evict a different entry")
+}
+
+// TestCacheSetOverwriteOldestKeepsCapacity guards the other branch of the fix:
+// when the key being refreshed is itself the oldest one, the cache must still
+// stay within maxEntries and keep the unrelated sibling.
+func TestCacheSetOverwriteOldestKeepsCapacity(t *testing.T) {
+	c := newTestCache(2)
+	c.Set("a", "a1")
+	time.Sleep(2 * time.Millisecond)
+	c.Set("b", "b1")
+
+	// Refresh the oldest entry.
+	c.Set("a", "a2")
+	assert.Len(t, c.cache, 2)
+
+	v, ok := c.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, "a2", v)
+	_, bOk := c.Get("b")
+	assert.True(t, bOk)
+}


### PR DESCRIPTION
## Description

`cache.Cache.Set` ran `evictOldest` whenever `len(c.cache) >= maxEntries`, regardless of whether the key being set already existed. Overwriting an existing entry does **not** grow the cache, so evicting in that case drops an unrelated entry.

Concrete reproducer at `maxEntries = 2`:

```
Set("a", "a1")   // cache: {a}
Set("b", "b1")   // cache: {a, b}   (now at capacity)
Set("b", "b2")   // refresh of an existing key
                 // BEFORE: evictOldest removes "a" -> cache: {b}
                 // AFTER:  no eviction -> cache: {a, b}
```

So every refresh of an already-cached entry silently shrinks the cache by one. This cache backs the metadata panel (`src/internal/ui/metadata`) and the image previewer (`src/pkg/file_preview`); on a re-render of an already-cached item the user loses an unrelated cached entry, causing re-computation of the dropped key on the next access.

## Root cause

```go
func (c *Cache[T]) Set(key string, obj T) {
	c.mutex.Lock()
	defer c.mutex.Unlock()

	// Check if we need to evict entries
	if len(c.cache) >= c.maxEntries {   // runs even when key is already present
		c.evictOldest()
	}
	c.cache[key] = cacheItemInternal[T]{...}
}
```

## Changes

- `src/pkg/cache/cache.go`: skip eviction when the key already exists (`if _, exists := c.cache[key]; !exists && len(c.cache) >= c.maxEntries { c.evictOldest() }`). Brand-new keys at capacity still evict the oldest entry exactly as before.
- `src/pkg/cache/cache_test.go`: new — the cache package had no unit tests at all. Covers basic `Set`/`Get`/`Remove`, capacity eviction of a brand-new key (`TestCacheEvictsOldestWhenFull`), and two regression cases for overwrite-at-capacity: refreshing the newest key (`TestCacheSetOverwriteDoesNotEvictSibling`, previously failed) and refreshing the oldest key (`TestCacheSetOverwriteOldestKeepsCapacity`).

## Test plan

- [x] `go test ./src/pkg/cache/ -count=1` — green, incl. the previously-failing regression case
- [x] `go test ./src/internal/ui/metadata/ ./src/pkg/file_preview/ -count=1` — both consuming packages green
- [x] `gofmt -l src/pkg/cache/` — empty
- [x] `golangci-lint run ./src/pkg/cache/...` (v2.12.2) — `0 issues.`
- [x] `go build ./...` — clean

## Checklist

- [x] PR title is valid Conventional Commits (`fix(cache): …`)
- [x] `go fmt` / `golangci-lint` clean, targeted tests green
- [x] No debug logs or TODOs introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed cache updates so overwriting an existing entry no longer removes another entry.
  - Cache capacity is now preserved when replacing existing values.
  - Oldest entries are still removed when adding a new entry to a full cache.

- **Tests**
  - Added coverage for cache reads, insertion, removal, capacity limits, and overwrite behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->