### PR TITLE
fix(metadata): stop showing a directory inode stat size as the folder size

### DIFF
--- a/src/internal/ui/metadata/const.go
+++ b/src/internal/ui/metadata/const.go
@@ -9,6 +9,7 @@ const keyValueSpacingLen = 1
 const fileStatErrorMsg = "Cannot load file stats"
 const linkFileBrokenMsg = "Link file is broken!"
 const etFetchErrorMsg = "Errors while fetching metadata via exiftool"
+const dirSizeUnfocusedMsg = "(focus)"
 
 const keyName = "Name"
 const keySize = "Size"

--- a/src/internal/ui/metadata/metadata.go
+++ b/src/internal/ui/metadata/metadata.go
@@ -111,7 +111,11 @@ func getMetaDataUnsorted(filePath string, metadataFocused bool, et *exiftool.Exi
 	// Add basic metadata information irrespective of what is fetched from exiftool
 	// Note : we prioritize these while sorting Metadata
 	name := [2]string{keyName, fileInfo.Name()}
+	// stat size of a directory inode is not the size of its contents
 	size := [2]string{keySize, common.FormatFileSize(fileInfo.Size())}
+	if fileInfo.IsDir() {
+		size = [2]string{keySize, dirSizeUnfocusedMsg}
+	}
 	modifyDate := [2]string{keyDataModified, fileInfo.ModTime().String()}
 	permissions := [2]string{keyPermissions, fileInfo.Mode().String()}
 	ownerVal, groupVal := getOwnerAndGroup(fileInfo)

--- a/src/internal/ui/metadata/metadata_test.go
+++ b/src/internal/ui/metadata/metadata_test.go
@@ -59,10 +59,19 @@ func TestDirectorySize(t *testing.T) {
 	filePath := filepath.Join(dirPath, "file1.txt")
 	require.NoError(t, os.WriteFile(filePath, fileContent, 0644))
 
+	// a file one level down, so the expected total below is only reachable by
+	// walking the tree, not by stat-ing the directory or its direct children
+	nestedContent := make([]byte, 3000)
+	nestedDir := filepath.Join(dirPath, "sub")
+	require.NoError(t, os.Mkdir(nestedDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "file2.txt"), nestedContent, 0644))
+
 	dirInfo, err := os.Lstat(dirPath)
 	require.NoError(t, err)
 	statSize := common.FormatFileSize(dirInfo.Size())
-	recursiveSize := common.FormatFileSize(utils.DirSize(dirPath))
+	// computed from the known file sizes rather than from DirSize, which is the
+	// function under test
+	recursiveSize := common.FormatFileSize(int64(len(fileContent) + len(nestedContent)))
 	fileSize := common.FormatFileSize(int64(len(fileContent)))
 
 	unfocusedDir, err := GetMetadata(dirPath, false, nil).GetValue(keySize)

--- a/src/internal/ui/metadata/metadata_test.go
+++ b/src/internal/ui/metadata/metadata_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/yorukot/superfile/src/internal/common"
 	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
@@ -46,5 +48,35 @@ func TestGetMetadata(t *testing.T) {
 				require.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestDirectorySize(t *testing.T) {
+	dirPath := t.TempDir()
+	// not 4096, or it would match the directory inode's own stat size and the
+	// focused assertion would pass without DirSize being called at all
+	fileContent := make([]byte, 9000)
+	filePath := filepath.Join(dirPath, "file1.txt")
+	require.NoError(t, os.WriteFile(filePath, fileContent, 0644))
+
+	dirInfo, err := os.Lstat(dirPath)
+	require.NoError(t, err)
+	statSize := common.FormatFileSize(dirInfo.Size())
+	recursiveSize := common.FormatFileSize(utils.DirSize(dirPath))
+	fileSize := common.FormatFileSize(int64(len(fileContent)))
+
+	unfocusedDir, err := GetMetadata(dirPath, false, nil).GetValue(keySize)
+	require.NoError(t, err)
+	assert.NotEqual(t, statSize, unfocusedDir)
+	assert.Equal(t, dirSizeUnfocusedMsg, unfocusedDir)
+
+	focusedDir, err := GetMetadata(dirPath, true, nil).GetValue(keySize)
+	require.NoError(t, err)
+	assert.Equal(t, recursiveSize, focusedDir)
+
+	for _, focused := range []bool{false, true} {
+		fileVal, err := GetMetadata(filePath, focused, nil).GetValue(keySize)
+		require.NoError(t, err)
+		assert.Equal(t, fileSize, fileVal)
 	}
 }


### PR DESCRIPTION
# Description

With the metadata panel unfocused, a directory's Size row shows the size of the directory inode, not of its contents. A directory holding 488 KiB of files reads:

```
Size          4.00 KiB
```

## The cause

`metadata.go` set `size` from `fileInfo.Size()` unconditionally, and only overwrote it with the recursive `utils.DirSize` when the panel was both a directory and focused. So the unfocused case silently presented the inode size as an answer.

## The fix

You wrote in the issue:

> Issue will be closed after we update metadata panel to not show size at all for directory (or write "focus on metadata to compute size"). Writing invalid value like 370B here, isn't good.

I took the placeholder rather than dropping the row. `keySize` has a fixed slot in `sortPriority` and the existing test's `defaultKeys` expects the key to be present, so removing the row would change the panel's row set on focus and cause a visible reflow.

The string is `(focus)`, deliberately short. At 80 columns the panel is 26 wide and the value column only fits 11 characters, so a longer message like "Focus to compute" gets truncated to `Focu...pute` at the width most people actually use.

## Verification

The metadata package suite passes in full, with exiftool installed:

```
ok  	github.com/yorukot/superfile/src/internal/ui/metadata
```

The test asserts three things: an unfocused directory no longer reports the inode size, a focused one still reports the recursive size, and a regular file is unchanged in both states.

One detail on that middle assertion. The test file is 9000 bytes rather than 4096 on purpose. With a 4096-byte file the directory's stat size and its recursive size are both 4096 on ext4, so the focused assertion would pass even against an implementation that never calls `DirSize`. I checked this by mutating the focused branch to return the stat size:

```
-8.79 KiB
+4.00 KiB
FAIL
```

With the real code it passes.

# Related Issues

Closes #1311.

# Screenshots (Optional)

None. The relevant before/after panel output is quoted above.

---

# ✅ Pre-Submission Checklist

- [x] I have run `go fmt ./...` to format the code (`gofmt -l` is clean; `go build ./...` and `go vet` are also clean)
- [x] I have run `golangci-lint run` and fixed any reported issues (`0 issues.`)
- [x] I have tested my changes and verified they work as expected (metadata package suite passes in full with exiftool installed, plus the mutation check quoted above)
- [x] I have reviewed the diff to make sure I'm not committing any debug logs or TODOs
- [x] I have checked that the PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

*Disclosure: written with AI assistance (Claude Code). I reproduced the issue, ran the change and the verification myself.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unfocused directory metadata now prompts users to calculate the directory’s recursive size.
  * Focused directories continue to display their recursive size.
* **Bug Fixes**
  * File size information remains available regardless of metadata focus state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->