### PR TITLE
feat: Added working directory sync

### DIFF
--- a/src/internal/ui/filemodel/navigation.go
+++ b/src/internal/ui/filemodel/navigation.go
@@ -1,6 +1,9 @@
 package filemodel
 
-import "log/slog"
+import (
+	"log/slog"
+	"os"
+)
 
 func (m *Model) NextFilePanel() {
 	m.MoveFocusedPanelBy(1)
@@ -18,4 +21,7 @@ func (m *Model) MoveFocusedPanelBy(delta int) {
 	m.GetFocusedFilePanel().IsFocused = false
 	m.FocusedPanelIndex = (m.FocusedPanelIndex + delta + m.PanelCount()) % m.PanelCount()
 	m.FilePanels[m.FocusedPanelIndex].IsFocused = true
+
+	// Updates working directory to properly pass cwd to newly spawned processes (terminals,editors, programs)
+	_ = os.Chdir(m.GetFocusedFilePanel().Location)
 }

--- a/src/internal/ui/filemodel/update.go
+++ b/src/internal/ui/filemodel/update.go
@@ -32,6 +32,9 @@ func (m *Model) CreateNewFilePanel(location string) (tea.Cmd, error) {
 	m.FilePanels[newPanelIndex].SetHeight(m.Height)
 	m.FocusedPanelIndex = newPanelIndex
 
+	// Updates working directory to properly pass cwd to newly spawned processes (terminals,editors, programs)
+	_ = os.Chdir(m.GetFocusedFilePanel().Location)
+
 	m.updateChildComponentWidth()
 	return m.ensurePreviewDimensionsSync(), nil
 }
@@ -48,6 +51,10 @@ func (m *Model) CloseFilePanel() (tea.Cmd, error) {
 		m.FocusedPanelIndex--
 	}
 	m.FilePanels[m.FocusedPanelIndex].IsFocused = true
+
+	// Updates working directory to properly pass cwd to newly spawned processes (terminals,editors, programs)
+	_ = os.Chdir(m.GetFocusedFilePanel().Location)
+
 	m.updateChildComponentWidth()
 
 	return m.ensurePreviewDimensionsSync(), nil

--- a/src/internal/ui/filepanel/update.go
+++ b/src/internal/ui/filepanel/update.go
@@ -45,6 +45,9 @@ func (m *Model) UpdateCurrentFilePanelDir(path string) error {
 		return fmt.Errorf("%s is not a directory", path)
 	}
 
+	// Updates working directory to properly pass cwd to newly spawned processes (terminals,editors, programs)
+	_ = os.Chdir(path)
+
 	// In case of switching to parent, explicitly set focus.
 	// This is to handle when there isn't a DirectoryRecord, yet.
 	if filepath.Dir(m.Location) == path {
@@ -52,7 +55,6 @@ func (m *Model) UpdateCurrentFilePanelDir(path string) error {
 	}
 	// Switch to "path"
 	m.Location = path
-
 	// NOTE: We are fetching the cursor and render from cache, but this could become invalid
 	// in case user deletes some items in the directory via another file manager and then switch back
 	// Basically this directoryRecords cache can be invalid. On each Update(), on dire change


### PR DESCRIPTION
- Added working directory updates for the Superfile process
- Switching directory in file panel updates CWD as well as switching active file panels
- This fixes file editors like helix not being able to correctly resolve other files for LSP and newly spawned instances of terminals opening in wrong directory

Note: This fix attempt of previous PR https://github.com/yorukot/superfile/pull/1460, which went out of sync with upstream/main.

This time the it should be good:
<img width="915" height="69" alt="image" src="https://github.com/user-attachments/assets/dc4f3303-bf80-46e7-8c54-749bc6bc6ec8" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * The process working directory now stays synchronized with the currently focused file panel.
  * Navigating between panels, creating or closing panels, and changing directories automatically updates the working directory.
  * Directory navigation continues to preserve existing focus, cursor, rendering, and search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->