### PR TITLE
docs(installation): add Debian install via the pkg.haus APT archive

### DIFF
--- a/website/src/content/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/getting-started/installation.mdx
@@ -96,6 +96,16 @@ sudo pacman -S superfile
 yay -S superfile-git
 ```
 
+### Debian
+
+superfile is available from the [pkg.haus](https://pkg.haus) APT archive for Debian stable, testing and unstable (amd64 and arm64), built from source at release tags. Set up the archive per the instructions on [pkg.haus](https://pkg.haus), then run:
+
+```bash
+sudo apt install superfile
+```
+
+The binary installs as `spf`.
+
 ### Homebrew
 
 Install [Homebrew](https://brew.sh/) and then run the following command:


### PR DESCRIPTION
[pkg.haus](https://pkg.haus) is a signed APT archive carrying superfile for Debian stable, testing and unstable (amd64/arm64), built from source at upstream release tags. This adds a Debian section to the installation docs and notes the binary installs as `spf`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Debian installation instructions using the pkg.haus APT archive.
  * Clarified that the installed executable is named `spf`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->