### PR TITLE
fix(file-preview): skip thumbnail generation when show_image_preview is disabled

### DIFF
--- a/src/internal/ui/preview/render.go
+++ b/src/internal/ui/preview/render.go
@@ -202,6 +202,12 @@ func (m *Model) RenderWithPath(
 	}
 
 	if m.thumbnailGenerator != nil && m.thumbnailGenerator.SupportsExt(ext) {
+		// Guard before the expensive thumbnail-generation subprocess: if the user
+		// has disabled image preview, skip thumbnail generation entirely so that
+		// ffmpeg (or any other generator) is never spawned.
+		if !common.Config.ShowImagePreview {
+			return r.AddLines(common.FilePreviewImagePreviewDisabledText).Render(), kittyClear
+		}
 		thumbnailPath, err := m.thumbnailGenerator.GetThumbnailOrGenerate(itemPath)
 		if err != nil {
 			slog.Error("Error generating thumbnail", "error", err)


### PR DESCRIPTION
### Problem

When `show_image_preview = false` is set in the config, superfile still spawned the ffmpeg subprocess to generate video thumbnails before ever checking the setting.

The flow was:
1. `RenderWithPath` detects a supported thumbnail extension
2. Calls `GetThumbnailOrGenerate` — **ffmpeg runs here**
3. Passes the thumbnail path to `renderImagePreview`
4. `renderImagePreview` checks `common.Config.ShowImagePreview`, sees it's false, returns "Image preview is disabled"

So the expensive process ran despite the user explicitly disabling previews.

### Fix

Add a `ShowImagePreview` guard in `RenderWithPath` **before** calling `GetThumbnailOrGenerate`, so the thumbnail generator is never invoked when image preview is off. This is consistent with how `renderImagePreview` already handles the direct image path (the `isImageFile` branch), where the check happens inside `renderImagePreview` before doing any work.

### Changed file

`src/internal/ui/preview/render.go` — 4 lines added in the thumbnail branch of `RenderWithPath`.

Fixes #1620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image thumbnails are no longer generated when image previews are disabled.
  * Displays the appropriate disabled-preview message instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->