### PR TITLE
[Build] Specify Go version to fix build issues on darwin/arm64

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
             pname = "superfile";
             version = "1.6.0";
             src = ./.;
+            go = pkgs.go_1_26;
             modules = ./gomod2nix.toml;
 
             # Temporary workaround: zoxide-related tests fail in the Nix sandbox.


### PR DESCRIPTION
This PR fixes the build issue identified in issue #1634.

It specifies the version of Go to use in the flake so that the build can complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package build configuration to use Go 1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->