### PR TITLE
fix(theme): update 0x96f theme author

### DIFF
--- a/src/superfile_config/theme/0x96f.toml
+++ b/src/superfile_config/theme/0x96f.toml
@@ -4,7 +4,7 @@
 #                                            #
 ##############################################
 
-# This theme was created by: https://github.com/filipjanevski ! Thank you <3
+# This theme was created by: https://github.com/0x96f ! Thank you <3
 
 # This contains the theme config file for superfile! For more details see:
 # https://superfile.dev/configure/custom-theme/

--- a/website/src/content/docs/list/theme-list.md
+++ b/website/src/content/docs/list/theme-list.md
@@ -11,8 +11,8 @@ head:
 ## 0x96f
 
 - Theme name: `0x96f`
-- Ported by: https://github.com/filipjanevski
-- Original Author: https://github.com/filipjanevski/
+- Ported by: https://github.com/0x96f
+- Original Author: https://github.com/0x96f/
 
 ![0x96f theme preview showing dark color scheme with blue accents](../../../assets/theme/0x96f.png)
 

--- a/website/src/content/docs/zh-tw/list/theme-list.md
+++ b/website/src/content/docs/zh-tw/list/theme-list.md
@@ -11,8 +11,8 @@ head:
 ## 0x96f
 
 - 主題名稱：`0x96f`
-- 移植者：https://github.com/filipjanevski
-- 原作者：https://github.com/filipjanevski/
+- 移植者：https://github.com/0x96f
+- 原作者：https://github.com/0x96f/
 
 ![0x96f 主題預覽，顯示帶有藍色點綴的深色配色](../../../../assets/theme/0x96f.png)
 


### PR DESCRIPTION
Updating the 0x96f author since I changed my username

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected attribution details for the `0x96f` theme in the English and Traditional Chinese theme lists.
  * Updated the theme’s attribution comment to consistently credit `0x96f`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->