### PR TITLE
feat: Add support for new FreeBSD flag NO_UCACHE

### DIFF
--- a/src/internal/ui/metadata/metadata_freebsd.go
+++ b/src/internal/ui/metadata/metadata_freebsd.go
@@ -20,6 +20,7 @@ const (
 	UF_REPARSE   = 0x00000400
 	UF_ARCHIVE   = 0x00000800
 	UF_READONLY  = 0x00001000
+	UF_NOCACHE   = 0x00002000
 	UF_HIDDEN    = 0x00008000
 
 	SF_ARCHIVED  = 0x00010000
@@ -53,6 +54,7 @@ var mapping = []struct {
 	{UF_REPARSE, "reparse"},
 	{UF_SPARSE, "sparse"},
 	{UF_SYSTEM, "system"},
+	{UF_NOCACHE, "nocache"},
 }
 
 func getFileAttributes(path string) (string, bool) {


### PR DESCRIPTION
This flag implements the NFSv4.2 non-caching semantics. See https://reviews.freebsd.org/D58181,
https://github.com/freebsd/freebsd-src/commit/290e563166b453413e1bf976b0819c301d559cad.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing the FreeBSD `nocache` file flag in metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->