### PR TITLE
feat(docs): add cd_on_quit instructions for xonsh

### DIFF
--- a/cd_on_quit/cd_on_quit.xsh
+++ b/cd_on_quit/cd_on_quit.xsh
@@ -4,14 +4,14 @@
 def _spf(args, stdin=None, stdout=None, stderr=None):
     import os
     import shlex
+    import platform
     import subprocess
     from pathlib import Path
 
-    os_name = $(uname -s)
-    if os_name == "Linux":
-        spf_last_dir = Path(f'{$HOME}/.local/state/superfile/lastdir')
-    else:
+    if platform.system() == 'Darwin':
         spf_last_dir = Path(f'{$HOME}/Library/Application Support/superfile/lastdir')
+    else:
+        spf_last_dir = Path(f'{$HOME}/.local/state/superfile/lastdir')
 
     status_code = subprocess.call(
         ('spf',) + tuple(args), # 'superfile' on nixos

--- a/cd_on_quit/cd_on_quit.xsh
+++ b/cd_on_quit/cd_on_quit.xsh
@@ -5,13 +5,19 @@ from pathlib import Path
 @aliases.uncapturable
 @aliases.unthreadable
 def _spf(args, stdin=None, stdout=None, stderr=None):
-    spf_last_dir = Path(f'{$HOME}/.local/state/superfile/lastdir')
+    os = $(uname -s)
+    if os == "Linux":
+        spf_last_dir = Path(f'{$HOME}/.local/state/superfile/lastdir')
+    else:
+        spf_last_dir = Path(f'{$HOME}/Library/Application Support/superfile/lastdir')
+
     status_code = subprocess.call(
         ('spf',) + tuple(args), # 'superfile' on nixos
         stdin=stdin,
         stderr=stderr,
         stdout=stdout,
     )
+
     if status_code == 0 and spf_last_dir.is_file():
         with spf_last_dir.open() as f:
             content = f.read()

--- a/cd_on_quit/cd_on_quit.xsh
+++ b/cd_on_quit/cd_on_quit.xsh
@@ -10,6 +10,8 @@ def _spf(args, stdin=None, stdout=None, stderr=None):
 
     if platform.system() == 'Darwin':
         spf_last_dir = Path(f'{$HOME}/Library/Application Support/superfile/lastdir')
+    elif 'XDG_STATE_HOME' in @.env:
+        spf_last_dir = Path(f'{$XDG_STATE_HOME}/superfile/lastdir')
     else:
         spf_last_dir = Path(f'{$HOME}/.local/state/superfile/lastdir')
 

--- a/cd_on_quit/cd_on_quit.xsh
+++ b/cd_on_quit/cd_on_quit.xsh
@@ -1,0 +1,23 @@
+import subprocess
+from pathlib import Path
+
+@aliases.register('spf')
+@aliases.uncapturable
+@aliases.unthreadable
+def _spf(args, stdin=None, stdout=None, stderr=None):
+    spf_last_dir = Path(f'{$HOME}/.local/state/superfile/lastdir')
+    status_code = subprocess.call(
+        ('spf',) + tuple(args), # 'superfile' on nixos
+        stdin=stdin,
+        stderr=stderr,
+        stdout=stdout,
+    )
+    if status_code == 0 and spf_last_dir.is_file():
+        with spf_last_dir.open() as f:
+            content = f.read()
+            if content:
+                evalx(content)
+        spf_last_dir.unlink()
+
+    return status_code
+

--- a/cd_on_quit/cd_on_quit.xsh
+++ b/cd_on_quit/cd_on_quit.xsh
@@ -2,10 +2,7 @@
 @aliases.uncapturable
 @aliases.unthreadable
 def _spf(args, stdin=None, stdout=None, stderr=None):
-    import os
-    import shlex
-    import platform
-    import subprocess
+    import os, shlex, platform, subprocess
     from pathlib import Path
 
     if platform.system() == 'Darwin':

--- a/cd_on_quit/cd_on_quit.xsh
+++ b/cd_on_quit/cd_on_quit.xsh
@@ -1,12 +1,14 @@
-import subprocess
-from pathlib import Path
-
 @aliases.register('spf')
 @aliases.uncapturable
 @aliases.unthreadable
 def _spf(args, stdin=None, stdout=None, stderr=None):
-    os = $(uname -s)
-    if os == "Linux":
+    import os
+    import shlex
+    import subprocess
+    from pathlib import Path
+
+    os_name = $(uname -s)
+    if os_name == "Linux":
         spf_last_dir = Path(f'{$HOME}/.local/state/superfile/lastdir')
     else:
         spf_last_dir = Path(f'{$HOME}/Library/Application Support/superfile/lastdir')
@@ -22,7 +24,8 @@ def _spf(args, stdin=None, stdout=None, stderr=None):
         with spf_last_dir.open() as f:
             content = f.read()
             if content:
-                evalx(content)
+                _, path = shlex.split(content)
+                os.chdir(path)
         spf_last_dir.unlink()
 
     return status_code

--- a/website/src/content/docs/configure/superfile-config.mdx
+++ b/website/src/content/docs/configure/superfile-config.mdx
@@ -88,6 +88,26 @@ Save, exit, and reload `config.fish`:
 source ~/.config/fish/config.fish
 ```
 
+###### Xonsh
+
+Open the file:
+
+```bash
+$EDITOR ~/.xonshrc
+```
+
+Copy the following code into the file:
+
+<CodeBlock file="cd_on_quit/cd_on_quit.xsh" />
+
+Save, exit, and reload your `.xonshrc` file:
+
+```bash
+source ~/.xonshrc
+```
+
+Alternatively, you can use [xontrib-superfile](https://github.com/TechnoStrife/xontrib-superfile)
+
 ##### Windows (Powershell)
 
 Open the file:


### PR DESCRIPTION

* **New Features**
  * Added Xonsh shell support for changing to the last directory used in Superfile after quitting.
  * Added an example of `.xonshrc` configuration with `spf` command alias.

* **Documentation**
  * Added setup instructions for enabling Xonsh integration, including configuration reload steps and an alternative package option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Xonsh shell support for automatically changing to the last directory after exiting superfile.
  * Added an `spf` command alias while preserving standard input, output, and error handling.
  * The working directory now updates automatically when superfile exits successfully.

* **Documentation**
  * Added setup instructions for configuring Xonsh support, including reload steps and an alternative package option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->