### PR TITLE
feat: show directory item count in the size column

### DIFF
--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -2,6 +2,7 @@ package filepanel
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -56,7 +57,9 @@ func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 	isSelected := m.CheckSelected(elem.Location)
 	sizeValue := common.FormatFileSize(elem.Info.Size())
 	if elem.Info.IsDir() {
-		sizeValue = ""
+		// TODO: If dotfiles are being shown, include them in the count.
+		// GetChildCount already works with dotfiles.
+		sizeValue = strconv.Itoa(elem.GetChildCount(false)) + " items"
 	}
 	return common.FilePanelItemRender(
 		sizeValue,

--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -58,11 +58,12 @@ func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 	sizeValue := common.FormatFileSize(elem.Info.Size())
 	if elem.Directory {
 		itemLabel := " items"
-		if elem.ChildCountErr != nil {
+		switch {
+		case elem.ChildCountErr != nil:
 			sizeValue = "(Error)"
-		} else if elem.ChildCount == -1 {
+		case elem.ChildCount == -1:
 			sizeValue = ">" + strconv.Itoa(dirMaxChildrenToCount) + itemLabel
-		} else {
+		default:
 			if elem.ChildCount == 1 {
 				itemLabel = " item"
 			}

--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -57,10 +57,12 @@ func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 	isSelected := m.CheckSelected(elem.Location)
 	sizeValue := common.FormatFileSize(elem.Info.Size())
 	if elem.Directory {
+		itemLabel := " items"
 		if elem.ChildCountErr != nil {
 			sizeValue = "(Error)"
+		} else if elem.ChildCount == -1 {
+			sizeValue = ">" + strconv.Itoa(dirMaxChildrenToCount) + itemLabel
 		} else {
-			itemLabel := " items"
 			if elem.ChildCount == 1 {
 				itemLabel = " item"
 			}

--- a/src/internal/ui/filepanel/columns.go
+++ b/src/internal/ui/filepanel/columns.go
@@ -56,10 +56,16 @@ func (m *Model) renderFileSize(indexElement int, columnWidth int) string {
 	elem := m.GetElementAtIdx(indexElement)
 	isSelected := m.CheckSelected(elem.Location)
 	sizeValue := common.FormatFileSize(elem.Info.Size())
-	if elem.Info.IsDir() {
-		// TODO: If dotfiles are being shown, include them in the count.
-		// GetChildCount already works with dotfiles.
-		sizeValue = strconv.Itoa(elem.GetChildCount(false)) + " items"
+	if elem.Directory {
+		if elem.ChildCountErr != nil {
+			sizeValue = "(Error)"
+		} else {
+			itemLabel := " items"
+			if elem.ChildCount == 1 {
+				itemLabel = " item"
+			}
+			sizeValue = strconv.Itoa(elem.ChildCount) + itemLabel
+		}
 	}
 	return common.FilePanelItemRender(
 		sizeValue,

--- a/src/internal/ui/filepanel/consts.go
+++ b/src/internal/ui/filepanel/consts.go
@@ -24,4 +24,6 @@ const (
 	nonFocussedPanelReRenderTime = 3 * time.Second
 
 	emptyCursor = " "
+
+	dirMaxChildrenToCount = 1000
 )

--- a/src/internal/ui/filepanel/get_elements.go
+++ b/src/internal/ui/filepanel/get_elements.go
@@ -31,7 +31,7 @@ func (m *Model) getDirectoryElements(displayDotFile bool) []Element {
 	if len(dirEntries) == 0 {
 		return nil
 	}
-	return sortFileElement(m.SortKind, m.SortReversed, dirEntries, m.Location)
+	return m.sortFileElements(dirEntries, displayDotFile)
 }
 
 // getDirectoryElementsBySearch returns filtered directory elements based on search string
@@ -70,7 +70,7 @@ func (m *Model) getDirectoryElementsBySearch(displayDotFile bool) []Element {
 		dirElements = append(dirElements, resultItem)
 	}
 
-	return sortFileElement(m.SortKind, m.SortReversed, dirElements, m.Location)
+	return m.sortFileElements(dirElements, displayDotFile)
 }
 
 // Helper to decide whether to skip updating a panel this tick.

--- a/src/internal/ui/filepanel/sort.go
+++ b/src/internal/ui/filepanel/sort.go
@@ -64,19 +64,8 @@ func getSizeOrderingFunc(elements []Element, reversed bool) sliceOrderFunc {
 		}
 
 		// This needs to be improved, and we should sort by actual size only
-		// Repeated recursive read would be slow, so we could cache
 		if elements[i].Directory && elements[j].Directory {
-			filesI, err := os.ReadDir(elements[i].Location)
-			// No need of early return, we only call len() on filesI, so nil would
-			// just result in 0
-			if err != nil {
-				slog.Error("Error when reading directory during sort", "error", err)
-			}
-			filesJ, err := os.ReadDir(elements[j].Location)
-			if err != nil {
-				slog.Error("Error when reading directory during sort", "error", err)
-			}
-			return len(filesI) < len(filesJ) != reversed
+			return elements[i].ChildCount < elements[j].ChildCount != reversed
 		}
 		return elements[i].Info.Size() < elements[j].Info.Size() != reversed
 	}
@@ -110,25 +99,33 @@ func getTypeOrderingFunc(elements []Element, reversed bool) sliceOrderFunc {
 	}
 }
 
-func sortFileElement(sortKind sortmodel.SortKind, reversed bool, dirEntries []os.DirEntry, location string) []Element {
+func (m *Model) sortFileElements(dirEntries []os.DirEntry, includeDotFiles bool) []Element {
 	elements := make([]Element, 0, len(dirEntries))
 	for _, item := range dirEntries {
 		info, err := item.Info()
 		if err != nil {
 			slog.Error("Error while retrieving file info during sort",
-				"error", err, "path", filepath.Join(location, item.Name()))
+				"error", err, "path", filepath.Join(m.Location, item.Name()))
 			continue
 		}
 
-		elements = append(elements, Element{
+		element := Element{
 			Name:      item.Name(),
-			Directory: item.IsDir() || isSymlinkToDir(location, info, item.Name()),
-			Location:  filepath.Join(location, item.Name()),
+			Directory: item.IsDir() || isSymlinkToDir(m.Location, info, item.Name()),
+			Location:  filepath.Join(m.Location, item.Name()),
 			Info:      info,
-		})
+		}
+		if element.Directory {
+			element.ChildCount, element.ChildCountErr = getChildCount(element.Location, includeDotFiles)
+			if element.ChildCountErr != nil {
+				slog.Error("Error when counting directory children",
+					"error", element.ChildCountErr, "path", element.Location)
+			}
+		}
+		elements = append(elements, element)
 	}
 
-	sort.Slice(elements, getOrderingFunc(elements, reversed, sortKind))
+	sort.Slice(elements, getOrderingFunc(elements, m.SortReversed, m.SortKind))
 
 	return elements
 }

--- a/src/internal/ui/filepanel/sort.go
+++ b/src/internal/ui/filepanel/sort.go
@@ -116,7 +116,11 @@ func (m *Model) sortFileElements(dirEntries []os.DirEntry, includeDotFiles bool)
 			Info:      info,
 		}
 		if element.Directory {
-			element.ChildCount, element.ChildCountErr = getChildCount(element.Location, includeDotFiles)
+			element.ChildCount, element.ChildCountErr = getChildCount(
+				element.Location,
+				includeDotFiles,
+				dirMaxChildrenToCount,
+			)
 			if element.ChildCountErr != nil {
 				slog.Error("Error when counting directory children",
 					"error", element.ChildCountErr, "path", element.Location)

--- a/src/internal/ui/filepanel/types.go
+++ b/src/internal/ui/filepanel/types.go
@@ -51,10 +51,12 @@ type directoryRecord struct {
 
 // Element within a file panel
 type Element struct {
-	Name      string
-	Location  string
-	Directory bool
-	Info      os.FileInfo
+	Name          string
+	Location      string
+	Directory     bool
+	Info          os.FileInfo
+	ChildCount    int
+	ChildCountErr error
 }
 
 // Type representing the mode of the panel

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -1,6 +1,10 @@
 package filepanel
 
-import "math"
+import (
+	"math"
+	"os"
+	"strings"
+)
 
 func (m *Model) GetCursor() int {
 	return m.cursor
@@ -163,4 +167,28 @@ func (m *Model) FindElementIndexByLocation(location string) int {
 		}
 	}
 	return -1
+}
+
+// Get the number of non-recursive files in the directory.
+// Only count dotfiles if includeDotFiles is true.
+// If the element is not a directory, return 0.
+func (e *Element) GetChildCount(includeDotFiles bool) int {
+	if e.Info == nil || !e.Info.IsDir() {
+		return 0
+	}
+
+	count := 0
+	entries, err := os.ReadDir(e.Location)
+	if err != nil {
+		return 0
+	}
+
+	for _, entry := range entries {
+		if !includeDotFiles && strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		count++
+	}
+
+	return count
 }

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -169,26 +169,29 @@ func (m *Model) FindElementIndexByLocation(location string) int {
 	return -1
 }
 
-// Get the number of non-recursive files in the directory.
-// Only count dotfiles if includeDotFiles is true.
-// If the element is not a directory, return 0.
-func (e *Element) GetChildCount(includeDotFiles bool) int {
-	if e.Info == nil || !e.Info.IsDir() {
-		return 0
+func getChildCount(location string, includeDotFiles bool) (int, error) {
+	directory, err := os.Open(location)
+	if err != nil {
+		return 0, err
 	}
+	defer directory.Close()
+
+	entryNames, err := directory.Readdirnames(-1)
+	if err != nil {
+		return 0, err
+	}
+	if includeDotFiles {
+		return len(entryNames), nil
+	}
+
 
 	count := 0
-	entries, err := os.ReadDir(e.Location)
-	if err != nil {
-		return 0
-	}
-
-	for _, entry := range entries {
-		if !includeDotFiles && strings.HasPrefix(entry.Name(), ".") {
+	for _, entryName := range entryNames {
+		if strings.HasPrefix(entryName, ".") {
 			continue
 		}
 		count++
 	}
 
-	return count
+	return count, nil
 }

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -184,7 +184,6 @@ func getChildCount(location string, includeDotFiles bool) (int, error) {
 		return len(entryNames), nil
 	}
 
-
 	count := 0
 	for _, entryName := range entryNames {
 		if strings.HasPrefix(entryName, ".") {

--- a/src/internal/ui/filepanel/utils.go
+++ b/src/internal/ui/filepanel/utils.go
@@ -1,6 +1,8 @@
 package filepanel
 
 import (
+	"errors"
+	"io"
 	"math"
 	"os"
 	"strings"
@@ -169,17 +171,29 @@ func (m *Model) FindElementIndexByLocation(location string) int {
 	return -1
 }
 
-func getChildCount(location string, includeDotFiles bool) (int, error) {
+func getChildCount(location string, includeDotFiles bool, maxCount int) (int, error) {
 	directory, err := os.Open(location)
 	if err != nil {
 		return 0, err
 	}
 	defer directory.Close()
 
-	entryNames, err := directory.Readdirnames(-1)
-	if err != nil {
+	// If maxCount <= 0, read all entries.
+	// Otherwise, read maxCount + 1 to check if there are more entries than maxCount.
+	toRead := maxCount
+	if maxCount > 0 {
+		toRead = maxCount + 1
+	}
+
+	entryNames, err := directory.Readdirnames(toRead)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return 0, err
 	}
+
+	if maxCount > 0 && len(entryNames) > maxCount {
+		return -1, nil
+	}
+
 	if includeDotFiles {
 		return len(entryNames), nil
 	}

--- a/src/internal/ui/filepanel/utils_test.go
+++ b/src/internal/ui/filepanel/utils_test.go
@@ -1,9 +1,12 @@
 package filepanel
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yorukot/superfile/src/internal/ui/sortmodel"
 )
@@ -65,6 +68,97 @@ func TestGetSelectedLocationsSortedAsVisible(t *testing.T) {
 			tt.panel.SortKind = sortmodel.SortByName
 			tt.panel.SetSelectedAll(tt.toSelect)
 			assert.Equal(t, tt.expectedSelected, tt.panel.GetSelectedLocationsSortedAsVisible())
+		})
+	}
+}
+
+func TestGetChildCount(t *testing.T) {
+	tests := []struct {
+		name            string
+		entries         []string
+		includeDotFiles bool
+		expectedCount   int
+		isDir           bool
+	}{
+		{
+			name:            "Empty dir",
+			entries:         []string{},
+			includeDotFiles: false,
+			expectedCount:   0,
+			isDir:           true,
+		},
+		{
+			name:            "Dir with 3 files",
+			entries:         []string{"file1.txt", "file2.txt", "file3.txt"},
+			includeDotFiles: false,
+			expectedCount:   3,
+			isDir:           true,
+		},
+		{
+			name:            "Dir with 2 non-dot files and 1 dot file, includeDotFiles false",
+			entries:         []string{"file1.txt", "file2.txt", ".file3.txt"},
+			includeDotFiles: false,
+			expectedCount:   2,
+			isDir:           true,
+		},
+		{
+			name:            "Dir with 2 non-dot files and 1 dot file, includeDotFiles true",
+			entries:         []string{"file1.txt", "file2.txt", ".file3.txt"},
+			includeDotFiles: true,
+			expectedCount:   3,
+			isDir:           true,
+		},
+		{
+			name:            "Dir with 3 dot files, includeDotFiles false",
+			entries:         []string{".file1.txt", ".file2.txt", ".file3.txt"},
+			includeDotFiles: false,
+			expectedCount:   0,
+			isDir:           true,
+		},
+		{
+			name:            "Dir with 3 dot files, includeDotFiles true",
+			entries:         []string{".file1.txt", ".file2.txt", ".file3.txt"},
+			includeDotFiles: true,
+			expectedCount:   3,
+			isDir:           true,
+		},
+		{
+			name:            "Non-dir returns 0",
+			entries:         []string{},
+			includeDotFiles: true,
+			expectedCount:   0,
+			isDir:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			for _, name := range tt.entries {
+				path := filepath.Join(dir, name)
+				require.NoError(t, os.WriteFile(path, []byte{}, 0644))
+			}
+
+			location := dir
+			if !tt.isDir {
+				location = filepath.Join(dir, "file.txt")
+				require.NoError(t, os.WriteFile(location, []byte{}, 0644))
+			}
+
+			info, err := os.Stat(location)
+			require.NoError(t, err)
+
+			element := Element{
+				Location: location,
+				Info:     info,
+			}
+
+			assert.Equal(
+				t,
+				tt.expectedCount,
+				element.GetChildCount(tt.includeDotFiles),
+			)
 		})
 	}
 }

--- a/src/internal/ui/filepanel/utils_test.go
+++ b/src/internal/ui/filepanel/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -128,7 +129,7 @@ func TestGetChildCount(t *testing.T) {
 			}
 			utils.SetupFiles(t, files...)
 
-			count, err := getChildCount(dir, tt.includeDotFiles)
+			count, err := getChildCount(dir, tt.includeDotFiles, -1)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedCount, count)
 		})
@@ -136,7 +137,7 @@ func TestGetChildCount(t *testing.T) {
 }
 
 func TestGetChildCountReturnsReadError(t *testing.T) {
-	count, err := getChildCount(filepath.Join(t.TempDir(), "missing"), true)
+	count, err := getChildCount(filepath.Join(t.TempDir(), "missing"), true, -1)
 
 	assert.Zero(t, count)
 	require.Error(t, err)
@@ -180,6 +181,55 @@ func TestDirectorySymlinkChildCount(t *testing.T) {
 	}
 }
 
+func TestGetChildCountWithMaxCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		entries       []string
+		maxCount      int
+		expectedCount int
+	}{
+		{
+			name:          "Fewer than maxCount",
+			entries:       []string{"file1.txt", "file2.txt"},
+			maxCount:      3,
+			expectedCount: 2,
+		},
+		{
+			name:          "Equal to maxCount",
+			entries:       []string{"file1.txt", "file2.txt", "file3.txt"},
+			maxCount:      3,
+			expectedCount: 3,
+		},
+		{
+			name:          "More than maxCount",
+			entries:       []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt"},
+			maxCount:      3,
+			expectedCount: -1,
+		},
+		{
+			name:          "-1 maxCount reads all",
+			entries:       []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt"},
+			maxCount:      -1,
+			expectedCount: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			files := make([]string, 0, len(tt.entries))
+			for _, name := range tt.entries {
+				files = append(files, filepath.Join(dir, name))
+			}
+			utils.SetupFiles(t, files...)
+
+			count, err := getChildCount(dir, false, tt.maxCount)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedCount, count)
+		})
+	}
+}
+
 func TestRenderFileSizeUsesPopulatedDirectoryCount(t *testing.T) {
 	dir := t.TempDir()
 	info, err := os.Stat(dir)
@@ -216,6 +266,15 @@ func TestRenderFileSizeUsesPopulatedDirectoryCount(t *testing.T) {
 				ChildCountErr: errors.New("read failed"),
 			},
 			expected: "(Error)",
+		},
+		{
+			name: "More than maxCount",
+			element: Element{
+				Directory:  true,
+				Info:       info,
+				ChildCount: -1,
+			},
+			expected: ">" + strconv.Itoa(dirMaxChildrenToCount) + " items",
 		},
 	}
 

--- a/src/internal/ui/filepanel/utils_test.go
+++ b/src/internal/ui/filepanel/utils_test.go
@@ -1,6 +1,7 @@
 package filepanel
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yorukot/superfile/src/internal/ui/sortmodel"
+	"github.com/yorukot/superfile/src/pkg/utils"
 )
 
 func TestGetSelectedLocationsSortedAsVisible(t *testing.T) {
@@ -78,87 +80,149 @@ func TestGetChildCount(t *testing.T) {
 		entries         []string
 		includeDotFiles bool
 		expectedCount   int
-		isDir           bool
 	}{
 		{
 			name:            "Empty dir",
 			entries:         []string{},
 			includeDotFiles: false,
 			expectedCount:   0,
-			isDir:           true,
 		},
 		{
 			name:            "Dir with 3 files",
 			entries:         []string{"file1.txt", "file2.txt", "file3.txt"},
 			includeDotFiles: false,
 			expectedCount:   3,
-			isDir:           true,
 		},
 		{
 			name:            "Dir with 2 non-dot files and 1 dot file, includeDotFiles false",
 			entries:         []string{"file1.txt", "file2.txt", ".file3.txt"},
 			includeDotFiles: false,
 			expectedCount:   2,
-			isDir:           true,
 		},
 		{
 			name:            "Dir with 2 non-dot files and 1 dot file, includeDotFiles true",
 			entries:         []string{"file1.txt", "file2.txt", ".file3.txt"},
 			includeDotFiles: true,
 			expectedCount:   3,
-			isDir:           true,
 		},
 		{
 			name:            "Dir with 3 dot files, includeDotFiles false",
 			entries:         []string{".file1.txt", ".file2.txt", ".file3.txt"},
 			includeDotFiles: false,
 			expectedCount:   0,
-			isDir:           true,
 		},
 		{
 			name:            "Dir with 3 dot files, includeDotFiles true",
 			entries:         []string{".file1.txt", ".file2.txt", ".file3.txt"},
 			includeDotFiles: true,
 			expectedCount:   3,
-			isDir:           true,
-		},
-		{
-			name:            "Non-dir returns 0",
-			entries:         []string{},
-			includeDotFiles: true,
-			expectedCount:   0,
-			isDir:           false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-
+			files := make([]string, 0, len(tt.entries))
 			for _, name := range tt.entries {
-				path := filepath.Join(dir, name)
-				require.NoError(t, os.WriteFile(path, []byte{}, 0644))
+				files = append(files, filepath.Join(dir, name))
 			}
+			utils.SetupFiles(t, files...)
 
-			location := dir
-			if !tt.isDir {
-				location = filepath.Join(dir, "file.txt")
-				require.NoError(t, os.WriteFile(location, []byte{}, 0644))
-			}
-
-			info, err := os.Stat(location)
+			count, err := getChildCount(dir, tt.includeDotFiles)
 			require.NoError(t, err)
+			assert.Equal(t, tt.expectedCount, count)
+		})
+	}
+}
 
-			element := Element{
-				Location: location,
-				Info:     info,
-			}
+func TestGetChildCountReturnsReadError(t *testing.T) {
+	count, err := getChildCount(filepath.Join(t.TempDir(), "missing"), true)
 
-			assert.Equal(
-				t,
-				tt.expectedCount,
-				element.GetChildCount(tt.includeDotFiles),
-			)
+	assert.Zero(t, count)
+	require.Error(t, err)
+}
+
+func TestDirectorySymlinkChildCount(t *testing.T) {
+	parent := t.TempDir()
+	target := t.TempDir()
+	utils.SetupFiles(t,
+		filepath.Join(target, "visible.txt"),
+		filepath.Join(target, ".hidden.txt"),
+	)
+
+	symlink := filepath.Join(parent, "directory-link")
+	if err := os.Symlink(target, symlink); err != nil {
+		t.Skipf("directory symlinks are unavailable: %v", err)
+	}
+	dirEntries, err := os.ReadDir(parent)
+	require.NoError(t, err)
+	require.Len(t, dirEntries, 1)
+
+	for _, tt := range []struct {
+		name            string
+		includeDotFiles bool
+		expectedCount   int
+	}{
+		{name: "Exclude dotfiles", includeDotFiles: false, expectedCount: 1},
+		{name: "Include dotfiles", includeDotFiles: true, expectedCount: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			panel := testModel(0, 0, 12, BrowserMode, nil)
+			panel.Location = parent
+			panel.SortKind = sortmodel.SortByName
+			elements := panel.sortFileElements(dirEntries, tt.includeDotFiles)
+			require.Len(t, elements, 1)
+			assert.True(t, elements[0].Directory)
+			assert.False(t, elements[0].Info.IsDir())
+			assert.Equal(t, tt.expectedCount, elements[0].ChildCount)
+			assert.NoError(t, elements[0].ChildCountErr)
+		})
+	}
+}
+
+func TestRenderFileSizeUsesPopulatedDirectoryCount(t *testing.T) {
+	dir := t.TempDir()
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		element  Element
+		expected string
+	}{
+		{
+			name: "Singular count",
+			element: Element{
+				Directory:  true,
+				Info:       info,
+				ChildCount: 1,
+			},
+			expected: "1 item",
+		},
+		{
+			name: "Plural count",
+			element: Element{
+				Directory:  true,
+				Info:       info,
+				ChildCount: 2,
+			},
+			expected: "2 items",
+		},
+		{
+			name: "Read error",
+			element: Element{
+				Directory:     true,
+				Info:          info,
+				ChildCountErr: errors.New("read failed"),
+			},
+			expected: "(Error)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			panel := testModel(0, 0, 12, BrowserMode, []Element{tt.element})
+			assert.Contains(t, panel.renderFileSize(0, FileSizeColumnWidth), tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
Before:
<img width="301" height="407" alt="image" src="https://github.com/user-attachments/assets/1d6ffbc2-fc5d-4348-8945-7b12b57b3a32" />

After:
<img width="305" height="397" alt="image" src="https://github.com/user-attachments/assets/0ef89cbd-2cf4-477a-be05-dc36e99ce2ed" />

The count does not include dot files. I wanted it to include them if they are being shown but it is just as a TODO because `filepanel.Model` no longer exposes the state of the toggle. If it were instead to be passed as a param to `renderFileSize`, `makeColumns` and all the other columns would also need to change. `Element.GetChildCount` does, however, support a dotfiles toggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory size information now displays the number of items, with singular or plural labels as appropriate.
  * Counts reflect the current hidden-file display setting.
  * Large directories show a “>” indicator when the exact item count exceeds the display limit.

* **Bug Fixes**
  * Empty directory size values are replaced with item counts.
  * Unreadable directories display “(Error),” while symbolic-link directory counts remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->