### PR TITLE
fix: clear Kitty graphics before opening overlays to prevent z-index obstruction

### DIFF
--- a/src/internal/key_function.go
+++ b/src/internal/key_function.go
@@ -141,10 +141,22 @@ func (m *model) mainKey(msg string) tea.Cmd { //nolint: gocyclo,cyclop,funlen,go
 		return m.zoxideModal.Open()
 
 	case slices.Contains(common.Hotkeys.OpenHelpMenu, msg):
+		// Clear Kitty graphics images before opening help menu to prevent
+		// z-index obstruction (image preview shows through help menu overlay)
+		helpMenuClearCmd := m.fileModel.FilePreview.ClearKittyImages()
 		m.helpMenu.Open()
+		if helpMenuClearCmd != nil {
+			return helpMenuClearCmd
+		}
 
 	case slices.Contains(common.Hotkeys.OpenSortOptionsMenu, msg):
+		// Clear Kitty graphics images before opening sort menu to prevent
+		// z-index obstruction (image preview shows through overlay)
+		sortClearCmd := m.fileModel.FilePreview.ClearKittyImages()
 		m.sortModal.Open(m.getFocusedFilePanel().SortKind)
+		if sortClearCmd != nil {
+			return sortClearCmd
+		}
 
 	case slices.Contains(common.Hotkeys.ToggleReverseSort, msg):
 		m.getFocusedFilePanel().ToggleReverseSort()

--- a/src/internal/ui/preview/model_utils.go
+++ b/src/internal/ui/preview/model_utils.go
@@ -1,6 +1,10 @@
 package preview
 
-import "log/slog"
+import (
+	"log/slog"
+
+	tea "charm.land/bubbletea/v2"
+)
 
 func (m *Model) GetContent() string {
 	return m.content
@@ -59,6 +63,17 @@ func (m *Model) CleanUp() {
 			slog.Error("Error While cleaning up TempDirectory", "error", err)
 		}
 	}
+}
+
+// ClearKittyImages returns a tea.Cmd that clears any Kitty graphics images
+// currently displayed in the terminal. This should be called before opening
+// overlays (like the help menu) to prevent image previews from showing through.
+func (m *Model) ClearKittyImages() tea.Cmd {
+	raw := m.imagePreviewer.GetKittyClearRaw()
+	if raw == "" {
+		return nil
+	}
+	return tea.Raw([]byte(raw))
 }
 
 func (m *Model) IsOpen() bool {


### PR DESCRIPTION
## Summary

When an image preview is open in the Kitty graphics protocol, opening the help menu or sort menu overlay would show the image preview through the overlay, making it difficult to read the menu content.

This fix clears Kitty graphics images before opening overlays, ensuring clean overlay rendering.

## Changes

- Added `ClearKittyImages()` method to `preview.Model` that returns a `tea.Cmd` to clear Kitty graphics
- Modified `mainKey()` to clear Kitty images before opening help menu and sort menu overlays

## Testing

- Verified the fix compiles correctly
- The `ClearKittyImages()` method reuses the existing `GetKittyClearRaw()` function that was already used elsewhere in the codebase for clearing Kitty images

## Related Issue

Fixes #1428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preview images are now cleared when opening the Help menu or Sort options.
  - Prevents file preview graphics from remaining visible behind these overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->