### PR TITLE
fix(utils): only expand tilde when followed by a path separator or alone

### DIFF
--- a/src/pkg/utils/file_utils.go
+++ b/src/pkg/utils/file_utils.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 
 	"github.com/adrg/xdg"
@@ -203,10 +204,10 @@ func ResolveAbsPath(currentDir string, path string) string {
 	if !filepath.IsAbs(currentDir) {
 		slog.Warn("currentDir is not absolute", "currentDir", currentDir)
 	}
-	if strings.HasPrefix(path, "~") {
-		// We dont use variable.HomeDir here, as the util package cannot have dependency
-		// on variable package
-		path = strings.Replace(path, "~", xdg.Home, 1)
+	if path == "~" {
+		path = xdg.Home
+	} else if strings.HasPrefix(path, "~/") || (runtime.GOOS == OsWindows && strings.HasPrefix(path, `~\`)) {
+		path = filepath.Join(xdg.Home, path[2:])
 	}
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(currentDir, path)

--- a/src/pkg/utils/file_utils_test.go
+++ b/src/pkg/utils/file_utils_test.go
@@ -67,6 +67,57 @@ func TestResolveAbsPath(t *testing.T) {
 			path:        filepath.Join(dir2, "~"),
 			expectedRes: filepath.Join(dir1, dir2, "~"),
 		},
+		{
+			name:        "Relative path starting with ~ followed by word",
+			cwd:         filepath.Join(root, dir1),
+			path:        "~backup",
+			expectedRes: filepath.Join(root, dir1, "~backup"),
+		},
+		{
+			name:        "Relative path starting with ~$ (office lock file)",
+			cwd:         filepath.Join(root, dir1),
+			path:        "~$document.docx",
+			expectedRes: filepath.Join(root, dir1, "~$document.docx"),
+		},
+		{
+			name:        "Path starting with ~/",
+			cwd:         filepath.Join(root, dir1),
+			path:        "~/documents",
+			expectedRes: filepath.Join(xdg.Home, "documents"),
+		},
+		{
+			name:        "Just ~/",
+			cwd:         filepath.Join(root, dir1),
+			path:        "~/",
+			expectedRes: xdg.Home,
+		},
+	}
+
+	if runtime.GOOS == "windows" {
+		testdata = append(testdata,
+			struct {
+				name        string
+				cwd         string
+				path        string
+				expectedRes string
+			}{
+				name:        "Path starting with ~\\ on Windows",
+				cwd:         filepath.Join(root, dir1),
+				path:        `~\documents`,
+				expectedRes: filepath.Join(xdg.Home, "documents"),
+			},
+			struct {
+				name        string
+				cwd         string
+				path        string
+				expectedRes string
+			}{
+				name:        "Just ~\\ on Windows",
+				cwd:         filepath.Join(root, dir1),
+				path:        `~\`,
+				expectedRes: xdg.Home,
+			},
+		)
 	}
 
 	for _, tt := range testdata {


### PR DESCRIPTION
## Description

`ResolveAbsPath` previously expanded any path starting with `~` by replacing the tilde with `xdg.Home`. This broke relative files or folders whose names start with a tilde (such as `~backup`, `~temp`, or office lock files like `~$document.docx`), turning them into bogus paths like `/home/userbackup` or `C:\Users\userbackup`.

This change restricts tilde expansion to:
- `~`
- Paths starting with `~/`
- Paths starting with `~\` (on Windows)

All other paths starting with `~` are preserved as relative paths and resolved against `currentDir`.

Fixes #1651

## Verification

- `go test ./src/pkg/utils -run TestResolveAbsPath -v` (all 12 subtests pass)
- `go test ./src/pkg/utils -v`
- `go vet ./src/pkg/utils`
- `go test ./src/internal/...`
- `go build ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of home-directory paths beginning with `~`.
  * Prevented filenames such as `~backup` and `~$document.docx` from being incorrectly interpreted as home-directory paths.
  * Added consistent support for slash- and backslash-based home-directory paths across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->