### PR TITLE
feat: write all selected files in --chooser-file mode

### DIFF
--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -463,6 +463,8 @@ func checkFileReadable(filename string) error {
 	return nil
 }
 
+// getSelectedOrFocusedPaths returns the newline-separated locations of all selected items in the panel,
+// or the focused item's location if no items are selected.
 func (m *model) getSelectedOrFocusedPaths(panel *filepanel.Model) string {
 	if panel.SelectedCount() > 0 {
 		return strings.Join(panel.GetSelectedLocationsSortedAsVisible(), "\n")
@@ -470,6 +472,7 @@ func (m *model) getSelectedOrFocusedPaths(panel *filepanel.Model) string {
 	return panel.GetFocusedItem().Location
 }
 
+// chooserFileWriteAndQuit writes the given path string to variable.ChooserFile and initiates quitting the model.
 func (m *model) chooserFileWriteAndQuit(path string) error {
 	// Attempt to write to the file
 	err := os.WriteFile(variable.ChooserFile, []byte(path), utils.ConfigFilePerm)
@@ -480,7 +483,8 @@ func (m *model) chooserFileWriteAndQuit(path string) error {
 	return nil
 }
 
-// Open file with default editor
+// openFileWithEditor opens the selected or focused file with the default editor, or writes
+// paths to the chooser file and exits if --chooser-file mode is enabled.
 func (m *model) openFileWithEditor() tea.Cmd {
 	panel := m.getFocusedFilePanel()
 	// Check if panel is empty
@@ -574,6 +578,7 @@ func (m *model) copyPath() {
 	}
 }
 
+// copyPathText returns the path text to copy, containing all selected paths or the focused path.
 func (m *model) copyPathText() string {
 	panel := m.getFocusedFilePanel()
 

--- a/src/internal/handle_file_operations.go
+++ b/src/internal/handle_file_operations.go
@@ -463,6 +463,13 @@ func checkFileReadable(filename string) error {
 	return nil
 }
 
+func (m *model) getSelectedOrFocusedPaths(panel *filepanel.Model) string {
+	if panel.SelectedCount() > 0 {
+		return strings.Join(panel.GetSelectedLocationsSortedAsVisible(), "\n")
+	}
+	return panel.GetFocusedItem().Location
+}
+
 func (m *model) chooserFileWriteAndQuit(path string) error {
 	// Attempt to write to the file
 	err := os.WriteFile(variable.ChooserFile, []byte(path), utils.ConfigFilePerm)
@@ -482,7 +489,7 @@ func (m *model) openFileWithEditor() tea.Cmd {
 	}
 
 	if variable.ChooserFile != "" {
-		err := m.chooserFileWriteAndQuit(panel.GetFocusedItem().Location)
+		err := m.chooserFileWriteAndQuit(m.getSelectedOrFocusedPaths(panel))
 		if err == nil {
 			return nil
 		}
@@ -574,11 +581,7 @@ func (m *model) copyPathText() string {
 		return ""
 	}
 
-	if panel.PanelMode == filepanel.SelectMode && panel.SelectedCount() > 0 {
-		return strings.Join(panel.GetSelectedLocationsSortedAsVisible(), "\n")
-	}
-
-	return panel.GetFocusedItem().Location
+	return m.getSelectedOrFocusedPaths(panel)
 }
 
 // TODO: This is also an IO operations, do it via tea.Cmd

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -24,8 +24,8 @@ func (m *model) parentDirectory() {
 	}
 }
 
-// Enter directory or open file with default application
-// TODO: Unit test this
+// enterPanel enters a directory, opens a file with default application, or writes
+// selected/focused paths to the chooser file and exits if --chooser-file mode is enabled.
 func (m *model) enterPanel() {
 	panel := m.getFocusedFilePanel()
 

--- a/src/internal/handle_panel_movement.go
+++ b/src/internal/handle_panel_movement.go
@@ -57,7 +57,7 @@ func (m *model) enterPanel() {
 	}
 
 	if variable.ChooserFile != "" {
-		chooserErr := m.chooserFileWriteAndQuit(panel.GetFocusedItem().Location)
+		chooserErr := m.chooserFileWriteAndQuit(m.getSelectedOrFocusedPaths(panel))
 		if chooserErr == nil {
 			return
 		}

--- a/src/internal/model_test.go
+++ b/src/internal/model_test.go
@@ -218,14 +218,17 @@ func TestChooserFile(t *testing.T) {
 	dir1 := filepath.Join(curTestDir, "dir1")
 	dir2 := filepath.Join(curTestDir, "dir2")
 	file1 := filepath.Join(dir1, "file1.txt")
+	file2 := filepath.Join(dir1, "file2.txt")
 	testChooserFile := filepath.Join(dir2, "chooser_file.txt")
 	utils.SetupDirectories(t, curTestDir, dir1, dir2)
-	utils.SetupFiles(t, file1)
+	utils.SetupFiles(t, file1, file2)
 
 	testdata := []struct {
 		name            string
 		chooserFile     string
 		hotkey          string
+		selectMode      bool
+		selectedFiles   []string
 		expectedQuit    bool
 		expectedContent string
 	}{
@@ -240,6 +243,23 @@ func TestChooserFile(t *testing.T) {
 			name:            "Open with file editor with valid chooser file",
 			chooserFile:     testChooserFile,
 			hotkey:          common.Hotkeys.OpenFileWithEditor[0],
+			expectedQuit:    true,
+			expectedContent: file1,
+		},
+		{
+			name:            "Open with file editor with multiple selected files",
+			chooserFile:     testChooserFile,
+			hotkey:          common.Hotkeys.OpenFileWithEditor[0],
+			selectMode:      true,
+			selectedFiles:   []string{file1, file2},
+			expectedQuit:    true,
+			expectedContent: file1 + "\n" + file2,
+		},
+		{
+			name:            "Open with file editor in select mode with no selection falls back to focused item",
+			chooserFile:     testChooserFile,
+			hotkey:          common.Hotkeys.OpenFileWithEditor[0],
+			selectMode:      true,
 			expectedQuit:    true,
 			expectedContent: file1,
 		},
@@ -270,6 +290,12 @@ func TestChooserFile(t *testing.T) {
 	for _, tt := range testdata {
 		t.Run(tt.name, func(t *testing.T) {
 			m := defaultTestModel(dir1)
+			if tt.selectMode {
+				m.getFocusedFilePanel().ChangeFilePanelMode()
+			}
+			if len(tt.selectedFiles) > 0 {
+				m.getFocusedFilePanel().SetSelectedAll(tt.selectedFiles)
+			}
 			if tt.expectedQuit {
 				err := os.WriteFile(tt.chooserFile, []byte{}, 0o644)
 				require.NoError(t, err)

--- a/src/internal/model_test.go
+++ b/src/internal/model_test.go
@@ -240,6 +240,21 @@ func TestChooserFile(t *testing.T) {
 			expectedContent: file1,
 		},
 		{
+			name:            "Open with default app with multiple selected files",
+			chooserFile:     testChooserFile,
+			hotkey:          common.Hotkeys.Confirm[0],
+			selectedFiles:   []string{file1, file2},
+			expectedQuit:    true,
+			expectedContent: file1 + "\n" + file2,
+		},
+		{
+			name:            "Open with default app with no selection falls back to focused item",
+			chooserFile:     testChooserFile,
+			hotkey:          common.Hotkeys.Confirm[0],
+			expectedQuit:    true,
+			expectedContent: file1,
+		},
+		{
 			name:            "Open with file editor with valid chooser file",
 			chooserFile:     testChooserFile,
 			hotkey:          common.Hotkeys.OpenFileWithEditor[0],


### PR DESCRIPTION
Fixes #1378

When superfile is run with `--chooser-file`, confirming with items selected in Select Mode only wrote the hovered item's path instead of all selected paths.

This change:
- Writes all selected file paths separated by newlines to `--chooser-file` when items are selected.
- Preserves fallback to the hovered item when no items are selected.
- Adds test cases to `TestChooserFile` verifying multi-item selection and empty-selection fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opening or copying paths now includes all selected files, or the focused file when no items are selected.
  * Entering a panel writes all selected paths to the chooser file when applicable.

* **Bug Fixes**
  * Improved multi-file selection handling when opening files with an editor.
  * Added coverage for opening multiple selected files and falling back to the focused file when no selection exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->